### PR TITLE
Fix Jira token variable name in core-config.yaml

### DIFF
--- a/plugins/prism-devtools/core-config.yaml
+++ b/plugins/prism-devtools/core-config.yaml
@@ -160,7 +160,7 @@ jira:
   enabled: true
   baseUrl: https://resolvesys.atlassian.net
   email: ${JIRA_EMAIL}
-  token: ${JIRA_TOKEN}
+  token: ${JIRA_API_TOKEN}
   defaultProject: PLAT
   issueKeyPattern: "[A-Z]+-\\d+"
 memory:


### PR DESCRIPTION
## Summary
- `core-config.yaml` referenced `${JIRA_TOKEN}` while every skill, script, and doc file uses `${JIRA_API_TOKEN}`
- This one-character mismatch caused Jira integration to silently fail when agents resolved the credential variable name from config
- Also updated local `.env` to use `JIRA_API_TOKEN` (not tracked in repo)

## Root Cause
The config file was the single outlier — 50+ references across 13 files use `JIRA_API_TOKEN`, but `core-config.yaml` alone used `JIRA_TOKEN`. Fix aligns the config to match the established convention rather than renaming everything else.

## Test plan
- [x] Verified `curl` direct API call to PLAT-2452 returns 200
- [x] Verified `jira_fetch.py PLAT-2452` returns full epic details
- [x] Verified `jira_search.py` with JQL returns search results
- [x] Verified env var `JIRA_API_TOKEN` loads correctly from `.env` via `.bashrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)