### PR TITLE
brain: multi-granular chunking + feedback loop + multi-language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ benchmarks/repos/
 benchmarks/results/
 benchmarks/.venv/
 services/bench-service/data-bench/
+.prism/feedback-buffer.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,10 @@ skills/orca-*/
 brain/
 .prism/brain/
 plugins/prism-devtools/tools/prism-cli/.prism/
+
+# Benchmarks — runtime data, cloned fixtures, and results (scripts only in git)
+benchmarks/data/
+benchmarks/repos/
+benchmarks/results/
+benchmarks/.venv/
+services/bench-service/data-bench/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "prism": {
-      "type": "url",
+      "type": "http",
       "url": "http://localhost:8081/mcp/?project=prism"
     }
   }

--- a/benchmarks/EXPERIMENTS.md
+++ b/benchmarks/EXPERIMENTS.md
@@ -1,0 +1,62 @@
+# Brain improvement experiments
+
+Append-only log of PRISM Brain changes and their effect on LongMemEval R@5.
+
+All runs go against the isolated bench service (`services/bench-service/`,
+port 18081). Smoke = stratified 50-Q sample. Full = all 500 Q.
+
+| # | Tag | Change | Smoke R@5 | Full R@5 | Δ vs baseline | Kept? | Notes |
+|---|---|---|---|---|---|---|---|
+| 0 | `baseline-potion` | potion-base-32M, RRF 3-index, identifier expansion on | — | **0.524** | — | ✅ (anchor) | 500 Q, 57 min. Per-type: assistant 0.80, preference 0.17, temporal 0.43 |
+| 1 | `minilm-smoke` | swap embedder: potion → all-MiniLM-L6-v2 | **0.800** | (full running) | **+0.276** | 🚀 (smoke crushed it, promoted to full) | 50 Q stratified. All types improved; preference jumped 0.17 → 0.75 |
+
+| 1 | `minilm-full` | swap embedder: potion → all-MiniLM-L6-v2 (full 500 Q) | 0.800 | **0.634** | +0.110 | ✅ | knowledge-update:0.667, multi-session:0.692, single-session-assistant:0.875, single-session-preference:0.467, single-session-user:0.543, temporal-reasoning:0.541 |
+
+| 2 | `nomic-code` | nomic-code, search=hybrid | 0.000 | — | -0.524 | ❌ | env={'PRISM_EMBEDDER': 'nomic-code', 'PRISM_SEARCH_MODE': 'hybrid'}; smoke below promotion threshold |
+
+| 2 | `jina-code` | jina-code, search=hybrid | — | — | — | ❌ | smoke failed |
+
+| 2 | `jina-code` | jina-code, search=hybrid | 0.060 | — | -0.464 | ❌ | env={'PRISM_EMBEDDER': 'jina-code', 'PRISM_SEARCH_MODE': 'hybrid'}; smoke below promotion threshold |
+| 3 | `bge-small` | BAAI/bge-small-en-v1.5, search=hybrid | 0.820 | 0.639 (partial 280/500) | +0.115 | ↔️ | Tracked MiniLM closely. Stopped early — no meaningful edge. |
+
+## Decision
+**Ship MiniLM as default.** All-MiniLM-L6-v2 gives +0.110 R@5 vs potion baseline for free
+(CPU-only, 22M params). bge-small offered no additional gain at this scale. Code-trained
+embedders (jina-code, nomic-code) underperform badly on conversational queries and should
+be avoided unless the query domain is code. `PRISM_EMBEDDER` default changed to `minilm`
+in `services/bench-service/docker-compose.yml`.
+
+## Log entries
+
+### 2026-04-19 — baseline-potion (full, 500 Q)
+- Stack: `potion-base-32M` (model2vec, 512-dim) + BM25(FTS5) + graph RRF
+- Identifier expansion: on
+- **R@5 = 0.524** (262/500), elapsed 57 min, 6 workers, project `bench-lme-potion-full`
+- Weakness: single-session-preference (0.167) — preferences are semantic and rarely share vocabulary with the question
+- Strength: single-session-assistant (0.804) — answer often literal in the assistant turn
+
+<!-- Append new entries below; keep human-readable and dated. -->
+### 2026-04-19 — minilm-full
+- swap embedder: potion → all-MiniLM-L6-v2 (full 500 Q)
+- Smoke R@5 = 0.800, Full R@5 = **0.634** (Δ +0.110)
+- knowledge-update:0.667, multi-session:0.692, single-session-assistant:0.875, single-session-preference:0.467, single-session-user:0.543, temporal-reasoning:0.541
+
+<!-- Append new entries below; keep human-readable and dated. -->
+### 2026-04-19 — nomic-code
+- nomic-code, search=hybrid
+- Smoke R@5 = 0.000, Full R@5 = — (Δ -0.524)
+- env={'PRISM_EMBEDDER': 'nomic-code', 'PRISM_SEARCH_MODE': 'hybrid'}; smoke below promotion threshold
+
+<!-- Append new entries below; keep human-readable and dated. -->
+### 2026-04-19 — jina-code
+- jina-code, search=hybrid
+- Smoke R@5 = —, Full R@5 = — (Δ —)
+- smoke failed
+
+<!-- Append new entries below; keep human-readable and dated. -->
+### 2026-04-19 — jina-code
+- jina-code, search=hybrid
+- Smoke R@5 = 0.060, Full R@5 = — (Δ -0.464)
+- env={'PRISM_EMBEDDER': 'jina-code', 'PRISM_SEARCH_MODE': 'hybrid'}; smoke below promotion threshold
+
+<!-- Append new entries below; keep human-readable and dated. -->

--- a/benchmarks/EXPERIMENTS.md
+++ b/benchmarks/EXPERIMENTS.md
@@ -18,6 +18,9 @@ port 18081). Smoke = stratified 50-Q sample. Full = all 500 Q.
 
 | 2 | `jina-code` | jina-code, search=hybrid | 0.060 | — | -0.464 | ❌ | env={'PRISM_EMBEDDER': 'jina-code', 'PRISM_SEARCH_MODE': 'hybrid'}; smoke below promotion threshold |
 | 3 | `bge-small` | BAAI/bge-small-en-v1.5, search=hybrid | 0.820 | 0.639 (partial 280/500) | +0.115 | ↔️ | Tracked MiniLM closely. Stopped early — no meaningful edge. |
+| 4 | `multi-granular-smoke` | multi-granular chunking (file + semantic + sliding window) on MiniLM | **0.940** | (full deferred) | **+0.416** vs baseline / **+0.140** vs MiniLM smoke | 🚀 | 50Q stratified. Initial run scored 0.080 due to stale eval matcher — fixed to strip `::*` chunk suffix from doc_ids before comparing, re-scored same data → 0.940. knowledge-update/assistant/preference all 1.000; multi-session/user/temporal 0.875-0.889. |
+| 5 | `context-prefix-smoke` | Anthropic-style contextual prefix on multi-granular stack (`PRISM_CONTEXT_PREFIX=on`) | 0.940 | — | 0.000 vs multi-granular | ↔️ | 50Q stratified. Prepends `File: <path>\nScope: <qualified entity>` before embedding/BM25. Per-type breakdown identical to multi-granular. LongMemEval queries are conversational prose; prefix adds no semantic signal for this corpus. Kept default on as theory says it should help code retrieval — needs swebench to confirm. |
+| 6 | `rerank-bge-v2-smoke` | BAAI/bge-reranker-v2-m3 cross-encoder post-RRF on multi-granular+prefix (`PRISM_RERANK=bge-v2`, top-50 pool) | 0.940 | — | 0.000 vs prior | ↔️ | 50Q stratified. Same per-type breakdown, +421s (+22%) wall time vs prefix smoke for zero gain. Suggests the LongMemEval smoke R@5 ceiling at 0.940 is semantic, not rank-order — the 3 missed Qs don't have the gold answer in top-50 to be reranked. Reranker kept as opt-in via env var. |
 
 ## Decision
 **Ship MiniLM as default.** All-MiniLM-L6-v2 gives +0.110 R@5 vs potion baseline for free
@@ -58,5 +61,44 @@ in `services/bench-service/docker-compose.yml`.
 - jina-code, search=hybrid
 - Smoke R@5 = 0.060, Full R@5 = — (Δ -0.464)
 - env={'PRISM_EMBEDDER': 'jina-code', 'PRISM_SEARCH_MODE': 'hybrid'}; smoke below promotion threshold
+
+### 2026-04-20 — multi-granular-smoke
+- Multi-granular chunking on MiniLM (commits a168914, adb44d3, a38c098). Each indexed doc now
+  emits a whole-file chunk plus function/class semantic chunks plus sliding-window chunks
+  for any file ≥2048 chars. Search collapses same-`source_file` hits post-RRF.
+- Smoke R@5 = **0.940** (Δ +0.416 vs potion baseline, +0.140 vs MiniLM smoke).
+- Per-type: knowledge-update 1.000, multi-session 0.889, single-session-assistant 1.000,
+  single-session-preference 1.000, single-session-user 0.875, temporal-reasoning 0.875.
+- Eval harness fix: `benchmarks/longmemeval/run.py` stripped only `::main` legacy suffix;
+  multi-granular emits `::win_N` / `::__file__` / `::__module__` / `::EntityName`. Gold answer
+  was #1 in every question but comparison never matched. Now strips any `::*` suffix before
+  `rsplit("/")`. Re-scored the captured JSON without re-running the 31-min bench.
+- Ingest ~6x slower (50Q in 31 min vs ~5 min for MiniLM smoke). Acceptable for the R@5 gain,
+  but worth profiling before a 500Q full run.
+
+### 2026-04-20 — context-prefix-smoke
+- Contextual chunk prefixing on the multi-granular stack. Before embedding/BM25 each chunk
+  is prepended with `File: <source>\nScope: <entity_kind entity_name (lines a-b)>`. Guarded
+  by `PRISM_CONTEXT_PREFIX=on|off` (default on). Raw `content_hash` still uses unprefixed
+  chunk so drift detection lines up with on-disk sha256.
+- Smoke R@5 = **0.940** (Δ 0.000 vs multi-granular smoke).
+- Per-type breakdown identical to multi-granular smoke — same hits, same misses.
+- Read: LongMemEval queries are conversational prose. The prefix's header adds path/scope
+  metadata that doesn't help disambiguate between conversational sessions. Kept default on
+  because theory (Anthropic Contextual Retrieval) predicts it helps code retrieval, which
+  is a separate eval (swebench).
+
+### 2026-04-20 — rerank-bge-v2-smoke
+- BAAI/bge-reranker-v2-m3 cross-encoder reranker, top-50 post-RRF pool, on the
+  multi-granular + contextual-prefix stack. Guarded by `PRISM_RERANK=bge-v2|jina-v2|
+  ms-marco-minilm|off` (default off). Model ~568M params, ~2GB download, runs on CPU.
+- Smoke R@5 = **0.940** (Δ 0.000 vs prior).
+- Per-type identical to prefix smoke. Same 3 misses.
+- Wall time 2379s vs 1958s for prefix smoke (+421s, +22%). Zero-gain latency cost.
+- Diagnosis: the 3 LongMemEval smoke misses are queries where the gold session is not in
+  the top-50 RRF candidate pool, so reranking can't reach it. The remaining ceiling at
+  0.940 is a retrieval-candidate-generation problem, not a rank-order problem.
+- Kept as opt-in env var. Will re-evaluate if we ever build a code-retrieval bench where
+  the cross-encoder should have room to move numbers.
 
 <!-- Append new entries below; keep human-readable and dated. -->

--- a/benchmarks/EXPERIMENTS.md
+++ b/benchmarks/EXPERIMENTS.md
@@ -124,6 +124,28 @@ in `services/bench-service/docker-compose.yml`.
   delivers clearly on code retrieval even though it saturated at the ceiling on
   LongMemEval smoke. The conversational corpus measures a different kind of hard.
 
+### 2026-04-21 — swebench-noreranker-limit10 (A/B vs yesterday's full stack)
+- Same 10 SWE-bench Lite instances, PRISM_RERANK=off, everything else identical to
+  2026-04-20 swebench-fullstack-limit10 (multi-granular + contextual prefix on).
+- **R@1 = 0.600** (vs 0.400 with bge-v2, **+0.200**)
+- **R@5 = 0.800** (identical)
+- **R@10 = 0.900** (identical)
+- Every non-trivial instance (6 of 10) showed the reranker demoting the correctly-#1-ranked
+  gold file down the top-10. Examples:
+    astropy-7746: off=0.833 -> bge=0.500
+    django-10914: off=0.714 -> bge=0.429
+    django-11019: off=0.600 -> bge=0.400
+  R@5 and R@10 survive because gold stays in the pool, just loses rank 1.
+- astropy-14995 is the one counter-example: bge lifted R@5 from 0.750 to 1.000 (found a
+  gold file that off missed at rank 5). Not enough to offset the aggregate R@1 regression.
+- Interpretation: bge-reranker-v2-m3 is trained on general-domain QA pairs. On
+  (problem_statement, code_chunk) pairs it apparently rewards surface-lexical overlap
+  over the graph/call-structure signals that MiniLM + RRF already exploit. CoIR-trained
+  rerankers (jina-v3) are untested here — would be a separate experiment if we ever
+  revisit.
+- **Decision: PRISM_RERANK=off is the permanent default.** Already the compose default;
+  no code change required. Keep the reranker wiring (opt-in for future models).
+
 ### 2026-04-20 — operator notes (cold-start behavior)
 - **Community summary prose-enrichment requires function/class docs.** The new
   ``communities.summary`` column (see graph rebuild) always gets a structural

--- a/benchmarks/EXPERIMENTS.md
+++ b/benchmarks/EXPERIMENTS.md
@@ -124,6 +124,35 @@ in `services/bench-service/docker-compose.yml`.
   delivers clearly on code retrieval even though it saturated at the ceiling on
   LongMemEval smoke. The conversational corpus measures a different kind of hard.
 
+### 2026-04-21 — swebench-noprefix-limit10 (A/B vs prefix=on baseline)
+- Same 10 SWE-bench Lite instances. Stack: multi-granular + rerank=off,
+  PRISM_CONTEXT_PREFIX=off vs the 2026-04-21 noreranker-limit10 baseline
+  at PRISM_CONTEXT_PREFIX=on.
+- **R@1 = 0.300** (vs 0.600 with prefix=on, **-0.300**)
+- **R@5 = 0.600** (vs 0.800, **-0.200**)
+- **R@10 = 0.700** (vs 0.900, **-0.200**)
+- Every non-trivial instance regressed. Aggregate R@10 across the 10 instances
+  cratered from 0.900 to 0.700 by removing the contextual prefix header.
+- Per-instance summary of R@10 (on -> off):
+    astropy-12907 1.000 -> 1.000    (trivial)
+    astropy-14182 1.000 -> 0.500
+    astropy-14365 1.000 -> 0.667
+    astropy-14995 1.000 -> 0.500
+    astropy-6938  1.000 -> 0.600
+    astropy-7746  1.000 -> 0.667
+    django-10914  0.857 -> 0.571
+    django-10924  0.875 -> 0.625
+    django-11001  0.889 -> 0.667
+    django-11019  0.900 -> 0.700
+- **Decision: PRISM_CONTEXT_PREFIX=on is the permanent default**, now with
+  evidence not faith. Replicates Anthropic Contextual Retrieval paper's
+  35-67% reduction in retrieval failures, on code retrieval specifically.
+- Dispels the earlier "contextual prefix is prose no-op" memory: the
+  LongMemEval smoke at the 0.940 ceiling cannot see prefix's value because
+  conversational sessions don't share structure with (problem_statement,
+  code_chunk) pairs the prefix is anchoring. Target-corpus validation is
+  mandatory before flipping a default based on LongMemEval alone.
+
 ### 2026-04-21 — swebench-noreranker-limit10 (A/B vs yesterday's full stack)
 - Same 10 SWE-bench Lite instances, PRISM_RERANK=off, everything else identical to
   2026-04-20 swebench-fullstack-limit10 (multi-granular + contextual prefix on).

--- a/benchmarks/EXPERIMENTS.md
+++ b/benchmarks/EXPERIMENTS.md
@@ -124,4 +124,20 @@ in `services/bench-service/docker-compose.yml`.
   delivers clearly on code retrieval even though it saturated at the ceiling on
   LongMemEval smoke. The conversational corpus measures a different kind of hard.
 
+### 2026-04-20 — operator notes (cold-start behavior)
+- **Community summary prose-enrichment requires function/class docs.** The new
+  ``communities.summary`` column (see graph rebuild) always gets a structural
+  "Covers `<file>`, `<file>`." fallback, but the richer per-entity prose path only
+  activates when ``brain.db`` has ``entity_kind`` in function/class/method — which is
+  only true for content indexed after the multi-granular chunking upgrade
+  (commits a168914+). Legacy indexes that predate multi-granular will show the
+  structural fallback until they are re-ingested. Re-index path: delete the project's
+  ``docs`` table (or ``brain.db``) and run ``brain_index_doc`` over the source tree,
+  then ``graph_rebuild``. No automatic migration — the raw chunks would need to be
+  re-extracted from disk which indexing already does.
+- **Observability defaults to on.** Every ``Brain.search()`` call logs to the
+  ``searches`` table regardless of env vars; opt-out would need a new flag. Table
+  size grows ~1 row per query; no retention policy yet. Check size periodically
+  if the service runs unattended for weeks.
+
 <!-- Append new entries below; keep human-readable and dated. -->

--- a/benchmarks/EXPERIMENTS.md
+++ b/benchmarks/EXPERIMENTS.md
@@ -101,4 +101,27 @@ in `services/bench-service/docker-compose.yml`.
 - Kept as opt-in env var. Will re-evaluate if we ever build a code-retrieval bench where
   the cross-encoder should have room to move numbers.
 
+### 2026-04-20 — swebench-fullstack-limit10
+- SWE-bench Lite, first 10 instances, full retrieval stack: MiniLM embedder + multi-granular
+  chunking + contextual prefix (on) + cross-encoder reranker (bge-reranker-v2-m3, top-50).
+  Each instance clones repo at base_commit, indexes every source file via MCP, queries
+  Brain with the PR's problem_statement, checks whether gold files appear in top-K.
+- **R@1 = 0.400**, **R@5 = 0.800**, **R@10 = 0.900** across 10 instances.
+- Prior MiniLM+graphify sample was ~0.80 R@10; this stack is **+0.10 R@10** over that.
+  Prior potion baseline was ~0.45 R@10, so **+0.45 R@10 cumulative** over the session's
+  shipping work since baseline.
+- Per-instance: astropy 1-6 R@10 = 1.000 across the board; django 7-10 R@10 = 0.857-0.900.
+  Django codebases are larger and have more gold files per PR, which dilutes R@1 but the
+  top-10 recall stays strong.
+- Total wall clock: 15332s (~4.3 hours) for 10 instances at multi-granular chunk depth.
+  Ingest-dominated — indexing astropy/django with per-function chunks is the bottleneck,
+  not querying.
+- Attribution gap: this is the stacked result, not an A/B. We can't say from one run
+  whether the +0.10 R@10 vs prior MiniLM+graphify sample is chunking, prefix, reranker,
+  or noise on a 10-sample. A limit-20 run split across env-toggle configs is overnight-
+  scale work.
+- Validates the 2026 GraphRAG roadmap's core bet: multi-granular + contextual + reranker
+  delivers clearly on code retrieval even though it saturated at the ceiling on
+  LongMemEval smoke. The conversational corpus measures a different kind of hard.
+
 <!-- Append new entries below; keep human-readable and dated. -->

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,50 @@
+# PRISM Brain benchmarks
+
+Evaluations of PRISM's Brain (hybrid BM25 + vector + graph search) on public
+retrieval benchmarks. **Not shipped with PRISM** — these are development
+tools, not plugin or service artifacts.
+
+## Isolation model
+
+Benchmarks run against a separate MCP service (`services/bench-service/`) on
+ports 18080/18081, so they physically cannot touch the real PRISM index at
+ports 8080/8081.
+
+```
+                      Your real work              Benchmarks
+                      ─────────────               ──────────
+Container             prism-service-prism-...     prism-bench-service
+MCP port              8081                        18081
+Data volume           ./data                      ./data-bench
+Project slugs         your real projects          bench-<...>
+```
+
+Before running any bench:
+
+```bash
+cd ../services/bench-service
+docker compose up -d --build
+```
+
+## Available benchmarks
+
+| Dir | Dataset | Metric | Status |
+|---|---|---|---|
+| `swebench/` | SWE-bench (file localization) | R@k on patched files | planned |
+
+## Conventions
+
+- All scripts target `http://localhost:18081/mcp/?project=bench-<slug>`.
+- Dataset dumps, cloned repos, and result JSON go under `data/`, `repos/`, and
+  `results/` respectively — all gitignored.
+- One runner script per benchmark, self-contained, standard-library only.
+- Each run writes a checkpointed JSON to `results/<bench>/<timestamp>.json`
+  so crashed runs can be resumed.
+
+## Why these are not in `plugins/` or `services/`
+
+- `plugins/prism-devtools/` is what Claude Code users install. Test fixtures
+  have no place there.
+- `services/prism-service/` ships as a Docker image. Dockerfile only copies
+  `app/`, so the benchmarks dir would never make it into the image anyway —
+  but keeping it out of `services/` makes intent obvious.

--- a/benchmarks/longmemeval/run.py
+++ b/benchmarks/longmemeval/run.py
@@ -99,7 +99,11 @@ def run_one(project: str, q_idx: int, entry: dict, k: int = 5) -> dict:
         payload = payload.get("results") or payload.get("matches") or []
     retrieved = []
     for item in payload:
-        did = item.get("doc_id", "").removesuffix("::main")
+        did = item.get("doc_id", "")
+        # Strip any chunk suffix (::main legacy, ::win_N sliding window,
+        # ::__file__, ::__module__, ::EntityName from multi-granular chunking).
+        if "::" in did:
+            did = did.split("::", 1)[0]
         if did:
             retrieved.append(did.rsplit("/", 1)[-1])
     query_sec = time.perf_counter() - t1

--- a/benchmarks/longmemeval/run.py
+++ b/benchmarks/longmemeval/run.py
@@ -1,0 +1,266 @@
+"""LongMemEval R@5 benchmark for PRISM Brain.
+
+Mirrors MemPalace's benchmark methodology: one haystack session = one document,
+queried with the question, check if any ground-truth session appears in top-5.
+
+Runs against the *isolated bench service* at port 18081 — never touches
+the real PRISM service at 8081.
+
+Usage:
+    # Quick stratified smoke (fast iteration during an experiment loop)
+    python run.py --stratify 50 --output ../results/longmemeval/smoke.json
+
+    # Full 500-question run
+    python run.py --output ../results/longmemeval/full.json
+
+    # Label the run so EXPERIMENTS.md can pick it up
+    python run.py --stratify 50 --tag miniLM-swap --output ../results/longmemeval/miniLM_smoke.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+MCP_BASE = "http://localhost:18081/mcp/"
+
+
+# ---------------------------------------------------------------------------
+# MCP client (stateless)
+# ---------------------------------------------------------------------------
+
+def mcp_call(project: str, tool: str, arguments: dict[str, Any]) -> dict:
+    url = f"{MCP_BASE}?project={project}"
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+               "params": {"name": tool, "arguments": arguments}}
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        raw = r.read().decode()
+        if "text/event-stream" in r.headers.get("Content-Type", ""):
+            for line in raw.splitlines():
+                if line.startswith("data: "):
+                    return json.loads(line[6:])
+        return json.loads(raw)
+
+
+def parse_result(resp: dict) -> Any:
+    if "error" in resp:
+        raise RuntimeError(f"MCP error: {resp['error']}")
+    content = resp.get("result", {}).get("content", [])
+    if not content:
+        return None
+    text = content[0].get("text", "")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+# ---------------------------------------------------------------------------
+# Per-question runner (domain-based isolation inside one project)
+# ---------------------------------------------------------------------------
+
+def format_session(turns: list[dict]) -> str:
+    return "\n\n".join(f"{t.get('role','user')}: {t.get('content','')}"
+                       for t in turns)
+
+
+def run_one(project: str, q_idx: int, entry: dict, k: int = 5) -> dict:
+    domain = f"lme_q{q_idx:03d}"
+    t0 = time.perf_counter()
+
+    # Ingest haystack
+    for sid, turns in zip(entry["haystack_session_ids"],
+                           entry["haystack_sessions"]):
+        path = f"lme/q{q_idx:03d}/{sid}"
+        mcp_call(project, "brain_index_doc", {
+            "path": path, "content": format_session(turns), "domain": domain,
+        })
+    ingest_sec = time.perf_counter() - t0
+
+    # Query
+    t1 = time.perf_counter()
+    resp = mcp_call(project, "brain_search",
+                    {"query": entry["question"], "domain": domain, "limit": k})
+    payload = parse_result(resp) or []
+    if isinstance(payload, dict):
+        payload = payload.get("results") or payload.get("matches") or []
+    retrieved = []
+    for item in payload:
+        did = item.get("doc_id", "").removesuffix("::main")
+        if did:
+            retrieved.append(did.rsplit("/", 1)[-1])
+    query_sec = time.perf_counter() - t1
+
+    gold = set(entry["answer_session_ids"])
+    hit = any(sid in gold for sid in retrieved)
+
+    return {
+        "q_idx": q_idx,
+        "question_id": entry["question_id"],
+        "question_type": entry["question_type"],
+        "hit@5": hit,
+        "retrieved_session_ids": retrieved,
+        "gold_session_ids": list(gold),
+        "ingest_sec": round(ingest_sec, 2),
+        "query_sec": round(query_sec, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dataset loading & stratification
+# ---------------------------------------------------------------------------
+
+def stratified_sample(data: list[dict], n: int, seed: int = 42) -> list[tuple[int, dict]]:
+    """Pick N indices balanced across question_type. Returns list of (orig_idx, entry)."""
+    rng = random.Random(seed)
+    by_type: dict[str, list[int]] = {}
+    for i, entry in enumerate(data):
+        by_type.setdefault(entry["question_type"], []).append(i)
+
+    types = sorted(by_type.keys())
+    base = n // len(types)
+    rem = n - base * len(types)
+
+    picked: list[int] = []
+    for i, t in enumerate(types):
+        take = base + (1 if i < rem else 0)
+        take = min(take, len(by_type[t]))
+        picked.extend(rng.sample(by_type[t], take))
+    picked.sort()
+    return [(i, data[i]) for i in picked]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", type=Path,
+                    default=Path(__file__).resolve().parent.parent
+                    / "data" / "longmemeval_s_cleaned.json")
+    ap.add_argument("--project", default="bench-lme")
+    ap.add_argument("--workers", type=int, default=6)
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Take first N questions (no stratification)")
+    ap.add_argument("--stratify", type=int, default=None,
+                    help="Pick N questions balanced across question types")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--tag", default=None,
+                    help="Label stored in summary for EXPERIMENTS.md")
+    ap.add_argument("--output", type=Path, required=True)
+    ap.add_argument("--resume", action="store_true")
+    args = ap.parse_args()
+
+    with open(args.dataset, encoding="utf-8") as f:
+        data = json.load(f)
+
+    if args.stratify:
+        sample = stratified_sample(data, args.stratify, seed=args.seed)
+    elif args.limit:
+        sample = [(i, data[i]) for i in range(min(args.limit, len(data)))]
+    else:
+        sample = [(i, entry) for i, entry in enumerate(data)]
+
+    # Probe service
+    try:
+        mcp_call(args.project, "project_list", {})
+    except Exception as e:
+        print(f"ERROR: bench MCP not reachable at {MCP_BASE} ({e})", file=sys.stderr)
+        return 2
+    mcp_call(args.project, "project_create", {"project_id": args.project})
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    done_qids: set[str] = set()
+    existing: list[dict] = []
+    if args.resume and args.output.exists():
+        try:
+            with open(args.output, encoding="utf-8") as f:
+                existing = json.load(f).get("per_question", [])
+            done_qids = {r["question_id"] for r in existing}
+            print(f"Resume: skipping {len(done_qids)} done", file=sys.stderr)
+        except Exception:
+            pass
+
+    todo = [(i, entry) for i, entry in sample
+            if entry["question_id"] not in done_qids]
+    print(f"Running {len(todo)} / {len(sample)} questions "
+          f"(workers={args.workers}, tag={args.tag})", file=sys.stderr)
+
+    results: list[dict] = list(existing)
+    hits = sum(1 for r in existing if r.get("hit@5"))
+    t0 = time.perf_counter()
+
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futures = {ex.submit(run_one, args.project, i, entry): (i, entry["question_id"])
+                   for i, entry in todo}
+        for n, fut in enumerate(as_completed(futures), 1):
+            i, qid = futures[fut]
+            try:
+                r = fut.result()
+            except Exception as e:
+                r = {"q_idx": i, "question_id": qid, "error": repr(e),
+                     "hit@5": False}
+            results.append(r)
+            if r.get("hit@5"):
+                hits += 1
+            if n % 10 == 0 or n == len(todo):
+                elapsed = time.perf_counter() - t0
+                total = len(results)
+                print(f"  [{total}/{len(sample)}] R@5={hits/total:.3f} "
+                      f"elapsed={elapsed:.0f}s", file=sys.stderr)
+                with open(args.output, "w", encoding="utf-8") as f:
+                    json.dump({"tag": args.tag, "per_question": results}, f, indent=2)
+
+    total = len(results)
+    r5 = hits / total if total else 0.0
+    by_type: dict[str, dict] = {}
+    for r in results:
+        t = r.get("question_type", "unknown")
+        b = by_type.setdefault(t, {"n": 0, "hits": 0})
+        b["n"] += 1
+        if r.get("hit@5"):
+            b["hits"] += 1
+    for _, b in by_type.items():
+        b["r@5"] = b["hits"] / b["n"] if b["n"] else 0.0
+
+    summary = {
+        "tag": args.tag,
+        "dataset": str(args.dataset),
+        "mode": "stratified" if args.stratify else ("limited" if args.limit else "full"),
+        "sample_size": len(sample),
+        "total_scored": total,
+        "hits@5": hits,
+        "recall@5": r5,
+        "by_type": by_type,
+        "elapsed_sec": round(time.perf_counter() - t0, 1),
+        "per_question": results,
+    }
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    print(file=sys.stderr)
+    print(f"RESULT [{args.tag or 'untagged'}]: R@5 = {r5:.4f}  ({hits}/{total})",
+          file=sys.stderr)
+    for t, b in sorted(by_type.items()):
+        print(f"  {t:<30} {b['r@5']:.3f}  ({b['hits']}/{b['n']})", file=sys.stderr)
+    print(f"Wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,3 @@
+# Benchmark runner deps — NOT shipped with PRISM.
+# Install into a local venv: `python -m venv .venv && .venv/bin/pip install -r requirements.txt`
+datasets>=2.14

--- a/benchmarks/run_experiments.py
+++ b/benchmarks/run_experiments.py
@@ -1,0 +1,287 @@
+"""Autonomous experiment driver for PRISM Brain improvements.
+
+Runs the full experiment chain end-to-end without operator intervention:
+  1. Waits for any in-flight LongMemEval run to finish.
+  2. For each experiment, restarts the bench service with new env vars,
+     runs a stratified smoke, and promotes to full if the smoke clears
+     baseline + NOISE_FLOOR.
+  3. Appends each outcome to EXPERIMENTS.md.
+  4. Writes a final summary JSON.
+
+Usage (from E:\\.prism\\benchmarks):
+    .venv/Scripts/python run_experiments.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parent
+REPO_ROOT = BENCH_DIR.parent
+COMPOSE_FILE = REPO_ROOT / "services" / "bench-service" / "docker-compose.yml"
+RESULTS_DIR = BENCH_DIR / "results" / "longmemeval"
+EXPERIMENTS_MD = BENCH_DIR / "results" / "EXPERIMENTS.md"
+RUNNER = BENCH_DIR / "longmemeval" / "run.py"
+PYTHON = BENCH_DIR / ".venv" / "Scripts" / "python.exe"
+
+BASELINE_R5 = 0.524                 # from baseline-potion full run
+NOISE_FLOOR = 0.05                  # smoke must exceed baseline by this to run full
+SMOKE_N = 50
+WORKERS = 6
+MCP_URL = "http://localhost:18081/mcp/"
+
+# Experiment queue. nomic-code removed: its torch.compile cache corrupted the
+# overlay2 fs and took Docker Desktop out. Replaced with jina-code (known good
+# via sentence-transformers, no torch.compile JIT path).
+EXPERIMENTS = [
+    # (tag, env_vars)
+    ("jina-code",          {"PRISM_EMBEDDER": "jina-code",  "PRISM_SEARCH_MODE": "hybrid"}),
+    ("bge-small",          {"PRISM_EMBEDDER": "bge-small",  "PRISM_SEARCH_MODE": "hybrid"}),
+    ("minilm-vector-only", {"PRISM_EMBEDDER": "minilm",     "PRISM_SEARCH_MODE": "vector"}),
+]
+
+
+def log(msg: str) -> None:
+    ts = time.strftime("%H:%M:%S")
+    print(f"[{ts}] {msg}", file=sys.stderr, flush=True)
+
+
+def append_experiments_md(row: dict) -> None:
+    """Append a single markdown row + log entry to EXPERIMENTS.md."""
+    n = row["n"]
+    tag = row["tag"]
+    change = row["change"]
+    smoke = f"{row['smoke']:.3f}" if row.get("smoke") is not None else "—"
+    full = f"**{row['full']:.3f}**" if row.get("full") is not None else "—"
+    delta = row.get("delta", "—")
+    delta_str = f"{delta:+.3f}" if isinstance(delta, float) else "—"
+    kept = row.get("kept", "—")
+    notes = row.get("notes", "")
+    table_row = f"| {n} | `{tag}` | {change} | {smoke} | {full} | {delta_str} | {kept} | {notes} |\n"
+
+    md = EXPERIMENTS_MD.read_text(encoding="utf-8")
+    # Insert before the "## Log entries" header
+    md = md.replace("## Log entries", table_row + "\n## Log entries", 1)
+
+    # Also append a dated log entry
+    date = time.strftime("%Y-%m-%d")
+    entry = f"\n### {date} — {tag}\n- {change}\n- Smoke R@5 = {smoke}, Full R@5 = {full} (Δ {delta_str})\n- {notes}\n"
+    md = md.rstrip() + entry + "\n<!-- Append new entries below; keep human-readable and dated. -->\n"
+    md = md.replace("<!-- Append new entries below; keep human-readable and dated. -->\n<!-- Append new entries below; keep human-readable and dated. -->", "<!-- Append new entries below; keep human-readable and dated. -->")
+    EXPERIMENTS_MD.write_text(md, encoding="utf-8")
+
+
+def compose_down() -> None:
+    subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "down"],
+                   check=False, capture_output=True)
+
+
+def compose_up(env_overrides: dict[str, str]) -> None:
+    env = os.environ.copy()
+    env.update(env_overrides)
+    subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d"],
+                   env=env, check=True, capture_output=True)
+
+
+def wait_for_mcp(timeout_s: int = 60) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{MCP_URL}?project=probe",
+                data=json.dumps({"jsonrpc": "2.0", "id": 1,
+                                 "method": "tools/call",
+                                 "params": {"name": "project_list", "arguments": {}}}).encode(),
+                headers={"Content-Type": "application/json",
+                         "Accept": "application/json, text/event-stream"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=5) as r:
+                if r.status == 200:
+                    return
+        except Exception:
+            pass
+        time.sleep(2)
+    raise RuntimeError("MCP service did not become ready")
+
+
+def warm_model(project: str) -> None:
+    """Trigger model load via a dummy index+search so the first benchmark
+    call doesn't eat the download latency."""
+    u = f"{MCP_URL}?project={project}"
+    for tool, args in [
+        ("project_create", {"project_id": project}),
+        ("brain_index_doc", {"path": "warm/a", "content": "warm up the embedder",
+                             "domain": "warm"}),
+        ("brain_search", {"query": "warm", "limit": 1, "domain": "warm"}),
+    ]:
+        payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                   "params": {"name": tool, "arguments": args}}
+        req = urllib.request.Request(
+            u, data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json",
+                     "Accept": "application/json, text/event-stream"},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=600).read()
+        except Exception as e:
+            log(f"warmup step {tool} failed: {e!r} (continuing)")
+
+
+def run_benchmark(tag: str, stratify: int | None) -> float | None:
+    """Run LongMemEval and return R@5, or None on failure."""
+    project = f"bench-lme-{tag}-{'smoke' if stratify else 'full'}"
+    out = RESULTS_DIR / f"{tag}_{'smoke' if stratify else 'full'}.json"
+    args = [str(PYTHON), str(RUNNER),
+            "--project", project,
+            "--workers", str(WORKERS),
+            "--tag", tag + ("-smoke" if stratify else "-full"),
+            "--output", str(out)]
+    if stratify:
+        args += ["--stratify", str(stratify)]
+    log(f"running {tag} ({'smoke' if stratify else 'full'}, project={project})")
+    t0 = time.time()
+    proc = subprocess.run(args, cwd=str(BENCH_DIR))
+    elapsed = time.time() - t0
+    if proc.returncode != 0:
+        log(f"  FAILED (exit {proc.returncode})")
+        return None
+    try:
+        data = json.loads(out.read_text(encoding="utf-8"))
+        r5 = float(data["recall@5"])
+        log(f"  R@5 = {r5:.4f}  ({data['hits@5']}/{data['total_scored']})  "
+            f"elapsed={elapsed:.0f}s")
+        return r5
+    except Exception as e:
+        log(f"  result parse failed: {e!r}")
+        return None
+
+
+def wait_for_other_python() -> None:
+    """Poll until no *other* python processes from benchmarks/ are running.
+    Distinguishes the driver (us) from benchmark runners by command args:
+    benchmark runners have 'longmemeval/run.py' in argv."""
+    log("waiting for any in-flight benchmark to finish...")
+    while True:
+        try:
+            out = subprocess.run(["ps", "-ef"], capture_output=True, text=True).stdout
+        except FileNotFoundError:
+            return
+        runners = [ln for ln in out.splitlines()
+                   if "longmemeval/run.py" in ln or "longmemeval\\run.py" in ln]
+        if not runners:
+            log("  no in-flight run detected")
+            return
+        time.sleep(30)
+
+
+def record_minilm_full() -> float | None:
+    """Read minilm-full result and append to EXPERIMENTS.md (once)."""
+    path = RESULTS_DIR / "minilm_full.json"
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        r5 = float(data["recall@5"])
+    except Exception as e:
+        log(f"cannot read minilm_full.json: {e!r}")
+        return None
+
+    # Skip if already recorded
+    md = EXPERIMENTS_MD.read_text(encoding="utf-8")
+    if "`minilm-full`" in md:
+        log(f"minilm-full already in EXPERIMENTS.md (R@5={r5:.4f}), skipping record")
+        return r5
+
+    by_type = {k: f"{v['r@5']:.3f}" for k, v in data.get("by_type", {}).items()}
+    notes = ", ".join(f"{k}:{v}" for k, v in sorted(by_type.items()))
+    append_experiments_md({
+        "n": 1,
+        "tag": "minilm-full",
+        "change": "swap embedder: potion → all-MiniLM-L6-v2 (full 500 Q)",
+        "smoke": 0.800,
+        "full": r5,
+        "delta": r5 - BASELINE_R5,
+        "kept": "✅" if r5 > BASELINE_R5 + NOISE_FLOOR else "↔️",
+        "notes": notes,
+    })
+    return r5
+
+
+def run_experiment(n: int, tag: str, env: dict[str, str]) -> dict:
+    """Run one experiment: restart container, smoke, promote to full if good."""
+    log(f"=== experiment {n}: {tag} — env={env} ===")
+    compose_down()
+    compose_up(env)
+    wait_for_mcp()
+    warm_model(f"bench-lme-{tag}-warm")
+
+    smoke = run_benchmark(tag, stratify=SMOKE_N)
+    full = None
+    kept = "❌"
+    if smoke is None:
+        notes = "smoke failed"
+    elif smoke > BASELINE_R5 + NOISE_FLOOR:
+        log(f"  smoke beat baseline+{NOISE_FLOOR:.2f}; promoting to full")
+        full = run_benchmark(tag, stratify=None)
+        if full is not None and full > BASELINE_R5 + NOISE_FLOOR:
+            kept = "✅"
+        notes = f"env={env}"
+    else:
+        log(f"  smoke did not beat baseline+{NOISE_FLOOR:.2f}; skip full")
+        notes = f"env={env}; smoke below promotion threshold"
+
+    delta = (full - BASELINE_R5) if full is not None else (
+        (smoke - BASELINE_R5) if smoke is not None else None)
+
+    row = {
+        "n": n,
+        "tag": tag,
+        "change": f"{env.get('PRISM_EMBEDDER','?')}, search={env.get('PRISM_SEARCH_MODE','?')}",
+        "smoke": smoke,
+        "full": full,
+        "delta": delta,
+        "kept": kept,
+        "notes": notes,
+    }
+    append_experiments_md(row)
+    return row
+
+
+def main() -> int:
+    wait_for_other_python()
+
+    results: list[dict] = []
+
+    r = record_minilm_full()
+    if r is not None:
+        log(f"minilm-full recorded: R@5={r:.4f}")
+        results.append({"tag": "minilm-full", "full": r, "delta": r - BASELINE_R5})
+
+    for n, (tag, env) in enumerate(EXPERIMENTS, start=2):
+        try:
+            row = run_experiment(n, tag, env)
+            results.append(row)
+        except Exception as e:
+            log(f"experiment {n} ({tag}) crashed: {e!r}")
+
+    summary = {
+        "baseline_r5": BASELINE_R5,
+        "noise_floor": NOISE_FLOOR,
+        "experiments": results,
+    }
+    (BENCH_DIR / "results" / "chain_summary.json").write_text(
+        json.dumps(summary, indent=2), encoding="utf-8")
+    log("=== all experiments complete ===")
+    log(f"summary -> {BENCH_DIR / 'results' / 'chain_summary.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/swebench/README.md
+++ b/benchmarks/swebench/README.md
@@ -1,0 +1,65 @@
+# SWE-bench file localization
+
+Measures whether PRISM Brain surfaces the right source files when given a
+GitHub issue description. This is the workload PRISM is actually designed
+for — "find the file that relates to this task" — so the result here
+matters more than generic retrieval benchmarks.
+
+## Setup (one-time)
+
+```bash
+# 1) Start the isolated bench MCP service
+cd ../../services/bench-service
+docker compose up -d --build
+
+# 2) Install benchmark deps into a local venv
+cd ../../benchmarks
+python -m venv .venv
+.venv/Scripts/pip install -r requirements.txt   # on Windows
+# or: .venv/bin/pip install -r requirements.txt   (Linux/macOS)
+```
+
+## Run
+
+```bash
+cd swebench
+../.venv/Scripts/python run.py --limit 20                  # quick signal
+../.venv/Scripts/python run.py --dataset lite --limit 300  # full SWE-bench Lite
+../.venv/Scripts/python run.py --dataset verified          # SWE-bench Verified (500)
+```
+
+Resume a crashed run:
+```bash
+../.venv/Scripts/python run.py --dataset lite --output ../results/swebench/lite_TIMESTAMP.json --resume
+```
+
+## Metric
+
+For each instance:
+- **Gold files** = files modified by the merged fix patch.
+- **Retrieved** = top-K from `brain_search(problem_statement, limit=K)`.
+- **Hit@K** = any gold file appears in top-K retrieved.
+
+Reported: `R@1`, `R@5`, `R@10` across scored instances.
+
+## What to expect
+
+No ground-truth number exists for BM25-only file localization on SWE-bench
+Lite — the closest published baseline is ~40-50% R@10 with naive BM25
+(per the SWE-bench paper's baseline retriever). A vector-augmented hybrid
+system should do meaningfully better. If PRISM lands under the BM25 baseline
+on its own intended workload, that's a real problem. If it lands well
+above, the LongMemEval result really was the wrong test for this system.
+
+## Disk budget
+
+- SWE-bench Lite: ~15 unique repos × 50-200 MB each = ~2 GB in `repos/`.
+- Per-instance `brain.db` + FTS + vec table: ~3-10 MB. 300 instances → ~1-3 GB.
+- Total rough budget for Lite full run: **~4-5 GB** under `benchmarks/` and
+  `services/bench-service/data-bench/`. Both dirs are gitignored.
+
+Nuke everything:
+```bash
+rm -rf benchmarks/repos benchmarks/results
+cd services/bench-service && docker compose down && rm -rf data-bench
+```

--- a/benchmarks/swebench/run.py
+++ b/benchmarks/swebench/run.py
@@ -195,10 +195,17 @@ def run_instance(inst: dict, k_max: int = 10, reset: bool = False) -> dict:
     payload = parse_result(resp) or []
     if isinstance(payload, dict):
         payload = payload.get("results") or payload.get("matches") or []
-    retrieved = []
+    # Dedupe file paths across chunks — multi-granular chunking emits
+    # ::win_N / ::__file__ / ::EntityName variants of the same file, and
+    # swebench scores at file granularity.
+    retrieved: list[str] = []
+    seen: set[str] = set()
     for item in payload:
-        did = item.get("doc_id", "").removesuffix("::main")
-        if did:
+        did = item.get("doc_id", "")
+        if "::" in did:
+            did = did.split("::", 1)[0]
+        if did and did not in seen:
+            seen.add(did)
             retrieved.append(did)
     query_sec = time.perf_counter() - t2
 

--- a/benchmarks/swebench/run.py
+++ b/benchmarks/swebench/run.py
@@ -1,0 +1,345 @@
+"""SWE-bench file-localization benchmark for PRISM Brain.
+
+For each SWE-bench instance:
+  1. Clone the repo at its `base_commit` (the state before the fix).
+  2. Index every source file via the bench MCP service at port 18081.
+  3. Query Brain with the issue `problem_statement`, request top-K results.
+  4. Extract the set of files modified by the gold `patch`.
+  5. Hit@K = did any of those files appear in the top-K retrieved?
+
+Report R@1 / R@5 / R@10.
+
+Runs against the isolated bench service (services/bench-service/), NOT the
+real PRISM service. Each instance gets its own project slug so per-instance
+indexes never bleed into each other.
+
+Usage:
+    cd benchmarks
+    python -m venv .venv && .venv/Scripts/pip install -r requirements.txt
+    cd ../services/bench-service && docker compose up -d --build
+    cd ../../benchmarks/swebench
+    python run.py --limit 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+MCP_URL = "http://localhost:18081/mcp/"
+BENCH_DIR = Path(__file__).resolve().parent
+REPOS_DIR = BENCH_DIR.parent / "repos"
+RESULTS_DIR = BENCH_DIR.parent / "results" / "swebench"
+
+SOURCE_EXTS = {".py", ".md", ".rst", ".txt", ".yaml", ".yml",
+               ".json", ".toml", ".cfg", ".ini"}
+SKIP_PARTS = {".git", "__pycache__", "node_modules", ".venv", "venv",
+              "dist", "build", ".tox", ".mypy_cache", ".pytest_cache",
+              ".eggs", "site-packages"}
+MAX_FILE_BYTES = 200_000
+
+
+# ---------------------------------------------------------------------------
+# MCP client (stateless HTTP POST, no session tracking)
+# ---------------------------------------------------------------------------
+
+def mcp_call(project: str, tool: str, arguments: dict[str, Any]) -> dict:
+    url = f"{MCP_URL}?project={project}"
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+               "params": {"name": tool, "arguments": arguments}}
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=180) as r:
+        raw = r.read().decode()
+        if "text/event-stream" in r.headers.get("Content-Type", ""):
+            for line in raw.splitlines():
+                if line.startswith("data: "):
+                    return json.loads(line[6:])
+        return json.loads(raw)
+
+
+def parse_result(resp: dict) -> Any:
+    if "error" in resp:
+        raise RuntimeError(f"MCP error: {resp['error']}")
+    content = resp.get("result", {}).get("content", [])
+    if not content:
+        return None
+    text = content[0].get("text", "")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+# ---------------------------------------------------------------------------
+# Repo checkout (shallow, per-commit)
+# ---------------------------------------------------------------------------
+
+def _run(cmd: list[str], cwd: Path | None = None) -> None:
+    subprocess.run(cmd, cwd=str(cwd) if cwd else None,
+                   check=True, capture_output=True)
+
+
+def ensure_commit_checkout(repo: str, commit: str) -> Path:
+    """Shallow-fetch `repo` at `commit` into repos/<repo-slug>__<sha[:8]>/.
+    Returns the checkout path. Cached across runs."""
+    slug = repo.replace("/", "__")
+    dest = REPOS_DIR / f"{slug}__{commit[:8]}"
+    marker = dest / ".prism_bench_ready"
+    if marker.exists():
+        return dest
+    dest.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-q"], cwd=dest)
+    _run(["git", "remote", "add", "origin", f"https://github.com/{repo}.git"],
+         cwd=dest)
+    # Try shallow fetch of the exact commit; fall back to full fetch if the
+    # server disallows by-SHA (some older GitHub configs).
+    try:
+        _run(["git", "fetch", "--depth=1", "origin", commit], cwd=dest)
+    except subprocess.CalledProcessError:
+        _run(["git", "fetch", "origin"], cwd=dest)
+    _run(["git", "checkout", "-q", commit], cwd=dest)
+    marker.touch()
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Corpus + patch extraction
+# ---------------------------------------------------------------------------
+
+def iter_source_files(root: Path) -> Iterable[tuple[str, str]]:
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix not in SOURCE_EXTS:
+            continue
+        rel_parts = p.relative_to(root).parts
+        if any(part in SKIP_PARTS for part in rel_parts):
+            continue
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        if size == 0 or size > MAX_FILE_BYTES:
+            continue
+        try:
+            content = p.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, UnicodeError):
+            continue
+        yield p.relative_to(root).as_posix(), content
+
+
+_PATCH_FILE_RE = re.compile(r"^(?:\+\+\+|---) [ab]/(?P<path>.+?)\s*$", re.M)
+
+
+def files_from_patch(patch: str) -> set[str]:
+    """Extract the set of file paths touched by a unified diff."""
+    files: set[str] = set()
+    for m in _PATCH_FILE_RE.finditer(patch):
+        path = m.group("path").strip()
+        if path and path != "/dev/null":
+            files.add(path)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Per-instance runner
+# ---------------------------------------------------------------------------
+
+def run_instance(inst: dict, k_max: int = 10, reset: bool = False) -> dict:
+    iid = inst["instance_id"]
+    project = f"bench-swe-{iid}".lower()
+    project = re.sub(r"[^a-z0-9_-]", "-", project)[:60]
+
+    t0 = time.perf_counter()
+    checkout = ensure_commit_checkout(inst["repo"], inst["base_commit"])
+    checkout_sec = time.perf_counter() - t0
+
+    mcp_call(project, "project_create", {"project_id": project})
+
+    # Ingest
+    t1 = time.perf_counter()
+    n_indexed = 0
+    for rel, content in iter_source_files(checkout):
+        mcp_call(project, "brain_index_doc",
+                 {"path": rel, "content": content, "domain": "code"})
+        n_indexed += 1
+    ingest_sec = time.perf_counter() - t1
+
+    # Build the graphify-backed code graph for this instance.
+    # Cheap for a single repo at a single commit; runs tree-sitter + Leiden.
+    t_g = time.perf_counter()
+    try:
+        mcp_call(project, "graph_rebuild", {})
+    except Exception as e:
+        print(f"graph_rebuild failed: {e!r}", file=sys.stderr)
+    graph_sec = time.perf_counter() - t_g
+
+    # Query
+    t2 = time.perf_counter()
+    query = inst["problem_statement"][:4000]  # cap; some statements are huge
+    resp = mcp_call(project, "brain_search",
+                    {"query": query, "limit": k_max})
+    payload = parse_result(resp) or []
+    if isinstance(payload, dict):
+        payload = payload.get("results") or payload.get("matches") or []
+    retrieved = []
+    for item in payload:
+        did = item.get("doc_id", "").removesuffix("::main")
+        if did:
+            retrieved.append(did)
+    query_sec = time.perf_counter() - t2
+
+    gold = files_from_patch(inst.get("patch", ""))
+    hits = {}
+    for k in (1, 5, 10):
+        topk = set(retrieved[:k])
+        hits[f"hit@{k}"] = bool(topk & gold) if gold else None
+
+    return {
+        "instance_id": iid,
+        "repo": inst["repo"],
+        "base_commit": inst["base_commit"][:12],
+        "n_indexed": n_indexed,
+        "gold_files": sorted(gold),
+        "retrieved": retrieved,
+        **hits,
+        "checkout_sec": round(checkout_sec, 2),
+        "ingest_sec": round(ingest_sec, 2),
+        "graph_sec": round(graph_sec, 2),
+        "query_sec": round(query_sec, 3),
+        "total_sec": round(time.perf_counter() - t0, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def load_dataset(name: str, split: str):
+    from datasets import load_dataset as _ld  # type: ignore
+    dataset_id = {
+        "lite": "princeton-nlp/SWE-bench_Lite",
+        "verified": "princeton-nlp/SWE-bench_Verified",
+    }[name]
+    return _ld(dataset_id, split=split)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", choices=["lite", "verified"], default="lite")
+    ap.add_argument("--split", default="test",
+                    help="'test' for lite, 'test' for verified")
+    ap.add_argument("--limit", type=int, default=20,
+                    help="Process first N instances (default 20 for a quick signal)")
+    ap.add_argument("--offset", type=int, default=0)
+    ap.add_argument("--output", type=Path, default=None)
+    ap.add_argument("--resume", action="store_true",
+                    help="Skip instances whose results already exist in --output")
+    args = ap.parse_args()
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    REPOS_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.output is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        args.output = RESULTS_DIR / f"{args.dataset}_{ts}.json"
+
+    # Probe bench MCP service is up
+    try:
+        mcp_call("bench-probe", "project_list", {})
+    except Exception as e:
+        print(f"ERROR: bench MCP service not reachable at {MCP_URL} ({e})",
+              file=sys.stderr)
+        print("Start it with: cd services/bench-service && docker compose up -d --build",
+              file=sys.stderr)
+        return 2
+
+    print(f"Loading {args.dataset} dataset...", file=sys.stderr)
+    ds = load_dataset(args.dataset, args.split)
+    instances = list(ds.select(range(args.offset,
+                                     min(args.offset + args.limit, len(ds)))))
+    print(f"  {len(instances)} instances selected "
+          f"(offset={args.offset}, limit={args.limit}, total={len(ds)})",
+          file=sys.stderr)
+
+    done_ids: set[str] = set()
+    existing: list[dict] = []
+    if args.resume and args.output.exists():
+        with open(args.output, encoding="utf-8") as f:
+            existing = json.load(f).get("per_instance", [])
+        done_ids = {r["instance_id"] for r in existing}
+        print(f"  resume: skipping {len(done_ids)} already-done",
+              file=sys.stderr)
+
+    results: list[dict] = list(existing)
+    t_start = time.perf_counter()
+
+    for n, inst in enumerate(instances, 1):
+        if inst["instance_id"] in done_ids:
+            continue
+        try:
+            r = run_instance(inst)
+        except Exception as e:
+            r = {"instance_id": inst["instance_id"],
+                 "repo": inst["repo"],
+                 "error": repr(e)}
+        results.append(r)
+
+        # Running tallies
+        scored = [x for x in results if "hit@5" in x and x["hit@5"] is not None]
+        r1 = sum(1 for x in scored if x["hit@1"]) / len(scored) if scored else 0
+        r5 = sum(1 for x in scored if x["hit@5"]) / len(scored) if scored else 0
+        r10 = sum(1 for x in scored if x["hit@10"]) / len(scored) if scored else 0
+        elapsed = time.perf_counter() - t_start
+        print(f"  [{n}/{len(instances)}] {inst['instance_id']:<40} "
+              f"R@1={r1:.3f} R@5={r5:.3f} R@10={r10:.3f}  "
+              f"elapsed={elapsed:.0f}s", file=sys.stderr)
+
+        # Checkpoint every instance
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump({"per_instance": results}, f, indent=2)
+
+    # Final summary
+    scored = [x for x in results if "hit@5" in x and x["hit@5"] is not None]
+    n = len(scored)
+    summary = {
+        "dataset": args.dataset,
+        "split": args.split,
+        "total_instances": len(results),
+        "scored_instances": n,
+        "recall@1": sum(1 for x in scored if x["hit@1"]) / n if n else 0,
+        "recall@5": sum(1 for x in scored if x["hit@5"]) / n if n else 0,
+        "recall@10": sum(1 for x in scored if x["hit@10"]) / n if n else 0,
+        "errors": [x for x in results if "error" in x],
+        "elapsed_sec": round(time.perf_counter() - t_start, 1),
+        "per_instance": results,
+    }
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    print(file=sys.stderr)
+    print(f"RESULT ({args.dataset}, n={n}):", file=sys.stderr)
+    print(f"  R@1  = {summary['recall@1']:.4f}", file=sys.stderr)
+    print(f"  R@5  = {summary['recall@5']:.4f}", file=sys.stderr)
+    print(f"  R@10 = {summary['recall@10']:.4f}", file=sys.stderr)
+    if summary["errors"]:
+        print(f"  errors: {len(summary['errors'])}", file=sys.stderr)
+    print(f"Wrote {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/tests/test_chunk_suffix_strip.py
+++ b/benchmarks/tests/test_chunk_suffix_strip.py
@@ -1,0 +1,66 @@
+"""Regression guard: bench eval runners must strip any ``::<anything>``
+chunk suffix from retrieved doc_ids before matching gold IDs.
+
+Context: a stale matcher that only stripped ``::main`` once made the
+multi-granular chunking change look like a 0.080 R@5 disaster when the
+real result was 0.940 (see memory ``bench-eval-chunk-suffix-bug-2026``).
+This test exists so the next person to extend doc_id formatting finds
+out from a unit test, not a five-hour bench run.
+
+Kept as a pure unit test (no container, no network) so it can run in
+pre-commit in under a second.
+"""
+
+from pathlib import Path
+
+
+def _strip_chunk_suffix(doc_id: str) -> str:
+    if "::" in doc_id:
+        return doc_id.split("::", 1)[0]
+    return doc_id
+
+
+_CASES = [
+    # Legacy whole-file / prose.
+    ("lme/q042/session_abc::main", "lme/q042/session_abc"),
+    # Multi-granular variants emitted by Brain._chunk_source_file.
+    ("lme/q042/session_abc::win_0", "lme/q042/session_abc"),
+    ("lme/q042/session_abc::win_12", "lme/q042/session_abc"),
+    ("src/foo.py::__file__", "src/foo.py"),
+    ("src/foo.py::__module__", "src/foo.py"),
+    ("src/foo.py::MyClass", "src/foo.py"),
+    ("src/foo.py::_private_fn", "src/foo.py"),
+    # No suffix must pass through unchanged.
+    ("no_suffix_here", "no_suffix_here"),
+    ("", ""),
+]
+
+
+def test_strip_chunk_suffix_handles_all_known_variants():
+    for raw, expected in _CASES:
+        got = _strip_chunk_suffix(raw)
+        assert got == expected, f"{raw!r} -> {got!r}, expected {expected!r}"
+
+
+def test_bench_runners_apply_canonical_stripping():
+    """Both eval runners must use split('::', 1)[0] before matching.
+
+    Catches the next person who copies the runner for a new dataset
+    and re-introduces the ``::main``-only matcher.
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    runners = [
+        repo_root / "benchmarks" / "longmemeval" / "run.py",
+        repo_root / "benchmarks" / "swebench" / "run.py",
+    ]
+    for path in runners:
+        assert path.exists(), f"expected runner at {path}"
+        src = path.read_text(encoding="utf-8")
+        has_split = (
+            'split("::", 1)[0]' in src or "split('::', 1)[0]" in src
+        )
+        assert has_split, (
+            f"{path} does not apply the canonical ``split('::', 1)[0]`` "
+            f"chunk-suffix stripping — see memory "
+            f"bench-eval-chunk-suffix-bug-2026."
+        )

--- a/plugins/prism-devtools/hooks/feedback_signal_hook.py
+++ b/plugins/prism-devtools/hooks/feedback_signal_hook.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""PostToolUse hook — implicit retrieval feedback signal.
+
+When Claude calls mcp__prism__brain_search and subsequently Read/Edit one
+of the returned source_files within a short window, this hook auto-emits
+a brain_search_feedback 'up' signal. Turns observability into training
+signal without requiring Claude to self-rate.
+
+Advisory only: always exits 0, silent on any error, never blocks the
+tool call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+_BUFFER_REL = ".prism/feedback-buffer.jsonl"
+_WINDOW_SECS = 600  # 10-minute correlation window
+_MAX_ENTRIES = 50   # per-session buffer cap
+
+# The remaining implementation is appended below via sequential edits
+# so each chunk stays within the project's 30-line write limit.
+def _project_root() -> Path:
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return cur
+
+
+def _mcp_url_and_project(root: Path) -> tuple[str, str] | None:
+    cfg = root / ".mcp.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for s in (data.get("mcpServers") or {}).values():
+        url = s.get("url", "")
+        if "/mcp" in url and "project=" in url:
+            base, q = url.split("?", 1)
+            project = [p.split("=", 1)[1] for p in q.split("&")
+                       if p.startswith("project=")][0]
+            return base.rstrip("/"), project
+    return None
+
+
+def _buffer_path(root: Path) -> Path:
+    return root / _BUFFER_REL
+
+
+def _load_buffer(root: Path) -> list[dict]:
+    p = _buffer_path(root)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    now = time.time()
+    try:
+        for ln in p.read_text(encoding="utf-8").splitlines():
+            ln = ln.strip()
+            if not ln:
+                continue
+            try:
+                row = json.loads(ln)
+            except Exception:
+                continue
+            if now - float(row.get("ts", 0)) <= _WINDOW_SECS:
+                out.append(row)
+    except Exception:
+        return []
+    return out[-_MAX_ENTRIES:]
+
+
+def _save_buffer(root: Path, rows: list[dict]) -> None:
+    p = _buffer_path(root)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("w", encoding="utf-8") as fh:
+            for r in rows[-_MAX_ENTRIES:]:
+                fh.write(json.dumps(r) + "\n")
+    except Exception:
+        pass
+
+
+def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
+    url = f"{base}/?project={project}"
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": tool, "arguments": args},
+    }).encode()
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=4).read()
+    except Exception:
+        pass
+
+
+def _parse_search_response(tool_response) -> list[dict]:
+    """Extract (search_id, doc_id, source_file) tuples from a brain_search
+    MCP response payload. The response format is a list of TextContent
+    items; the first item's .text is a JSON list of result dicts."""
+    try:
+        content = (tool_response or {}).get("content") or []
+        if not content:
+            return []
+        txt = content[0].get("text") or ""
+        results = json.loads(txt)
+        if not isinstance(results, list):
+            return []
+        out = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            sid = r.get("search_id")
+            did = r.get("doc_id")
+            sf = r.get("source_file")
+            if sid and did:
+                out.append({"search_id": int(sid), "doc_id": did,
+                            "source_file": sf or ""})
+        return out
+    except Exception:
+        return []
+
+
+def _handle_search(root: Path, tool_response) -> None:
+    hits = _parse_search_response(tool_response)
+    if not hits:
+        return
+    buf = _load_buffer(root)
+    now = time.time()
+    for h in hits:
+        buf.append({**h, "ts": now, "emitted": False})
+    _save_buffer(root, buf)
+
+
+def _handle_read_or_edit(root: Path, tool_input: dict,
+                         signal: str = "up") -> None:
+    fp = (tool_input or {}).get("file_path") or ""
+    if not fp:
+        return
+    buf = _load_buffer(root)
+    conn = _mcp_url_and_project(root)
+    if conn is None:
+        return
+    base, project = conn
+    # Normalise: allow match on trailing segment too.
+    fp_norm = str(fp).replace("\\", "/")
+    for row in buf:
+        if row.get("emitted"):
+            continue
+        sf = (row.get("source_file") or "").replace("\\", "/")
+        if not sf:
+            continue
+        if sf == fp_norm or fp_norm.endswith("/" + sf) or sf.endswith(fp_norm):
+            _mcp_call(base, project, "brain_search_feedback", {
+                "search_id": int(row["search_id"]),
+                "doc_id": row["doc_id"],
+                "signal": signal,
+                "note": f"implicit: {signal} from tool use",
+            })
+            row["emitted"] = True
+    _save_buffer(root, buf)
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw:
+            return
+        data = json.loads(raw)
+    except Exception:
+        return
+    tool_name = data.get("tool_name") or ""
+    tool_input = data.get("tool_input") or {}
+    tool_response = data.get("tool_response") or {}
+    root = _project_root()
+
+    if tool_name.endswith("brain_search"):
+        _handle_search(root, tool_response)
+    elif tool_name in ("Read", "Edit", "Write"):
+        signal = "up" if tool_name == "Read" else "up"
+        _handle_read_or_edit(root, tool_input, signal=signal)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass
+    sys.exit(0)

--- a/plugins/prism-devtools/hooks/hooks.json
+++ b/plugins/prism-devtools/hooks/hooks.json
@@ -123,6 +123,16 @@
             "description": "Log terminal command outputs to files for later grep searching"
           }
         ]
+      },
+      {
+        "matcher": "mcp__prism__brain_search|Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${PRISM_DEVTOOLS_ROOT}/hooks/feedback_signal_hook.py",
+            "description": "Implicit retrieval feedback: correlate brain_search results with Read/Edit to emit auto thumbs-up via brain_search_feedback MCP"
+          }
+        ]
       }
     ],
     "SubagentStart": [

--- a/services/bench-service/README.md
+++ b/services/bench-service/README.md
@@ -1,0 +1,39 @@
+# Bench service
+
+Isolated copy of the PRISM MCP service for running benchmarks. Uses the same
+code and image as `../prism-service`, but runs on different ports with a
+separate data volume.
+
+## Why separate?
+
+Benchmarks ingest large corpora (thousands of docs, tens of cloned repos) and
+query hard. Running that against the real PRISM service would:
+- pollute the real project index if a project slug collides,
+- slow real search/ingest while the benchmark is hot,
+- mix bench data onto the same disk volume as real data.
+
+This stack removes all three risks. The bench service cannot see the real
+service's data and vice-versa.
+
+## Run
+
+```bash
+cd services/bench-service
+docker compose up -d --build
+```
+
+| Endpoint | Port | URL |
+|---|---|---|
+| Web UI | 18080 | http://localhost:18080 |
+| MCP | 18081 | http://localhost:18081/mcp/?project=<slug> |
+
+Benchmark scripts under `../../benchmarks/` always target port **18081**.
+
+## Reset
+
+```bash
+docker compose down
+rm -rf data-bench
+```
+
+That's it — fully nuked. Real PRISM data at `../prism-service/data` is untouched.

--- a/services/bench-service/docker-compose.yml
+++ b/services/bench-service/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}
       # hybrid (default) | vector | bm25 — which search indices contribute
       - PRISM_SEARCH_MODE=${PRISM_SEARCH_MODE:-hybrid}
+      # Cross-encoder reranker: off (default) | bge-v2 | jina-v2 | ms-marco-minilm
+      - PRISM_RERANK=${PRISM_RERANK:-off}
+      - PRISM_RERANK_TOPN=${PRISM_RERANK_TOPN:-50}
+      # Contextual chunk prefixing (Anthropic-style): on (default) | off
+      - PRISM_CONTEXT_PREFIX=${PRISM_CONTEXT_PREFIX:-on}
       # Keep torch.compile / inductor temp files inside the mounted volume
       # (not in the overlay fs root) so a bad model load can't brick Docker.
       - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache

--- a/services/bench-service/docker-compose.yml
+++ b/services/bench-service/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  bench-service:
+    build: ../prism-service
+    ports:
+      - "18080:8080"
+      - "18081:8081"
+    volumes:
+      - ./data-bench:/data
+    environment:
+      - PRISM_DATA_DIR=/data
+      # Override per experiment: potion | minilm | bge-small | jina-code
+      # (nomic-code excluded — its torch.compile cache corrupts the overlay fs)
+      - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}
+      # hybrid (default) | vector | bm25 — which search indices contribute
+      - PRISM_SEARCH_MODE=${PRISM_SEARCH_MODE:-hybrid}
+      # Keep torch.compile / inductor temp files inside the mounted volume
+      # (not in the overlay fs root) so a bad model load can't brick Docker.
+      - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache
+      - TORCH_HOME=/data/torch-home
+      - HF_HOME=/data/hf-home
+    restart: unless-stopped

--- a/services/bench-service/docker-compose.yml
+++ b/services/bench-service/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - PRISM_CONTEXT_PREFIX=${PRISM_CONTEXT_PREFIX:-on}
       # Feedback consumption weight; "off" disables entirely.
       - PRISM_FEEDBACK_WEIGHT=${PRISM_FEEDBACK_WEIGHT:-0.002}
+      # Drift auto-reindex — benches do not want implicit reindex; disable.
+      - PRISM_DRIFT_INTERVAL=${PRISM_DRIFT_INTERVAL:-0}
       # Keep torch.compile / inductor temp files inside the mounted volume
       # (not in the overlay fs root) so a bad model load can't brick Docker.
       - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache

--- a/services/bench-service/docker-compose.yml
+++ b/services/bench-service/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - PRISM_RERANK_TOPN=${PRISM_RERANK_TOPN:-50}
       # Contextual chunk prefixing (Anthropic-style): on (default) | off
       - PRISM_CONTEXT_PREFIX=${PRISM_CONTEXT_PREFIX:-on}
+      # Feedback consumption weight; "off" disables entirely.
+      - PRISM_FEEDBACK_WEIGHT=${PRISM_FEEDBACK_WEIGHT:-0.002}
       # Keep torch.compile / inductor temp files inside the mounted volume
       # (not in the overlay fs root) so a bad model load can't brick Docker.
       - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache

--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -1,0 +1,14 @@
+"""Single source of truth for PRISM's version.
+
+Bump on user-visible changes — schema migrations, new tools, hook script
+updates, install-manifest changes. Served alongside the install manifest
+so users can tell which version is live and which one installed their hook.
+"""
+
+PRISM_VERSION = "0.2.0"
+
+# Changelog-ish notes (free-form; keep short)
+PRISM_VERSION_NOTES = (
+    "graphify-backed code graph, pluggable embedder (MiniLM default), "
+    "drift detection via content-hash, self-installing SessionStart hook"
+)

--- a/services/prism-service/app/assets/feedback_signal_hook.py
+++ b/services/prism-service/app/assets/feedback_signal_hook.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""PostToolUse hook — implicit retrieval feedback signal.
+
+When Claude calls mcp__prism__brain_search and subsequently Read/Edit one
+of the returned source_files within a short window, this hook auto-emits
+a brain_search_feedback 'up' signal. Turns observability into training
+signal without requiring Claude to self-rate.
+
+Advisory only: always exits 0, silent on any error, never blocks the
+tool call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+_BUFFER_REL = ".prism/feedback-buffer.jsonl"
+_WINDOW_SECS = 600  # 10-minute correlation window
+_MAX_ENTRIES = 50   # per-session buffer cap
+
+# The remaining implementation is appended below via sequential edits
+# so each chunk stays within the project's 30-line write limit.
+def _project_root() -> Path:
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return cur
+
+
+def _mcp_url_and_project(root: Path) -> tuple[str, str] | None:
+    cfg = root / ".mcp.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for s in (data.get("mcpServers") or {}).values():
+        url = s.get("url", "")
+        if "/mcp" in url and "project=" in url:
+            base, q = url.split("?", 1)
+            project = [p.split("=", 1)[1] for p in q.split("&")
+                       if p.startswith("project=")][0]
+            return base.rstrip("/"), project
+    return None
+
+
+def _buffer_path(root: Path) -> Path:
+    return root / _BUFFER_REL
+
+
+def _load_buffer(root: Path) -> list[dict]:
+    p = _buffer_path(root)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    now = time.time()
+    try:
+        for ln in p.read_text(encoding="utf-8").splitlines():
+            ln = ln.strip()
+            if not ln:
+                continue
+            try:
+                row = json.loads(ln)
+            except Exception:
+                continue
+            if now - float(row.get("ts", 0)) <= _WINDOW_SECS:
+                out.append(row)
+    except Exception:
+        return []
+    return out[-_MAX_ENTRIES:]
+
+
+def _save_buffer(root: Path, rows: list[dict]) -> None:
+    p = _buffer_path(root)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("w", encoding="utf-8") as fh:
+            for r in rows[-_MAX_ENTRIES:]:
+                fh.write(json.dumps(r) + "\n")
+    except Exception:
+        pass
+
+
+def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
+    url = f"{base}/?project={project}"
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": tool, "arguments": args},
+    }).encode()
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=4).read()
+    except Exception:
+        pass
+
+
+def _parse_search_response(tool_response) -> list[dict]:
+    """Extract (search_id, doc_id, source_file) tuples from a brain_search
+    MCP response payload. The response format is a list of TextContent
+    items; the first item's .text is a JSON list of result dicts."""
+    try:
+        content = (tool_response or {}).get("content") or []
+        if not content:
+            return []
+        txt = content[0].get("text") or ""
+        results = json.loads(txt)
+        if not isinstance(results, list):
+            return []
+        out = []
+        for r in results:
+            if not isinstance(r, dict):
+                continue
+            sid = r.get("search_id")
+            did = r.get("doc_id")
+            sf = r.get("source_file")
+            if sid and did:
+                out.append({"search_id": int(sid), "doc_id": did,
+                            "source_file": sf or ""})
+        return out
+    except Exception:
+        return []
+
+
+def _handle_search(root: Path, tool_response) -> None:
+    hits = _parse_search_response(tool_response)
+    if not hits:
+        return
+    buf = _load_buffer(root)
+    now = time.time()
+    for h in hits:
+        buf.append({**h, "ts": now, "emitted": False})
+    _save_buffer(root, buf)
+
+
+def _handle_read_or_edit(root: Path, tool_input: dict,
+                         signal: str = "up") -> None:
+    fp = (tool_input or {}).get("file_path") or ""
+    if not fp:
+        return
+    buf = _load_buffer(root)
+    conn = _mcp_url_and_project(root)
+    if conn is None:
+        return
+    base, project = conn
+    # Normalise: allow match on trailing segment too.
+    fp_norm = str(fp).replace("\\", "/")
+    for row in buf:
+        if row.get("emitted"):
+            continue
+        sf = (row.get("source_file") or "").replace("\\", "/")
+        if not sf:
+            continue
+        if sf == fp_norm or fp_norm.endswith("/" + sf) or sf.endswith(fp_norm):
+            _mcp_call(base, project, "brain_search_feedback", {
+                "search_id": int(row["search_id"]),
+                "doc_id": row["doc_id"],
+                "signal": signal,
+                "note": f"implicit: {signal} from tool use",
+            })
+            row["emitted"] = True
+    _save_buffer(root, buf)
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw:
+            return
+        data = json.loads(raw)
+    except Exception:
+        return
+    tool_name = data.get("tool_name") or ""
+    tool_input = data.get("tool_input") or {}
+    tool_response = data.get("tool_response") or {}
+    root = _project_root()
+
+    if tool_name.endswith("brain_search"):
+        _handle_search(root, tool_response)
+    elif tool_name in ("Read", "Edit", "Write"):
+        signal = "up" if tool_name == "Read" else "up"
+        _handle_read_or_edit(root, tool_input, signal=signal)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass
+    sys.exit(0)

--- a/services/prism-service/app/config.py
+++ b/services/prism-service/app/config.py
@@ -21,6 +21,13 @@ MCP_PORT = int(os.environ.get("PRISM_MCP_PORT", "8081"))
 # Governance
 GOVERNANCE_INTERVAL_SECONDS = int(os.environ.get("PRISM_GOVERNANCE_INTERVAL", "300"))  # 5 min
 
+# Drift auto-reindex — how often a background thread runs
+# incremental_reindex across all projects. 0 disables the loop
+# entirely so ops can opt out.
+DRIFT_INTERVAL_SECONDS = int(
+    os.environ.get("PRISM_DRIFT_INTERVAL", "1800"),  # 30 min default
+)
+
 # Shelf-life defaults per domain (days)
 DOMAIN_SHELF_LIFE: dict[str, int] = {
     "default": 30,

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -2048,6 +2048,143 @@ class Brain:
             return []
 
     # ------------------------------------------------------------------
+    # Semantic chunk accessors (token-efficient alternatives to file Read)
+    # ------------------------------------------------------------------
+
+    def find_symbol(
+        self,
+        name: str,
+        kind: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Return chunks whose entity_name matches ``name``.
+
+        Optional ``kind`` filter (function/class/method/etc). Returns the
+        full chunk content so Claude can read a bounded semantic unit
+        instead of loading the whole parent file.
+        """
+        try:
+            if kind:
+                rows = self._brain.execute(
+                    "SELECT id, source_file, content, entity_name, "
+                    "entity_kind, line_start, line_end FROM docs "
+                    "WHERE entity_name = ? AND entity_kind = ? "
+                    "ORDER BY source_file, line_start LIMIT ?",
+                    (name, kind, int(limit)),
+                ).fetchall()
+            else:
+                rows = self._brain.execute(
+                    "SELECT id, source_file, content, entity_name, "
+                    "entity_kind, line_start, line_end FROM docs "
+                    "WHERE entity_name = ? "
+                    "ORDER BY source_file, line_start LIMIT ?",
+                    (name, int(limit)),
+                ).fetchall()
+        except Exception:
+            return []
+        return [dict(r) for r in rows]
+
+    def outline(self, source_file: str) -> list[dict]:
+        """Return the symbol outline of a file — metadata only, no bodies.
+
+        For a ~2500-line file this drops the read cost from ~15K tokens
+        (whole-file Read) to ~200 tokens (one line per entity).
+        """
+        try:
+            rows = self._brain.execute(
+                "SELECT entity_name, entity_kind, line_start, line_end "
+                "FROM docs WHERE source_file = ? "
+                "AND entity_kind NOT IN ('window', 'file') "
+                "AND entity_name NOT IN ('__file__', '__module__') "
+                "ORDER BY line_start",
+                (source_file,),
+            ).fetchall()
+        except Exception:
+            return []
+        return [dict(r) for r in rows]
+
+    def find_references(
+        self, name: str, limit: int = 20,
+    ) -> list[dict]:
+        """Return call sites referencing ``name`` via the graph.
+
+        Looks up ``name`` in graph.db entities, then finds inbound
+        relationships. For each caller, returns its name/kind/file and
+        the relation type. No chunk body — use find_symbol() on the
+        returned caller names for content.
+        """
+        try:
+            tgt = self._graph.execute(
+                "SELECT id FROM entities WHERE name = ? LIMIT 1", (name,),
+            ).fetchone()
+            if not tgt:
+                return []
+            rows = self._graph.execute(
+                "SELECT e.name AS caller_name, e.kind AS caller_kind, "
+                "e.file AS caller_file, r.relation AS relation "
+                "FROM relationships r "
+                "JOIN entities e ON e.id = r.source_id "
+                "WHERE r.target_id = ? LIMIT ?",
+                (tgt["id"], int(limit)),
+            ).fetchall()
+        except Exception:
+            return []
+        return [dict(r) for r in rows]
+
+    def call_chain(
+        self,
+        entity: str,
+        depth: int = 2,
+        limit: int = 50,
+    ) -> list[dict]:
+        """Bounded BFS on the relationships graph starting at ``entity``.
+
+        Returns a flat list of edges [{from, to, kind, relation, hop}]
+        so the caller can reconstruct either tree or flat views. Hop 0
+        is the entity itself; hop 1 is direct callees; etc.
+        """
+        try:
+            start = self._graph.execute(
+                "SELECT id, name FROM entities WHERE name = ? LIMIT 1",
+                (entity,),
+            ).fetchone()
+            if not start:
+                return []
+            visited = {start["id"]}
+            frontier = [start["id"]]
+            edges: list[dict] = []
+            for hop in range(1, max(1, int(depth)) + 1):
+                if not frontier or len(edges) >= limit:
+                    break
+                placeholders = ",".join("?" * len(frontier))
+                rows = self._graph.execute(
+                    f"SELECT r.source_id AS src_id, "
+                    f"s.name AS src_name, t.name AS tgt_name, "
+                    f"t.kind AS tgt_kind, t.id AS tgt_id, "
+                    f"r.relation AS relation "
+                    f"FROM relationships r "
+                    f"JOIN entities s ON s.id = r.source_id "
+                    f"JOIN entities t ON t.id = r.target_id "
+                    f"WHERE r.source_id IN ({placeholders}) "
+                    f"LIMIT ?",
+                    (*frontier, int(limit) - len(edges)),
+                ).fetchall()
+                next_frontier: list[int] = []
+                for r in rows:
+                    edges.append({
+                        "from": r["src_name"], "to": r["tgt_name"],
+                        "kind": r["tgt_kind"], "relation": r["relation"],
+                        "hop": hop,
+                    })
+                    if r["tgt_id"] not in visited:
+                        visited.add(r["tgt_id"])
+                        next_frontier.append(r["tgt_id"])
+                frontier = next_frontier
+            return edges
+        except Exception:
+            return []
+
+    # ------------------------------------------------------------------
     # Ingest
     # ------------------------------------------------------------------
 

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -816,6 +816,13 @@ class Brain:
                 "line_end": end + 1,
             })
 
+            if kind == "class":
+                chunks.extend(
+                    self._python_class_methods(
+                        def_node, lines, name, filepath,
+                    )
+                )
+
         # Module-level chunk: non-empty lines not covered by any definition
         module_lines = [
             lines[i] for i in range(len(lines))
@@ -849,6 +856,58 @@ class Brain:
             }]
 
         return chunks
+
+    def _python_class_methods(
+        self, class_node, lines, class_name, filepath,
+    ) -> list[dict]:
+        """Emit one method chunk per function_definition inside a class.
+
+        The class chunk itself still carries the full class body so
+        whole-class queries work; these extra chunks let find_symbol
+        return a ~40-line method slice instead.
+        """
+        block = next(
+            (c for c in class_node.children if c.type == "block"), None,
+        )
+        if block is None:
+            return []
+        out: list[dict] = []
+        for child in block.children:
+            if child.type == "decorated_definition":
+                mdef = next(
+                    (c for c in child.children
+                     if c.type == "function_definition"), None,
+                )
+                outer = child
+            elif child.type == "function_definition":
+                mdef = child
+                outer = child
+            else:
+                continue
+            if mdef is None:
+                continue
+            nname = next(
+                (c for c in mdef.children if c.type == "identifier"),
+                None,
+            )
+            if nname is None:
+                continue
+            mname = nname.text.decode("utf-8", errors="replace")
+            start = outer.start_point[0]
+            end = outer.end_point[0]
+            body = "\n".join(lines[start:end + 1])
+            summary = self._extract_python_docstring(mdef)
+            if summary:
+                body = f"{summary}\n\n{body}"
+            out.append({
+                "doc_id": f"{filepath}::{class_name}.{mname}",
+                "content": body,
+                "entity_name": mname,
+                "entity_kind": "method",
+                "line_start": start + 1,
+                "line_end": end + 1,
+            })
+        return out
 
     @staticmethod
     def _extract_python_docstring(func_or_class_node: object) -> str:
@@ -1021,7 +1080,62 @@ class Brain:
                 "line_end": len(lines) or 1,
             })
 
+        # Second pass: for Python classes, emit indented-def as method chunks
+        # so find_symbol('method_name') returns a ~40-line slice instead of
+        # the whole class. Python-only for now — other languages can follow
+        # with appropriate indent-aware regex.
+        if suffix == ".py":
+            chunks.extend(self._regex_python_methods(filepath, lines, chunks))
+
         return chunks
+
+    def _regex_python_methods(
+        self, filepath: str, lines: list[str], chunks: list[dict],
+    ) -> list[dict]:
+        """Emit method chunks for directly-nested defs inside each class chunk.
+
+        Locks onto the indent level of the first def seen in the class body
+        and only emits defs at that exact level, so nested helper functions
+        inside a method don't collide with their outer siblings.
+        """
+        mre = re.compile(r"^(\s+)(?:async\s+)?def\s+(\w+)")
+        out: list[dict] = []
+        seen: set[str] = set()
+        for c in chunks:
+            if c.get("entity_kind") != "class":
+                continue
+            cname = c["entity_name"]
+            cs, ce = c["line_start"] - 1, c["line_end"] - 1
+            method_indent: int | None = None
+            hits: list[tuple[int, str]] = []
+            for i in range(cs, ce + 1):
+                m = mre.match(lines[i])
+                if not m:
+                    continue
+                indent = len(m.group(1))
+                if method_indent is None:
+                    method_indent = indent
+                if indent != method_indent:
+                    continue  # nested helper inside a method
+                hits.append((i, m.group(2)))
+            if not hits:
+                continue
+            for j, (ms, mname) in enumerate(hits):
+                me = hits[j + 1][0] - 1 if j + 1 < len(hits) else ce
+                doc_id = f"{filepath}::{cname}.{mname}"
+                if doc_id in seen:
+                    continue  # defensive: suffix-level collision
+                seen.add(doc_id)
+                body = "\n".join(lines[ms:me + 1])
+                out.append({
+                    "doc_id": doc_id,
+                    "content": body,
+                    "entity_name": mname,
+                    "entity_kind": "method",
+                    "line_start": ms + 1,
+                    "line_end": me + 1,
+                })
+        return out
 
     def _index_files(self, files: list[str]) -> None:
         for filepath in files:

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -672,18 +672,43 @@ class Brain:
         self._brain.commit()
 
     def _purge_deleted(self) -> int:
-        """Remove DB entries for files that no longer exist or are now excluded.
+        """Remove DB entries for files that no longer exist or are excluded.
 
-        Returns count of purged documents.
+        Safety: if ZERO indexed source files are reachable from this
+        process, the project directory is likely not mounted (common in
+        service-mode containers). A 100%-purge decision in that case
+        wipes the index. We detect and skip, logging so operators know.
+        Override with PRISM_PURGE_FORCE=1 for environments where the
+        empty result is the actual truth.
         """
+        import os as _os
+        import sys as _sys
         rows = self._brain.execute(
             "SELECT id, source_file FROM docs WHERE source_file IS NOT NULL"
         ).fetchall()
+        if not rows:
+            return 0
         to_purge: list[str] = []
+        reachable = 0
         for row in rows:
             sf = row["source_file"]
-            if not Path(sf).exists() or not self._should_index(sf):
+            exists = Path(sf).exists()
+            if exists:
+                reachable += 1
+                if not self._should_index(sf):
+                    to_purge.append(sf)
+            else:
                 to_purge.append(sf)
+        if to_purge and reachable == 0:
+            if _os.environ.get("PRISM_PURGE_FORCE", "").strip() != "1":
+                print(
+                    f"[purge-skip] {len(to_purge)}/{len(rows)} rows look "
+                    f"missing but no indexed file is reachable — "
+                    f"skipping purge (project likely unmounted). Set "
+                    f"PRISM_PURGE_FORCE=1 to override.",
+                    file=_sys.stderr,
+                )
+                return 0
         if to_purge:
             self._remove_entries_by_source(to_purge)
         return len(to_purge)

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -38,6 +38,46 @@ class BrainCorruptError(Exception):
 _MODEL = None
 _SQLITE_VEC_LOADED = False
 
+# Cross-encoder reranker (lazy-loaded on first use when PRISM_RERANK != off).
+# Separate from the embedder so both can coexist in memory.
+_RERANKER = None
+_RERANKER_KEY = ""
+
+_RERANKER_PRESETS = {
+    # key -> sentence-transformers CrossEncoder model_id
+    "bge-v2": "BAAI/bge-reranker-v2-m3",
+    "jina-v2": "jinaai/jina-reranker-v2-base-multilingual",
+    "ms-marco-minilm": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+}
+
+
+def _load_reranker(preset: str):
+    """Return a cached CrossEncoder for ``preset``, or None on failure.
+
+    Loading is lazy and cached process-wide. Unknown preset -> None.
+    """
+    global _RERANKER, _RERANKER_KEY
+    preset = (preset or "").strip().lower()
+    if preset in ("", "off", "none"):
+        return None
+    if preset not in _RERANKER_PRESETS:
+        print(f"Brain: unknown PRISM_RERANK={preset!r}; disabling reranker",
+              file=sys.stderr)
+        return None
+    if _RERANKER is not None and _RERANKER_KEY == preset:
+        return _RERANKER
+    try:
+        from sentence_transformers import CrossEncoder  # type: ignore
+        model_id = _RERANKER_PRESETS[preset]
+        _RERANKER = CrossEncoder(model_id, trust_remote_code=True)
+        _RERANKER_KEY = preset
+        print(f"Brain: reranker = {preset} ({model_id})", file=sys.stderr)
+        return _RERANKER
+    except Exception as e:
+        print(f"Brain: reranker load failed ({preset}: {e!r}); disabled",
+              file=sys.stderr)
+        return None
+
 # ---------------------------------------------------------------------------
 # Tree-sitter language loader
 # ---------------------------------------------------------------------------
@@ -1619,6 +1659,25 @@ class Brain:
             fused = reciprocal_rank_fusion(
                 [bm25, vec, graph] if self.vector_enabled else [bm25, graph]
             )
+
+        # Optional cross-encoder reranker (PRISM_RERANK=bge-v2|jina-v2|
+        # ms-marco-minilm|off). Rescores the top PRISM_RERANK_TOPN candidates
+        # by feeding (query, chunk_content) pairs through a cross-encoder,
+        # then replaces that slice of ``fused`` with the reranked order.
+        rerank_preset = (
+            _os.environ.get("PRISM_RERANK", "off").strip().lower()
+        )
+        if rerank_preset not in ("", "off", "none") and fused:
+            try:
+                pool_n = int(_os.environ.get("PRISM_RERANK_TOPN", "50"))
+            except ValueError:
+                pool_n = 50
+            pool_n = max(inner, pool_n)
+            pool = fused[:pool_n]
+            reranked = self._rerank_candidates(query, pool, rerank_preset)
+            if reranked is not None:
+                fused = reranked + fused[pool_n:]
+
         # Take a larger candidate pool when aggregating so collapsing doesn't
         # leave us short of ``limit`` results.
         top = fused[: inner if aggregate else limit]
@@ -1661,6 +1720,50 @@ class Brain:
             if len(results) >= limit:
                 break
         return results
+
+    def _rerank_candidates(
+        self, query: str, candidates: list[dict], preset: str,
+    ) -> Optional[list[dict]]:
+        """Rescore ``candidates`` with a cross-encoder and return new order.
+
+        Returns None when the reranker is unavailable so the caller falls
+        back to RRF order. Attaches a ``rerank_score`` field to each
+        returned item. Caps each document at 2048 chars to keep the
+        cross-encoder under its input limit.
+        """
+        if not candidates:
+            return None
+        reranker = _load_reranker(preset)
+        if reranker is None:
+            return None
+        ids = [c["doc_id"] for c in candidates]
+        placeholders = ",".join("?" * len(ids))
+        rows = self._brain.execute(
+            f"SELECT id, content FROM docs WHERE id IN ({placeholders})", ids,
+        ).fetchall()
+        content_by_id = {r["id"]: r["content"] for r in rows}
+        pairs: list[tuple[str, str]] = []
+        ordered: list[dict] = []
+        for c in candidates:
+            text = content_by_id.get(c["doc_id"])
+            if not text:
+                continue
+            pairs.append((query, text[:2048]))
+            ordered.append(c)
+        if not pairs:
+            return None
+        try:
+            scores = reranker.predict(pairs)
+        except Exception as e:
+            print(f"Brain: reranker predict failed: {e!r}", file=sys.stderr)
+            return None
+        scored: list[dict] = []
+        for c, s in zip(ordered, scores):
+            c2 = dict(c)
+            c2["rerank_score"] = float(s)
+            scored.append(c2)
+        scored.sort(key=lambda x: -x["rerank_score"])
+        return scored
 
     def system_context(
         self,

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -426,6 +426,18 @@ class Brain:
             );
             CREATE INDEX IF NOT EXISTS idx_searches_ts
                 ON searches(ts DESC);
+            CREATE TABLE IF NOT EXISTS search_feedback (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                search_id INTEGER,
+                doc_id TEXT NOT NULL,
+                signal TEXT NOT NULL,
+                note TEXT,
+                ts TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_sf_search
+                ON search_feedback(search_id);
+            CREATE INDEX IF NOT EXISTS idx_sf_doc
+                ON search_feedback(doc_id);
         """)
         # Migrate existing DBs: add chunk metadata columns if missing
         _meta_cols = [
@@ -1741,7 +1753,7 @@ class Brain:
             })
             if len(results) >= limit:
                 break
-        self._log_search(
+        search_id = self._log_search(
             query=query,
             domain=domain,
             domains=domains,
@@ -1755,6 +1767,9 @@ class Brain:
             results=results,
             latency_ms=int((_time.perf_counter() - _search_t0) * 1000),
         )
+        if search_id is not None:
+            for r in results:
+                r["search_id"] = search_id
         return results
 
     def _log_search(
@@ -1770,10 +1785,12 @@ class Brain:
         limit_requested: int,
         results: list[dict],
         latency_ms: int,
-    ) -> None:
+    ) -> Optional[int]:
         """Persist one search event to the ``searches`` table.
 
-        Silent on failure — observability must never break retrieval.
+        Returns the new row id (used by search() to stamp each result with a
+        ``search_id`` so feedback can be tied back later). Silent on failure —
+        observability must never break retrieval.
         """
         try:
             import json as _json
@@ -1787,7 +1804,7 @@ class Brain:
                 }
                 for r in results
             ])
-            self._brain.execute(
+            cur = self._brain.execute(
                 "INSERT INTO searches (query, domain, domains, mode, rerank, "
                 "context_prefix, chunk_agg, limit_requested, n_results, "
                 "latency_ms, final_top) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -1801,22 +1818,97 @@ class Brain:
                 ),
             )
             self._brain.commit()
+            return cur.lastrowid
         except Exception:
-            pass
+            return None
 
     def get_recent_searches(self, limit: int = 50) -> list[dict]:
-        """Return the last ``limit`` search events, newest first."""
+        """Return the last ``limit`` search events, newest first.
+
+        Each row is augmented with ``up_count`` and ``down_count`` aggregated
+        from the ``search_feedback`` table so the UI can surface sentiment
+        without a second round-trip.
+        """
         try:
             rows = self._brain.execute(
-                "SELECT id, ts, query, domain, domains, mode, rerank, "
-                "context_prefix, chunk_agg, limit_requested, n_results, "
-                "latency_ms, final_top FROM searches "
-                "ORDER BY id DESC LIMIT ?",
+                "SELECT s.id, s.ts, s.query, s.domain, s.domains, s.mode, "
+                "s.rerank, s.context_prefix, s.chunk_agg, s.limit_requested, "
+                "s.n_results, s.latency_ms, s.final_top, "
+                "COALESCE(SUM(CASE WHEN f.signal='up' THEN 1 ELSE 0 END), 0) "
+                "    AS up_count, "
+                "COALESCE(SUM(CASE WHEN f.signal='down' THEN 1 ELSE 0 END), 0) "
+                "    AS down_count "
+                "FROM searches s "
+                "LEFT JOIN search_feedback f ON f.search_id = s.id "
+                "GROUP BY s.id "
+                "ORDER BY s.id DESC LIMIT ?",
                 (int(limit),),
             ).fetchall()
         except Exception:
             return []
         return [dict(r) for r in rows]
+
+    def record_search_feedback(
+        self,
+        search_id: int,
+        doc_id: str,
+        signal: str,
+        note: Optional[str] = None,
+    ) -> Optional[int]:
+        """Record a thumbs-up / thumbs-down on one doc from a prior search.
+
+        Returns the new feedback row id, or None if the insert failed (e.g.
+        unknown search_id, malformed signal). Only 'up' and 'down' signals
+        are accepted.
+        """
+        if signal not in ("up", "down"):
+            return None
+        try:
+            cur = self._brain.execute(
+                "INSERT INTO search_feedback (search_id, doc_id, signal, note) "
+                "VALUES (?, ?, ?, ?)",
+                (int(search_id), doc_id, signal, note),
+            )
+            self._brain.commit()
+            return cur.lastrowid
+        except Exception:
+            return None
+
+    def get_search_feedback(self, search_id: int) -> list[dict]:
+        """Return all feedback rows tied to ``search_id``."""
+        try:
+            rows = self._brain.execute(
+                "SELECT id, search_id, doc_id, signal, note, ts "
+                "FROM search_feedback WHERE search_id = ? ORDER BY id",
+                (int(search_id),),
+            ).fetchall()
+        except Exception:
+            return []
+        return [dict(r) for r in rows]
+
+    def feedback_stats(self) -> dict:
+        """Aggregate thumbs up/down counts and per-doc win rates."""
+        try:
+            total = self._brain.execute(
+                "SELECT signal, COUNT(*) AS n FROM search_feedback "
+                "GROUP BY signal"
+            ).fetchall()
+            counts = {r["signal"]: r["n"] for r in total}
+            worst = self._brain.execute(
+                "SELECT doc_id, "
+                "  SUM(CASE WHEN signal='down' THEN 1 ELSE 0 END) AS downs, "
+                "  SUM(CASE WHEN signal='up' THEN 1 ELSE 0 END) AS ups, "
+                "  COUNT(*) AS total "
+                "FROM search_feedback GROUP BY doc_id "
+                "HAVING downs > ups ORDER BY downs DESC LIMIT 10"
+            ).fetchall()
+        except Exception:
+            return {"up": 0, "down": 0, "worst": []}
+        return {
+            "up": int(counts.get("up", 0)),
+            "down": int(counts.get("down", 0)),
+            "worst": [dict(r) for r in worst],
+        }
 
     def _rerank_candidates(
         self, query: str, candidates: list[dict], preset: str,

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -97,8 +97,35 @@ _TS_LANG_MAP: dict[str, str] = {
 }
 
 
+_EMBEDDER_PRESETS = {
+    # key -> (backend, model_id)
+    # backend in {"model2vec", "sentence-transformers"}
+    "potion": ("model2vec", "minishlab/potion-base-32M"),
+    "minilm": ("sentence-transformers", "sentence-transformers/all-MiniLM-L6-v2"),
+    "nomic-code": ("sentence-transformers", "nomic-ai/nomic-embed-code"),
+    "bge-small": ("sentence-transformers", "BAAI/bge-small-en-v1.5"),
+    "jina-code": ("sentence-transformers", "jinaai/jina-embeddings-v2-base-code"),
+}
+
+
+def _load_sentence_transformer(model_id: str):
+    """Load a sentence-transformers model. Returns object with .encode([str]) API."""
+    from sentence_transformers import SentenceTransformer  # type: ignore
+    return SentenceTransformer(model_id)
+
+
+def _load_model2vec(model_id: str):
+    from model2vec import StaticModel  # type: ignore
+    return StaticModel.from_pretrained(model_id)
+
+
 def _try_enable_vector(db: sqlite3.Connection) -> bool:
-    """Attempt to load sqlite-vec extension and model2vec. Returns True on success."""
+    """Attempt to load sqlite-vec extension and an embedding model.
+
+    The embedding model is chosen via env var PRISM_EMBEDDER (one of the keys
+    in _EMBEDDER_PRESETS); defaults to 'potion'. Returns True on success.
+    """
+    import os
     global _MODEL, _SQLITE_VEC_LOADED
     try:
         import sqlite_vec  # type: ignore
@@ -107,24 +134,31 @@ def _try_enable_vector(db: sqlite3.Connection) -> bool:
         db.enable_load_extension(False)
         _SQLITE_VEC_LOADED = True
     except (ImportError, AttributeError, Exception):
-        print(
-            "Brain: running in BM25+GraphRAG mode "
-            "(install sqlite-vec model2vec for vector search)",
-            file=sys.stderr,
-        )
+        print("Brain: running in BM25+GraphRAG mode (sqlite-vec unavailable)",
+              file=sys.stderr)
         return False
 
+    preset = os.environ.get("PRISM_EMBEDDER", "potion").strip().lower()
+    if preset not in _EMBEDDER_PRESETS:
+        print(f"Brain: unknown PRISM_EMBEDDER={preset!r}; falling back to 'potion'",
+              file=sys.stderr)
+        preset = "potion"
+    backend, model_id = _EMBEDDER_PRESETS[preset]
+
+    if _MODEL is not None:
+        return True  # already loaded (same process reuse)
+
     try:
-        from model2vec import StaticModel  # type: ignore
-        if _MODEL is None:
-            _MODEL = StaticModel.from_pretrained("minishlab/potion-base-32M")
+        if backend == "model2vec":
+            _MODEL = _load_model2vec(model_id)
+        elif backend == "sentence-transformers":
+            _MODEL = _load_sentence_transformer(model_id)
+        print(f"Brain: embedder = {preset} ({backend}: {model_id})",
+              file=sys.stderr)
         return True
-    except (ImportError, OSError, Exception):
-        print(
-            "Brain: running in BM25+GraphRAG mode "
-            "(install sqlite-vec model2vec for vector search)",
-            file=sys.stderr,
-        )
+    except Exception as e:
+        print(f"Brain: embedder load failed ({preset}: {e!r}); BM25+GraphRAG only",
+              file=sys.stderr)
         return False
 
 
@@ -358,10 +392,18 @@ class Brain:
                     pass
 
         if self.vector_enabled:
+            # Discover the model's native embedding dimension at startup so
+            # the vec0 table matches whatever local model is loaded
+            # (potion-base-32M is 512-dim; MiniLM-L6 is 384-dim).
+            try:
+                probe = _MODEL.encode(["probe"])[0]
+                dim = len(probe)
+            except Exception:
+                dim = 384
             try:
                 self._brain.execute(
-                    "CREATE VIRTUAL TABLE IF NOT EXISTS docs_vec "
-                    "USING vec0(doc_id TEXT, embedding float[384])"
+                    f"CREATE VIRTUAL TABLE IF NOT EXISTS docs_vec "
+                    f"USING vec0(doc_id TEXT, embedding float[{dim}])"
                 )
                 self._brain.commit()
             except Exception:
@@ -1456,18 +1498,31 @@ class Brain:
         # In CLI mode the Brain auto-ingests CWD on first search.
         # In service mode, documents are indexed via brain_index_doc MCP tool.
         # The old CLI auto-ingest would index /app (the container code) which is wrong.
+        import os as _os
 
         inner = limit * 2
-        bm25 = self._fts5_search(query, domain, inner, domains=domains)
-        vec = (
-            self._vector_search(query, domain, inner, domains=domains)
-            if self.vector_enabled
-            else []
-        )
-        graph = self._graph_search(query, inner)
 
-        fused = reciprocal_rank_fusion([bm25, vec, graph] if self.vector_enabled
-                                       else [bm25, graph])
+        # Experimental: PRISM_SEARCH_MODE controls which indices contribute.
+        #   hybrid (default) = BM25 + vector + graph, fused via RRF
+        #   vector           = vector search only (when vector_enabled)
+        #   bm25             = BM25 only
+        mode = _os.environ.get("PRISM_SEARCH_MODE", "hybrid").strip().lower()
+
+        if mode == "vector" and self.vector_enabled:
+            fused = self._vector_search(query, domain, inner, domains=domains)
+        elif mode == "bm25":
+            fused = self._fts5_search(query, domain, inner, domains=domains)
+        else:
+            bm25 = self._fts5_search(query, domain, inner, domains=domains)
+            vec = (
+                self._vector_search(query, domain, inner, domains=domains)
+                if self.vector_enabled
+                else []
+            )
+            graph = self._graph_search(query, inner)
+            fused = reciprocal_rank_fusion(
+                [bm25, vec, graph] if self.vector_enabled else [bm25, graph]
+            )
         top = fused[:limit]
         if not top:
             return []

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -566,21 +566,41 @@ class Brain:
     # ------------------------------------------------------------------
 
     def _chunk_source_file(self, filepath: str, content: str) -> list[dict]:
-        """Split a source file into semantic chunks.
+        """Split a source file into multi-granular chunks.
 
         Returns a list of chunk dicts with keys:
           doc_id, content, entity_name, entity_kind, line_start, line_end
 
-        Code files (.py/.ts/.tsx/.js/.jsx/.cs): split by function/class/module.
-        Other files: single whole-file chunk with entity_kind='module'.
+        Three granularity tiers (all emitted when PRISM_MULTIGRAN=on, default):
+          - coarse: one whole-file chunk (``path::__file__`` for code, or the
+            existing single-chunk ``filepath`` id for prose)
+          - mid: semantic chunks at function/class boundaries (code only,
+            ``path::EntityName``) and a ``path::__module__`` for loose
+            top-level statements
+          - fine: sliding 2048-char windows with 256-char overlap over the
+            whole content (``path::win_N``). Emitted when content is large
+            enough that windows carry new signal (>= min_chars).
+
+        Chars/4 approximation: 2048 chars ~ 512 tokens, 256 chars ~ 64 tokens,
+        matching the [512, 128]-token mid/fine target plus a file-level
+        coarse pass. Per brain_engine.search() matches `_embed()`'s own
+        2048-char truncation, so windows are sized to fit one embedding.
+
+        Set PRISM_MULTIGRAN=off to fall back to the original single-tier
+        semantic-only chunking (useful for A/B comparisons).
         """
+        import os as _os
+
+        multigran = _os.environ.get("PRISM_MULTIGRAN", "on").strip().lower() != "off"
+
         suffix = Path(filepath).suffix.lower()
         lines = content.splitlines()
         n = len(lines) or 1
 
         if suffix not in _TS_LANG_MAP:
-            # Non-code file: single whole-file chunk
-            return [{
+            # Prose/config/unknown: keep the legacy single whole-file chunk
+            # as the coarse tier, then add sliding windows for large files.
+            chunks: list[dict] = [{
                 "doc_id": filepath,
                 "content": content,
                 "entity_name": "__module__",
@@ -588,6 +608,11 @@ class Brain:
                 "line_start": 1,
                 "line_end": n,
             }]
+            if multigran:
+                chunks.extend(
+                    self._sliding_window_chunks(filepath, content, min_chars=2048)
+                )
+            return chunks
 
         lang_name = _TS_LANG_MAP[suffix]
         parser = _get_treesitter_parser(lang_name)
@@ -597,7 +622,69 @@ class Brain:
         else:
             chunks = self._chunk_regex_fallback(filepath, content, lines, suffix)
 
+        if not multigran:
+            return chunks
+
+        # Coarse tier: whole-file view, distinct from __module__ (which only
+        # covers lines NOT covered by any def/class). Only worth emitting when
+        # the file has multiple semantic chunks AND is substantial.
+        if len(chunks) > 1 and len(content) >= 2048:
+            chunks.append({
+                "doc_id": f"{filepath}::__file__",
+                "content": content,
+                "entity_name": "__file__",
+                "entity_kind": "file",
+                "line_start": 1,
+                "line_end": n,
+            })
+
+        # Fine tier: sliding windows over full content. Skips small files
+        # where the semantic chunks already cover everything.
+        chunks.extend(
+            self._sliding_window_chunks(filepath, content, min_chars=2048)
+        )
+
         return chunks
+
+    def _sliding_window_chunks(
+        self,
+        filepath: str,
+        content: str,
+        *,
+        min_chars: int = 2048,
+        window_chars: int = 2048,
+        overlap_chars: int = 256,
+    ) -> list[dict]:
+        """Emit overlapping content windows for the fine-granularity tier.
+
+        Returns an empty list when content is shorter than ``min_chars``
+        (no new signal vs. the whole-file chunk). Windows are ``window_chars``
+        wide with ``overlap_chars`` overlap between consecutive windows.
+        Line ranges are computed from newline counts so UI linking stays
+        accurate on arbitrary offsets.
+        """
+        total = len(content)
+        if total < min_chars:
+            return []
+        step = max(1, window_chars - overlap_chars)
+        windows: list[dict] = []
+        pos = 0
+        idx = 0
+        while pos < total:
+            end_pos = min(pos + window_chars, total)
+            windows.append({
+                "doc_id": f"{filepath}::win_{idx}",
+                "content": content[pos:end_pos],
+                "entity_name": f"win_{idx}",
+                "entity_kind": "window",
+                "line_start": content.count("\n", 0, pos) + 1,
+                "line_end": content.count("\n", 0, end_pos) + 1,
+            })
+            idx += 1
+            if end_pos >= total:
+                break
+            pos += step
+        return windows
 
     def _chunk_python_treesitter(
         self, filepath: str, content: str, parser: object, lines: list[str]

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -1587,13 +1587,22 @@ class Brain:
         # The old CLI auto-ingest would index /app (the container code) which is wrong.
         import os as _os
 
-        inner = limit * 2
-
         # Experimental: PRISM_SEARCH_MODE controls which indices contribute.
         #   hybrid (default) = BM25 + vector + graph, fused via RRF
         #   vector           = vector search only (when vector_enabled)
         #   bm25             = BM25 only
         mode = _os.environ.get("PRISM_SEARCH_MODE", "hybrid").strip().lower()
+
+        # PRISM_CHUNK_AGG (default on): collapse same-source_file hits to the
+        # single best-ranked chunk per file so multi-granular chunking doesn't
+        # crowd top-K with __file__/__module__/func_X variants of one file.
+        aggregate = (
+            _os.environ.get("PRISM_CHUNK_AGG", "on").strip().lower() != "off"
+        )
+
+        # When aggregating we over-fetch from each sub-index and from the
+        # fused list so there are enough candidates left after dedupe.
+        inner = limit * 6 if aggregate else limit * 2
 
         if mode == "vector" and self.vector_enabled:
             fused = self._vector_search(query, domain, inner, domains=domains)
@@ -1610,33 +1619,47 @@ class Brain:
             fused = reciprocal_rank_fusion(
                 [bm25, vec, graph] if self.vector_enabled else [bm25, graph]
             )
-        top = fused[:limit]
+        # Take a larger candidate pool when aggregating so collapsing doesn't
+        # leave us short of ``limit`` results.
+        top = fused[: inner if aggregate else limit]
         if not top:
             return []
 
         ids = [item["doc_id"] for item in top]
         placeholders = ",".join("?" * len(ids))
         rows = self._brain.execute(
-            f"SELECT id, content, domain, entity_name, entity_kind, line_start, line_end "
+            f"SELECT id, source_file, content, domain, entity_name, entity_kind, "
+            f"line_start, line_end "
             f"FROM docs WHERE id IN ({placeholders})",
             ids,
         ).fetchall()
         content_map = {r["id"]: r for r in rows}
 
-        results = []
+        results: list[dict] = []
+        seen_files: set[str] = set()
         for item in top:
             row = content_map.get(item["doc_id"])
-            if row:
-                results.append({
-                    "doc_id": item["doc_id"],
-                    "content": row["content"],
-                    "domain": row["domain"],
-                    "entity_name": row["entity_name"],
-                    "entity_kind": row["entity_kind"],
-                    "line_start": row["line_start"],
-                    "line_end": row["line_end"],
-                    "rrf_score": item.get("rrf_score", 0.0),
-                })
+            if not row:
+                continue
+            if aggregate:
+                # Use source_file as the dedupe key; fall back to doc_id for
+                # rows without one (legacy expertise/memory domain docs).
+                group_key = row["source_file"] or item["doc_id"]
+                if group_key in seen_files:
+                    continue
+                seen_files.add(group_key)
+            results.append({
+                "doc_id": item["doc_id"],
+                "content": row["content"],
+                "domain": row["domain"],
+                "entity_name": row["entity_name"],
+                "entity_kind": row["entity_kind"],
+                "line_start": row["line_start"],
+                "line_end": row["line_end"],
+                "rrf_score": item.get("rrf_score", 0.0),
+            })
+            if len(results) >= limit:
+                break
         return results
 
     def system_context(

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -409,6 +409,23 @@ class Brain:
                 key TEXT PRIMARY KEY,
                 value TEXT
             );
+            CREATE TABLE IF NOT EXISTS searches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (datetime('now')),
+                query TEXT NOT NULL,
+                domain TEXT,
+                domains TEXT,
+                mode TEXT,
+                rerank TEXT,
+                context_prefix INTEGER,
+                chunk_agg INTEGER,
+                limit_requested INTEGER,
+                n_results INTEGER,
+                latency_ms INTEGER,
+                final_top TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_searches_ts
+                ON searches(ts DESC);
         """)
         # Migrate existing DBs: add chunk metadata columns if missing
         _meta_cols = [
@@ -1626,6 +1643,9 @@ class Brain:
         # In service mode, documents are indexed via brain_index_doc MCP tool.
         # The old CLI auto-ingest would index /app (the container code) which is wrong.
         import os as _os
+        import time as _time
+
+        _search_t0 = _time.perf_counter()
 
         # Experimental: PRISM_SEARCH_MODE controls which indices contribute.
         #   hybrid (default) = BM25 + vector + graph, fused via RRF
@@ -1709,6 +1729,7 @@ class Brain:
                 seen_files.add(group_key)
             results.append({
                 "doc_id": item["doc_id"],
+                "source_file": row["source_file"],
                 "content": row["content"],
                 "domain": row["domain"],
                 "entity_name": row["entity_name"],
@@ -1716,10 +1737,86 @@ class Brain:
                 "line_start": row["line_start"],
                 "line_end": row["line_end"],
                 "rrf_score": item.get("rrf_score", 0.0),
+                "rerank_score": item.get("rerank_score"),
             })
             if len(results) >= limit:
                 break
+        self._log_search(
+            query=query,
+            domain=domain,
+            domains=domains,
+            mode=mode,
+            rerank=rerank_preset,
+            context_prefix=_os.environ.get(
+                "PRISM_CONTEXT_PREFIX", "on"
+            ).strip().lower() != "off",
+            chunk_agg=aggregate,
+            limit_requested=limit,
+            results=results,
+            latency_ms=int((_time.perf_counter() - _search_t0) * 1000),
+        )
         return results
+
+    def _log_search(
+        self,
+        *,
+        query: str,
+        domain: Optional[str],
+        domains: Optional[list[str]],
+        mode: str,
+        rerank: str,
+        context_prefix: bool,
+        chunk_agg: bool,
+        limit_requested: int,
+        results: list[dict],
+        latency_ms: int,
+    ) -> None:
+        """Persist one search event to the ``searches`` table.
+
+        Silent on failure — observability must never break retrieval.
+        """
+        try:
+            import json as _json
+            final_top = _json.dumps([
+                {
+                    "doc_id": r.get("doc_id"),
+                    "rrf_score": r.get("rrf_score"),
+                    "rerank_score": r.get("rerank_score"),
+                    "domain": r.get("domain"),
+                    "entity_name": r.get("entity_name"),
+                }
+                for r in results
+            ])
+            self._brain.execute(
+                "INSERT INTO searches (query, domain, domains, mode, rerank, "
+                "context_prefix, chunk_agg, limit_requested, n_results, "
+                "latency_ms, final_top) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    query, domain,
+                    _json.dumps(domains) if domains else None,
+                    mode, rerank or "off",
+                    1 if context_prefix else 0,
+                    1 if chunk_agg else 0,
+                    limit_requested, len(results), latency_ms, final_top,
+                ),
+            )
+            self._brain.commit()
+        except Exception:
+            pass
+
+    def get_recent_searches(self, limit: int = 50) -> list[dict]:
+        """Return the last ``limit`` search events, newest first."""
+        try:
+            rows = self._brain.execute(
+                "SELECT id, ts, query, domain, domains, mode, rerank, "
+                "context_prefix, chunk_agg, limit_requested, n_results, "
+                "latency_ms, final_top FROM searches "
+                "ORDER BY id DESC LIMIT ?",
+                (int(limit),),
+            ).fetchall()
+        except Exception:
+            return []
+        return [dict(r) for r in rows]
 
     def _rerank_candidates(
         self, query: str, candidates: list[dict], preset: str,

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -102,6 +102,17 @@ def _init_treesitter_lib() -> None:
         pass
 
 
+def _ts_find_name(node, name_types):
+    """Return the text of the first identifier-like child, or None."""
+    try:
+        for c in node.children:  # type: ignore[attr-defined]
+            if c.type in name_types:
+                return c.text.decode("utf-8", errors="replace")  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    return None
+
+
 def _get_treesitter_parser(lang_name: str) -> Optional[object]:
     """Return a cached tree_sitter.Parser for the given language, or None."""
     if lang_name in _TS_PARSER_CACHE:
@@ -127,6 +138,70 @@ def _get_treesitter_parser(lang_name: str) -> Optional[object]:
 
 
 # Map file suffix -> tree-sitter language name (as in languages.so symbol)
+# Per-language chunker config for _chunk_treesitter_lang. Keys are
+# language names from _TS_LANG_MAP. Entries describe which AST node
+# types are top-level declarations, which of those carry member
+# bodies, what the body node type is, which member node types to
+# emit as methods, and which wrapper/container nodes to transparently
+# descend through (decorators, namespaces, export statements).
+_LANG_CHUNK_CONFIG: dict[str, dict | str] = {
+    "python": {
+        "top": {"function_definition": "function",
+                "class_definition": "class"},
+        "decorated_wrapper": "decorated_definition",
+        "class_types": {"class_definition"},
+        "body_type": "block",
+        "method": {"function_definition": "method"},
+        "name_types": ("identifier",),
+        "descend": set(),
+    },
+    "c_sharp": {
+        "top": {"class_declaration": "class",
+                "interface_declaration": "interface",
+                "struct_declaration": "struct",
+                "record_declaration": "record"},
+        "decorated_wrapper": None,
+        "class_types": {"class_declaration", "interface_declaration",
+                        "struct_declaration", "record_declaration"},
+        "body_type": "declaration_list",
+        "method": {"method_declaration": "method",
+                   "constructor_declaration": "constructor"},
+        "name_types": ("identifier",),
+        # namespace bodies also use declaration_list in C#; descend
+        # into it so class_declaration inside a namespace is reached.
+        # The walker only RECURSES into ``descend`` types — class
+        # members are not reached this way because class_declaration
+        # itself is not in ``descend``; its methods are emitted via
+        # _chunk_ts_methods, which walks the class body explicitly.
+        "descend": {"namespace_declaration", "declaration_list"},
+    },
+    "typescript": {
+        "top": {"class_declaration": "class",
+                "function_declaration": "function",
+                "interface_declaration": "interface"},
+        "decorated_wrapper": None,
+        "class_types": {"class_declaration", "interface_declaration"},
+        "body_type": "class_body",
+        "method": {"method_definition": "method"},
+        "name_types": ("identifier", "property_identifier",
+                       "type_identifier"),
+        "descend": {"export_statement"},
+    },
+    "javascript": {
+        "top": {"class_declaration": "class",
+                "function_declaration": "function"},
+        "decorated_wrapper": None,
+        "class_types": {"class_declaration"},
+        "body_type": "class_body",
+        "method": {"method_definition": "method"},
+        "name_types": ("identifier", "property_identifier"),
+        "descend": {"export_statement"},
+    },
+    "tsx": "typescript",      # alias resolved at lookup time
+    "jsx": "javascript",
+}
+
+
 _TS_LANG_MAP: dict[str, str] = {
     ".py": "python",
     ".ts": "typescript",
@@ -686,8 +761,10 @@ class Brain:
         lang_name = _TS_LANG_MAP[suffix]
         parser = _get_treesitter_parser(lang_name)
 
-        if parser is not None and suffix == ".py":
-            chunks = self._chunk_python_treesitter(filepath, content, parser, lines)
+        if parser is not None and lang_name in _LANG_CHUNK_CONFIG:
+            chunks = self._chunk_treesitter_lang(
+                filepath, content, parser, lines, lang_name,
+            )
         else:
             chunks = self._chunk_regex_fallback(filepath, content, lines, suffix)
 
@@ -754,6 +831,168 @@ class Brain:
                 break
             pos += step
         return windows
+
+    def _chunk_treesitter_lang(
+        self,
+        filepath: str,
+        content: str,
+        parser: object,
+        lines: list[str],
+        lang_name: str,
+    ) -> list[dict]:
+        """Language-generic tree-sitter chunker.
+
+        Produces the same output shape as ``_chunk_python_treesitter`` for
+        any language that has an entry in ``_LANG_CHUNK_CONFIG`` (Python,
+        C#, TypeScript, JavaScript, TSX, JSX today). Methods nested in
+        classes/interfaces/structs are emitted as their own chunks with
+        doc_id = ``{path}::{ContainerName}.{method_name}`` so
+        find_symbol can return a function-level slice.
+        """
+        cfg = _LANG_CHUNK_CONFIG.get(lang_name)
+        if cfg is None:
+            return []
+        if isinstance(cfg, str):
+            cfg = _LANG_CHUNK_CONFIG[cfg]  # alias
+        raw = content.encode("utf-8", errors="replace")
+        tree = parser.parse(raw)  # type: ignore[attr-defined]
+        chunks: list[dict] = []
+        covered: set[int] = set()
+        self._chunk_ts_walk(
+            tree.root_node, cfg, filepath, lines, chunks, covered,
+            emit_docstring=(lang_name == "python"),
+        )
+        module_lines = [
+            lines[i] for i in range(len(lines))
+            if i not in covered and lines[i].strip()
+        ]
+        if module_lines:
+            chunks.append({
+                "doc_id": f"{filepath}::__module__",
+                "content": "\n".join(module_lines),
+                "entity_name": "__module__",
+                "entity_kind": "module",
+                "line_start": 1,
+                "line_end": len(lines) or 1,
+            })
+        if not chunks:
+            return [{
+                "doc_id": filepath, "content": content,
+                "entity_name": "__module__", "entity_kind": "module",
+                "line_start": 1, "line_end": len(lines) or 1,
+            }]
+        return chunks
+
+    def _chunk_ts_walk(
+        self, node, cfg, filepath, lines, chunks, covered, emit_docstring,
+    ):
+        """Recursive AST visitor for _chunk_treesitter_lang."""
+        for child in node.children:
+            t = child.type
+            if t in cfg["descend"]:
+                self._chunk_ts_walk(
+                    child, cfg, filepath, lines, chunks, covered,
+                    emit_docstring,
+                )
+                continue
+            self._chunk_ts_emit(
+                child, cfg, filepath, lines, chunks, covered, emit_docstring,
+            )
+
+    def _chunk_ts_emit(
+        self, outer, cfg, filepath, lines, chunks, covered, emit_docstring,
+    ):
+        """Emit a chunk for ``outer`` if it is a top-level declaration."""
+        t = outer.type
+        def_node = outer
+        if cfg["decorated_wrapper"] and t == cfg["decorated_wrapper"]:
+            inner = next(
+                (c for c in outer.children if c.type in cfg["top"]),
+                None,
+            )
+            if inner is None:
+                return
+            def_node = inner
+            t = inner.type
+        if t not in cfg["top"]:
+            return
+        kind = cfg["top"][t]
+        name = _ts_find_name(def_node, cfg["name_types"])
+        if name is None:
+            return
+        start = outer.start_point[0]
+        end = outer.end_point[0]
+        body = "\n".join(lines[start:end + 1])
+        if emit_docstring:
+            summary = self._extract_python_docstring(def_node)
+            if summary:
+                body = f"{summary}\n\n{body}"
+        for i in range(start, end + 1):
+            covered.add(i)
+        chunks.append({
+            "doc_id": f"{filepath}::{name}",
+            "content": body,
+            "entity_name": name,
+            "entity_kind": kind,
+            "line_start": start + 1,
+            "line_end": end + 1,
+        })
+        if t in cfg["class_types"]:
+            self._chunk_ts_methods(
+                def_node, cfg, filepath, lines, chunks, name,
+                emit_docstring,
+            )
+
+    def _chunk_ts_methods(
+        self, class_node, cfg, filepath, lines, chunks, class_name,
+        emit_docstring,
+    ):
+        """Emit method chunks for members of a class-like node."""
+        body = next(
+            (c for c in class_node.children if c.type == cfg["body_type"]),
+            None,
+        )
+        if body is None:
+            return
+        seen: set[str] = set()
+        for member in body.children:
+            outer_m = member
+            mtype = member.type
+            mnode = member
+            if cfg["decorated_wrapper"] and mtype == cfg["decorated_wrapper"]:
+                inner = next(
+                    (c for c in member.children if c.type in cfg["method"]),
+                    None,
+                )
+                if inner is None:
+                    continue
+                mnode = inner
+                mtype = inner.type
+            if mtype not in cfg["method"]:
+                continue
+            mkind = cfg["method"][mtype]
+            mname = _ts_find_name(mnode, cfg["name_types"])
+            if mname is None:
+                continue
+            doc_id = f"{filepath}::{class_name}.{mname}"
+            if doc_id in seen:
+                continue
+            seen.add(doc_id)
+            ms = outer_m.start_point[0]
+            me = outer_m.end_point[0]
+            mbody = "\n".join(lines[ms:me + 1])
+            if emit_docstring:
+                msummary = self._extract_python_docstring(mnode)
+                if msummary:
+                    mbody = f"{msummary}\n\n{mbody}"
+            chunks.append({
+                "doc_id": doc_id,
+                "content": mbody,
+                "entity_name": mname,
+                "entity_kind": mkind,
+                "line_start": ms + 1,
+                "line_end": me + 1,
+            })
 
     def _chunk_python_treesitter(
         self, filepath: str, content: str, parser: object, lines: list[str]

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -1710,6 +1710,33 @@ class Brain:
             if reranked is not None:
                 fused = reranked + fused[pool_n:]
 
+        # PRISM_FEEDBACK_WEIGHT (default 0.002; "off" disables): close the
+        # feedback loop by nudging rrf_score by accumulated past thumbs on
+        # each doc_id. Small weight so a single vote doesn't flip ordering —
+        # ~3 consistent thumbs overcome a typical RRF gap.
+        fb_weight_env = _os.environ.get("PRISM_FEEDBACK_WEIGHT", "0.002")
+        try:
+            fb_weight = 0.0 if fb_weight_env.strip().lower() in (
+                "off", "none", ""
+            ) else float(fb_weight_env)
+        except ValueError:
+            fb_weight = 0.0
+        if fb_weight and fused:
+            fb_scores = self.get_feedback_scores(
+                [c["doc_id"] for c in fused[:200]]
+            )
+            if fb_scores:
+                for c in fused:
+                    adj = fb_scores.get(c["doc_id"], 0.0)
+                    if adj:
+                        c["rrf_score"] = (
+                            c.get("rrf_score", 0.0) + fb_weight * adj
+                        )
+                        c["feedback_adj"] = adj
+                fused = sorted(fused, key=lambda x: (
+                    -x.get("rrf_score", 0.0), x.get("doc_id", ""),
+                ))
+
         # Take a larger candidate pool when aggregating so collapsing doesn't
         # leave us short of ``limit`` results.
         top = fused[: inner if aggregate else limit]
@@ -1750,6 +1777,7 @@ class Brain:
                 "line_end": row["line_end"],
                 "rrf_score": item.get("rrf_score", 0.0),
                 "rerank_score": item.get("rerank_score"),
+                "feedback_adj": item.get("feedback_adj"),
             })
             if len(results) >= limit:
                 break
@@ -1885,6 +1913,53 @@ class Brain:
         except Exception:
             return []
         return [dict(r) for r in rows]
+
+    def get_feedback_scores(
+        self,
+        doc_ids: list[str],
+        cap: float = 5.0,
+        decay_days: int = 30,
+    ) -> dict:
+        """Return a net signal per doc_id for the consumption layer.
+
+        net = SUM(up) - SUM(down), clamped to [-cap, +cap]. Rows older
+        than ``decay_days`` get weight 0.3 so ancient feedback decays
+        rather than dominating. Silent on error — retrieval must keep
+        working even if feedback data is weird.
+        """
+        if not doc_ids:
+            return {}
+        try:
+            placeholders = ",".join("?" * len(doc_ids))
+            rows = self._brain.execute(
+                f"SELECT doc_id, signal, ts FROM search_feedback "
+                f"WHERE doc_id IN ({placeholders})",
+                list(doc_ids),
+            ).fetchall()
+        except Exception:
+            return {}
+        if not rows:
+            return {}
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        out: dict[str, float] = {}
+        for r in rows:
+            try:
+                ts = datetime.fromisoformat(
+                    (r["ts"] or "").replace(" ", "T")
+                )
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                age_days = (now - ts).days
+            except Exception:
+                age_days = 0
+            w = 0.3 if age_days > decay_days else 1.0
+            delta = w if r["signal"] == "up" else (-w if r["signal"] == "down" else 0)
+            out[r["doc_id"]] = out.get(r["doc_id"], 0.0) + delta
+        # Clamp to [-cap, +cap]
+        for k in list(out):
+            out[k] = max(-cap, min(cap, out[k]))
+        return out
 
     def feedback_stats(self) -> dict:
         """Aggregate thumbs up/down counts and per-doc win rates."""

--- a/services/prism-service/app/main.py
+++ b/services/prism-service/app/main.py
@@ -6,7 +6,8 @@ import threading
 from nicegui import ui, app
 
 from app.config import (DATA_DIR, PROJECTS_DIR,
-                         UI_PORT, MCP_PORT, GOVERNANCE_INTERVAL_SECONDS)
+                         UI_PORT, MCP_PORT, GOVERNANCE_INTERVAL_SECONDS,
+                         DRIFT_INTERVAL_SECONDS)
 
 # Ensure base directories exist
 PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -35,6 +36,44 @@ def start_governance_timer():
         time.sleep(GOVERNANCE_INTERVAL_SECONDS)
 
 
+def start_drift_timer():
+    """Walk every project, reindex drifted docs on a cadence.
+
+    ``prism_status`` already exposes drift; this loop acts on it. Any
+    project whose Brain.incremental_reindex returns >0 gets its
+    reindexed count logged so ops can see the loop is earning its keep.
+    PRISM_DRIFT_INTERVAL=0 disables entirely.
+    """
+    import sys as _sys
+    import time
+    if DRIFT_INTERVAL_SECONDS <= 0:
+        print("Drift timer disabled (PRISM_DRIFT_INTERVAL=0)",
+              file=_sys.stderr)
+        return
+    from app.project_context import get_project, get_all_projects
+    print(
+        f"Drift timer running every {DRIFT_INTERVAL_SECONDS}s",
+        file=_sys.stderr,
+    )
+    while True:
+        try:
+            for pid in get_all_projects():
+                try:
+                    ctx = get_project(pid)
+                    n = ctx.brain_svc.incremental_reindex()
+                    if n:
+                        print(
+                            f"[drift] {pid}: reindexed {n} drifted file(s)",
+                            file=_sys.stderr,
+                        )
+                except Exception as e:
+                    print(f"Drift cycle error ({pid}): {e}",
+                          file=_sys.stderr)
+        except Exception as e:
+            print(f"Drift timer error: {e}", file=_sys.stderr)
+        time.sleep(DRIFT_INTERVAL_SECONDS)
+
+
 # Import UI pages (they register routes with NiceGUI)
 from app.ui import (
     dashboard, brain_page, graph_page, memory_page,
@@ -53,6 +92,7 @@ async def startup():
         _LOCK_FILE.write_text(str(threading.get_ident()))
         threading.Thread(target=start_mcp_server, daemon=True).start()
         threading.Thread(target=start_governance_timer, daemon=True).start()
+        threading.Thread(target=start_drift_timer, daemon=True).start()
     except Exception as e:
         print(f"Startup error: {e}")
 

--- a/services/prism-service/app/main.py
+++ b/services/prism-service/app/main.py
@@ -36,7 +36,10 @@ def start_governance_timer():
 
 
 # Import UI pages (they register routes with NiceGUI)
-from app.ui import dashboard, brain_page, memory_page, tasks_page, conductor_page, sessions_page
+from app.ui import (
+    dashboard, brain_page, graph_page, memory_page,
+    tasks_page, conductor_page, sessions_page,
+)
 
 # Guard against double-start using file lock
 _LOCK_FILE = DATA_DIR / ".mcp_started"

--- a/services/prism-service/app/main.py
+++ b/services/prism-service/app/main.py
@@ -38,7 +38,7 @@ def start_governance_timer():
 # Import UI pages (they register routes with NiceGUI)
 from app.ui import (
     dashboard, brain_page, graph_page, memory_page,
-    tasks_page, conductor_page, sessions_page,
+    tasks_page, conductor_page, sessions_page, retrievals_page,
 )
 
 # Guard against double-start using file lock

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -95,6 +95,100 @@ TOOLS: list[Tool] = [
         },
     ),
     Tool(
+        name="graph_rebuild",
+        description=(
+            "Rebuild the code knowledge graph for this project using graphify "
+            "(tree-sitter AST pass, Leiden community detection, rationale "
+            "extraction). Operates on source files staged via prior "
+            "brain_index_doc calls. LLM-free, runs locally. Returns counts of "
+            "nodes, edges, communities, and imported entities/relationships."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="prism_status",
+        description=(
+            "Check whether this project's Brain/Graph layers are in sync. "
+            "Returns doc counts, staged-file count, graph stats, and a "
+            "`stale` flag with `reasons`. If called with `file_hashes` "
+            "({path: sha256}), also returns precise `drifted: [...]` list "
+            "with reason `missing` or `content_changed` for each path that "
+            "doesn't match Brain. Called by the SessionStart hook."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_hashes": {
+                    "type": "object",
+                    "description": "Optional {path: sha256} map of on-disk "
+                                   "files to diff against Brain's "
+                                   "content_hash. Enables precise drift "
+                                   "detection.",
+                    "additionalProperties": {"type": "string"},
+                },
+            },
+        },
+    ),
+    Tool(
+        name="prism_sync",
+        description=(
+            "Make Brain + Graph self-consistent. Backfills the graphify "
+            "staging dir from any docs in Brain that weren't staged, then "
+            "runs graph_rebuild. Idempotent."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="prism_refresh",
+        description=(
+            "Batch-ingest a map of {path: content} and then trigger a "
+            "graph_rebuild in one call. Use when the SessionStart hook "
+            "detected drift: pass only the drifted paths with their current "
+            "disk content. Returns indexed-count + rebuild summary."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "files": {
+                    "type": "object",
+                    "description": "{path: content} map for bulk re-ingest.",
+                    "additionalProperties": {"type": "string"},
+                },
+                "domain": {
+                    "type": "string",
+                    "description": "Default domain for files without a per-path override. Default 'code'.",
+                },
+            },
+            "required": ["files"],
+        },
+    ),
+    Tool(
+        name="prism_install",
+        description=(
+            "Return the install manifest a coding agent should apply to "
+            "the current project on first onboard: files to create "
+            "(.claude/hooks.json + hook script), step-by-step instructions, "
+            "and verification steps. The MCP is self-describing — no "
+            "external docs needed. Call this inside project_onboard's flow "
+            "or any time you want to re-install the client-side hooks."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="prism_guide",
+        description=(
+            "READ FIRST. Returns a concise orientation for this PRISM instance: "
+            "what each tool does, when to use it, the daily workflow loop, and "
+            "common anti-patterns. Call this once at session start if you're a "
+            "coding agent that hasn't used PRISM in this project before."
+        ),
+        inputSchema={"type": "object", "properties": {
+            "section": {"type": "string", "description":
+                "Optional: 'overview' | 'tools' | 'workflow' | 'memory' | "
+                "'graph' | 'examples'. Omit for the full guide."},
+        }},
+    ),
+    Tool(
         name="memory_store",
         description=(
             "Store an expertise entry in long-term memory. IMPORTANT: Always include "
@@ -369,6 +463,532 @@ def _json(obj: Any) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Self-documenting guide (returned by prism_guide tool)
+# ---------------------------------------------------------------------------
+
+def _version_banner() -> str:
+    try:
+        from app.__version__ import PRISM_VERSION as _v, PRISM_VERSION_NOTES as _n
+        return f"PRISM version: **{_v}** — {_n}"
+    except Exception:
+        return "PRISM version: unknown"
+
+
+_GUIDE_SECTIONS: dict[str, str] = {
+    "overview": _version_banner() + "\n\n" + """\
+# PRISM — what it is
+
+An on-prem memory + knowledge layer for coding agents. Four tightly coupled
+pillars, all accessed via this MCP endpoint:
+
+- **Brain** — hybrid search over source files, docs, and architecture notes.
+  Combines BM25 (FTS5), dense vector search (sentence-transformers MiniLM by
+  default), and a code graph (graphify: tree-sitter + Leiden clustering).
+- **Memory** — durable project conventions, decisions, and failures. Survives
+  across sessions. Full-text-searchable with supersession semantics.
+- **Tasks** — kanban-style tracker with dependencies, priorities, personas.
+- **Workflow** — SDLC state machine (planning → RED → GREEN → review) with
+  per-step gates.
+
+Everything is scoped per project via `?project=<slug>` on this URL. Data lives
+in SQLite inside the container's /data volume — no network, no API keys.
+
+# First contact — do this at session start if the project isn't initialized
+
+1. `project_list` — is this project already onboarded?
+2. `prism_status` — are Brain and Graph in sync? Returns `stale: true` with
+   concrete reasons if anything drifted (e.g. docs ingested before graphify
+   was wired up, or schema migrations not applied). **If stale, call
+   `prism_sync` to self-heal.**
+3. If project is not onboarded: `project_onboard(project_name="...",
+   sub_projects=[...])` returns a 7-step Architect checklist. Walk it:
+   discover structure, identify tech stack, map entry points, discover
+   conventions, index key files via `brain_index_doc`, call
+   `graph_rebuild` once after the batch, store initial conventions via
+   `memory_store`.
+4. If already onboarded and in sync: `context_bundle(persona="dev")` to
+   load current tasks + recent memory.
+
+## Keeping in sync as you go
+
+- Every `brain_index_doc` with a code-suffix path (.py/.ts/.js/.cs/.go/etc)
+  auto-stages the file for graphify. You do NOT need to re-stage manually.
+- After a BATCH of ingests, call `graph_rebuild` once. Don't call per file.
+- `graph_rebuild` auto-backfills from the Brain docs table if staging is
+  empty — so you can't get "graph frozen behind Brain" for long.
+- If `prism_status` reports staleness, `prism_sync` fixes it in one call
+  (backfill + rebuild).
+
+Only call `prism_guide` (this tool) once per session — the guide doesn't
+change between calls. Cache it.
+""",
+    "tools": """\
+# All tools — what they do and when to call them
+
+## Project lifecycle + sync health (CALL THESE FIRST)
+- `project_list()` — list all projects with data in this instance. Check if
+  the current slug is already onboarded.
+- `project_create(project_id)` — create a new isolated project. Rarely needed
+  manually; the service auto-creates on first MCP hit with a new slug.
+- **`project_onboard(project_name, sub_projects?, conventions?)`** — THE
+  initialization route. Returns a 7-step checklist. If you're a fresh
+  coding agent in a brand-new PRISM project, call this BEFORE doing
+  anything else. It seeds project identity + sub-project map into memory
+  so later sessions know the layout.
+- **`prism_status()`** — sync health check. Returns doc counts, staged-file
+  count, graph entity/relationship count, graphify coverage, and a list of
+  staleness reasons. Call at session start.
+- **`prism_sync()`** — idempotent self-heal. Backfills graphify staging
+  from the Brain docs table, then runs `graph_rebuild`. Use when
+  `prism_status` reports `stale: true`.
+
+## Brain (indexed knowledge)
+- `brain_index_doc(path, content, domain)` — **you read the file on the
+  host and send the content here**. PRISM indexes into FTS + vector + stages
+  for the code graph. Call for every source file you want searchable.
+- `brain_search(query, limit, domain?, domains?)` — hybrid RRF search
+  (BM25 + vector + graph). Returns ranked docs with content + rrf_score.
+  Default limit 5.
+- `brain_list(domain?, limit?)` — list indexed docs. Useful for a sanity
+  check after bulk ingest.
+- `brain_graph(entity, relation?, limit?)` — query the code graph by
+  entity name. Returns related nodes with relation type.
+- **`graph_rebuild()`** — run graphify (tree-sitter AST + Leiden clusters).
+  Populates entities and relationships with confidence scores and community
+  IDs. **Call once at the end of a bulk-ingest batch**, not per file.
+
+## Memory (long-term expertise)
+- `memory_store(domain, name, description, type, classification, evidence?,
+  importance?, memory_type?)` — save a convention, decision, pattern, or
+  failure. Supersession is automatic: if a later entry contradicts an
+  older one, the older is marked invalid (not deleted).
+  - `type`: pattern | convention | failure | decision
+  - `classification`: tactical | foundational | strategic
+  - `memory_type`: semantic | episodic | procedural (default: semantic)
+  - **description must include file paths and code examples** — vague
+    memories are nearly useless.
+- `memory_recall(query, domain?, limit?)` — FTS search. Returns active,
+  temporally valid entries sorted by importance.
+
+## Tasks
+- `task_create(title, description?, priority?, dependencies?, tags?,
+  story_file?, assigned_agent?)` — new task.
+- `task_list(status?, assigned_agent?, tag?, story_file?)` — filtered list.
+- `task_next()` — highest-priority unblocked task.
+- `task_update(id, status?, priority?, assigned_agent?, blocked_reason?)` —
+  mutate.
+
+## Workflow
+- `workflow_state()` — current step, progress, session info.
+- `workflow_advance(validation?, gate_action?)` — move to next step. For
+  gate steps, pass `gate_action="approve"` or `"reject"`.
+
+## Context + help
+- `context_bundle(persona?, story_file?)` — full session context dump:
+  brain context + memory recall + active tasks + workflow state + health.
+  Good to call once at session start after onboarding.
+- `prism_guide(section?)` — this tool. Sections: overview | tools |
+  workflow | memory | graph | examples.
+""",
+    "workflow": """\
+# Daily workflow loop (coding agent)
+
+## Once per project (first session ever)
+1. `project_list` — confirm this slug is/isn't already onboarded.
+2. `project_onboard(project_name, sub_projects?)` — returns 7-step
+   checklist. Walk it: read README/package.json/tsconfig/etc., discover
+   tech stack, pick key source files, `brain_index_doc` each, `memory_store`
+   each convention you find, then `graph_rebuild` at the end.
+
+## Once per session
+1. `prism_guide` (this tool) → cache the result.
+2. `context_bundle(persona="dev")` → loads tasks + recent memory + workflow.
+3. `workflow_state()` if a workflow is in progress.
+
+## Per task
+1. **Gather context** — `brain_search` with the task description. Read top
+   3-5 results. For structural questions use `brain_graph(entity=<name>)`.
+2. **Recall conventions** — `memory_recall("testing")`, `memory_recall("
+   error handling")`, etc. Pick up project-specific rules BEFORE writing.
+3. **Write code**.
+4. **Learn something** — if you discovered a convention, bug pattern, or
+   architectural reason, `memory_store(...)` so future sessions inherit it.
+5. **New/changed source files** — `brain_index_doc` each, then
+   `graph_rebuild()` once after the batch.
+6. **Track progress** — `task_update(status=...)`. `task_next` for the
+   next unblocked item.
+""",
+    "memory": """\
+# Memory — the killer feature for coding agents
+
+Agents forget. PRISM's memory is what keeps conventions, decisions, and
+incident learnings across sessions.
+
+## When to store
+- You just inferred a project convention (e.g. "endpoints use Minimal APIs,
+  not controllers"). **Always include the file path where you saw it.**
+- A decision was made that would surprise a future agent (e.g. "we chose
+  not to use Redis because of compliance").
+- A bug was fixed and the root cause is non-obvious.
+- A file structure pattern matters (e.g. "handlers live in Features/*/").
+
+## When NOT to store
+- Obvious things derivable from `git log` or the codebase itself.
+- Task-specific state (use tasks for that).
+- Information already in CLAUDE.md — don't duplicate.
+
+## Good vs bad
+BAD:  description="Use minimal APIs"
+GOOD: description="Endpoints use ASP.NET Minimal APIs with TypedResults
+      (not controllers). Routes in Features/*/Endpoints.cs, each delegating
+      to a Handler.cs. Example: Features/Matches/MatchesEndpoints.cs maps
+      GET /api/matches to GetMatchesHandler.Handle."
+
+Always set `type` (pattern|convention|failure|decision) and
+`classification` (tactical|foundational|strategic).
+""",
+    "graph": """\
+# Code graph — what it's for
+
+Brain's graph layer is powered by graphify (tree-sitter + Leiden clustering).
+It's populated by calling `graph_rebuild()` after bulk-ingesting source.
+
+## Query patterns
+- `brain_graph(entity="MatchesHandler")` — list methods, callers,
+  containers of a known class/function.
+- Community IDs cluster related entities. Entities in the same community
+  are structurally/semantically adjacent.
+- Edges have confidence: `EXTRACTED` (tree-sitter direct, conf 1.0),
+  `INFERRED` (best-effort), `AMBIGUOUS` (flagged).
+
+## When it helps
+- "Who calls X across the repo?" → traverse the graph.
+- "What files are in the same module as X?" → check X's community.
+- "What's the shape of this class?" → brain_graph returns methods.
+
+## When it doesn't help
+- Free-text / conversational queries — those go through vector + BM25.
+- Brand-new files not yet in a graph_rebuild batch.
+""",
+    "examples": """\
+# Example flows
+
+## Onboarding a brand-new project (FIRST session)
+1. `project_list` → confirm slug unknown.
+2. `project_onboard(project_name="My App", sub_projects=[
+     {"name": "api", "tech": "C#/.NET", "path": "/home/me/api"},
+     {"name": "client", "tech": "React/TS", "path": "/home/me/client"}])`
+   → returns a 7-step Architect checklist.
+3. Walk it: read README, package.json, pyproject.toml, etc. For every
+   important source file, `brain_index_doc(path=<rel>, content=<text>,
+   domain="code")`.
+4. After the batch: `graph_rebuild()` — builds the code graph in one shot.
+5. For each convention you discovered:
+   `memory_store(domain="conventions", name="minimal-apis",
+    description="Endpoints use Minimal APIs at Features/*/Endpoints.cs...",
+    type="convention", classification="foundational",
+    evidence={"file_paths": ["src/Features/Matches/MatchesEndpoints.cs"]})`.
+
+## Daily "implement a feature" loop
+1. `context_bundle(persona="dev")` → tasks + recent memory.
+2. `brain_search("user authentication flow", limit=5)` → relevant files.
+3. `memory_recall("auth", limit=5)` → project auth rules.
+4. Write code.
+5. New files → `brain_index_doc` each → `graph_rebuild()` at end.
+6. `task_update(id=..., status="done")`.
+
+## Debugging an incident
+1. `memory_recall("similar failure", limit=10)` — seen it before?
+2. `brain_search("<error message>", limit=5)` — in any doc?
+3. `brain_graph(entity="<suspected component>")` — who uses it?
+4. Fix.
+5. `memory_store(type="failure", name="oauth-null-token", description="Root
+    cause was X, observed at file.py:123, fix was Y.",
+    classification="foundational", importance=8)`.
+
+## Picking up after a crash
+1. `workflow_state()` — which step was active?
+2. `task_list(status="in_progress")` — what was I doing?
+3. `context_bundle()` — full picture.
+4. Resume from the last known-good state.
+""",
+}
+
+
+def _prism_guide(section: str | None) -> str:
+    order = ["overview", "tools", "workflow", "memory", "graph", "examples"]
+    if section and section in _GUIDE_SECTIONS:
+        return _GUIDE_SECTIONS[section]
+    return "\n\n".join(_GUIDE_SECTIONS[s] for s in order)
+
+
+# ---------------------------------------------------------------------------
+# Client-side install manifest — served by prism_install / project_onboard so
+# the agent can Write the SessionStart hook directly into the user's project.
+# ---------------------------------------------------------------------------
+
+from app.__version__ import PRISM_VERSION, PRISM_VERSION_NOTES
+
+
+_HOOK_SCRIPT = r'''#!/usr/bin/env python3
+"""PRISM SessionStart hook — keeps Brain/Graph in sync with disk.
+
+Installed by PRISM version: __PRISM_VERSION__
+
+
+Walks the project source tree (respects .gitignore when git is available),
+hashes each file, asks PRISM via prism_status which files have drifted,
+and pushes the current content of drifted files via prism_refresh.
+
+Installed by PRISM's prism_install / project_onboard manifest. The hook
+reads its target MCP URL + project slug from .mcp.json at the project
+root, so no hardcoded values live here — one hook works across projects.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+SOURCE_EXTS = {".py", ".ts", ".tsx", ".js", ".jsx", ".cs", ".go", ".rs",
+               ".java", ".rb", ".php", ".cpp", ".c", ".h", ".hpp",
+               ".md", ".yml", ".yaml", ".toml"}
+SKIP_PARTS = {".git", "node_modules", "__pycache__", ".venv", "venv",
+              "dist", "build", ".tox", ".mypy_cache", ".pytest_cache",
+              ".next", ".nuxt", "target", ".claude"}
+MAX_FILE_BYTES = 300_000
+
+
+def _project_root() -> Path:
+    # Walk up from cwd looking for .mcp.json
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return cur
+
+
+def _mcp_url_and_project(root: Path) -> tuple[str, str] | None:
+    cfg = root / ".mcp.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    servers = (data.get("mcpServers") or {}).values()
+    for s in servers:
+        url = s.get("url", "")
+        if "/mcp" in url:
+            # Split out ?project= query
+            if "project=" in url:
+                base, q = url.split("?", 1)
+                project = [p.split("=", 1)[1] for p in q.split("&")
+                           if p.startswith("project=")][0]
+                return base.rstrip("/"), project
+    return None
+
+
+def _mcp_call(base: str, project: str, tool: str, args: dict) -> dict:
+    url = f"{base}/?project={project}"
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+               "params": {"name": tool, "arguments": args}}
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        raw = r.read().decode()
+        if "text/event-stream" in r.headers.get("Content-Type", ""):
+            for line in raw.splitlines():
+                if line.startswith("data: "):
+                    return json.loads(line[6:])
+        return json.loads(raw)
+
+
+def _parse_result(resp: dict):
+    content = resp.get("result", {}).get("content", [])
+    if not content:
+        return None
+    text = content[0].get("text", "")
+    try:
+        return json.loads(text)
+    except Exception:
+        return text
+
+
+def _git_tracked(root: Path) -> set[str] | None:
+    """Return set of git-tracked relative paths, or None if no git repo."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "ls-files"],
+            capture_output=True, text=True, timeout=15, check=True,
+        ).stdout
+        return {line.strip() for line in out.splitlines() if line.strip()}
+    except Exception:
+        return None
+
+
+def _should_skip(path: Path, root: Path) -> bool:
+    rel_parts = path.relative_to(root).parts
+    if any(p in SKIP_PARTS for p in rel_parts):
+        return True
+    if path.suffix not in SOURCE_EXTS:
+        return True
+    try:
+        sz = path.stat().st_size
+    except OSError:
+        return True
+    if sz == 0 or sz > MAX_FILE_BYTES:
+        return True
+    return False
+
+
+def _hash_file(p: Path) -> str | None:
+    """Hash the TEXT form (newline-normalized utf-8) so hashes match
+    what the server stores — avoids spurious CRLF-vs-LF drift on Windows."""
+    try:
+        text = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _collect(root: Path) -> dict[str, tuple[str, Path]]:
+    """Return {rel_path: (sha256, abs_path)} for source files under root."""
+    out: dict[str, tuple[str, Path]] = {}
+    tracked = _git_tracked(root)
+    if tracked:
+        for rel in tracked:
+            p = root / rel
+            if not p.is_file() or _should_skip(p, root):
+                continue
+            sha = _hash_file(p)
+            if sha:
+                out[rel.replace("\\", "/")] = (sha, p)
+    else:
+        for p in root.rglob("*"):
+            if not p.is_file() or _should_skip(p, root):
+                continue
+            sha = _hash_file(p)
+            if sha:
+                out[p.relative_to(root).as_posix()] = (sha, p)
+    return out
+
+
+def main() -> int:
+    root = _project_root()
+    cfg = _mcp_url_and_project(root)
+    if cfg is None:
+        # No .mcp.json — user hasn't opted in. Silent skip.
+        return 0
+    base, project = cfg
+
+    files = _collect(root)
+    if not files:
+        return 0
+
+    hashes = {path: sha for path, (sha, _) in files.items()}
+    try:
+        resp = _mcp_call(base, project, "prism_status",
+                         {"file_hashes": hashes})
+    except Exception as e:
+        print(f"[prism-sync] could not reach {base} ({e!r}); skipping",
+              file=sys.stderr)
+        return 0
+
+    status = _parse_result(resp) or {}
+    drifted = status.get("drifted", []) or []
+    if not drifted:
+        return 0
+
+    # Re-ingest drifted files
+    to_refresh: dict[str, str] = {}
+    for entry in drifted:
+        path = entry.get("path")
+        if not path:
+            continue
+        fe = files.get(path)
+        if not fe:
+            continue
+        try:
+            to_refresh[path] = fe[1].read_text(encoding="utf-8")
+        except Exception:
+            pass
+    if not to_refresh:
+        return 0
+
+    try:
+        _mcp_call(base, project, "prism_refresh", {"files": to_refresh})
+        print(f"[prism-sync] refreshed {len(to_refresh)} drifted file(s)",
+              file=sys.stderr)
+    except Exception as e:
+        print(f"[prism-sync] prism_refresh failed: {e!r}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+
+def _install_manifest(project_id: str) -> dict:
+    """Return the install manifest the agent should apply on first onboard.
+    The PRISM service is the single source of truth — if the hook logic
+    changes in a future release, a re-onboard serves the new version."""
+    hook_script = _HOOK_SCRIPT.replace("__PRISM_VERSION__", PRISM_VERSION)
+    return {
+        "prism_version": PRISM_VERSION,
+        "version_notes": PRISM_VERSION_NOTES,
+        "project_id": project_id,
+        "instructions_for_agent": [
+            "Use the Write tool to create each entry in install_files.",
+            "If .claude/hooks.json already exists, MERGE the SessionStart "
+            "array instead of overwriting.",
+            "After writing, tell the user: 'Restart Claude so the "
+            "SessionStart hook activates.'",
+            "The hook will auto-sync Brain/Graph on every future session "
+            "— no manual prism_sync needed.",
+        ],
+        "install_files": [
+            {
+                "path": ".claude/hooks.json",
+                "action": "create_or_merge",
+                "merge_key": "SessionStart",
+                "content": json.dumps({
+                    "SessionStart": [
+                        {
+                            "type": "command",
+                            "command": "python .claude/hooks/prism-sync.py",
+                            "timeout": 30000,
+                        },
+                    ],
+                }, indent=2),
+            },
+            {
+                "path": ".claude/hooks/prism-sync.py",
+                "action": "create",
+                "content": hook_script,
+                "mode": "0755",
+            },
+        ],
+        "verification_steps": [
+            "After Claude restart, re-invoke any tool and confirm no errors.",
+            "Call prism_status with no args — expect stale: false.",
+            "Edit any indexed source file, restart Claude, check the hook "
+            "logs for '[prism-sync] refreshed 1 drifted file(s)'.",
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Tool handler
 # ---------------------------------------------------------------------------
 
@@ -460,10 +1080,23 @@ async def handle_tool(name: str, arguments: dict, *, project_id: str = "default"
 
             # Return direct imperative instructions as plain text.
             # This is NOT a report — Claude must execute these steps.
+            manifest = _install_manifest(project_id)
+            files_list = "\n".join(
+                f"  - {f['path']} (action: {f['action']})"
+                for f in manifest["install_files"]
+            )
             instructions = f"""PRISM onboarding initialized for "{project_name}" (project: {project_id}).
 {seeded} conventions seeded into memory.{sp_hints}
 IMPORTANT: Onboarding is NOT complete. You MUST now execute all of the following steps.
 Do NOT summarize this response to the user — work through each step and call the MCP tools.
+
+== STEP 0: Install the client-side drift-sync hook ==
+Call prism_install to fetch the install manifest. It returns:
+{files_list}
+Use the Write tool to create each file. For .claude/hooks.json, MERGE the
+SessionStart array if the file already exists (don't overwrite other hooks).
+This one-time setup makes PRISM auto-sync on every future Claude session —
+no manual re-indexing needed.
 
 == STEP 1: Index architecture docs ==
 Find and read: README.md, CLAUDE.md, architecture.md, CONTRIBUTING.md, any docs/ folder.
@@ -502,12 +1135,18 @@ Include FILE PATHS and CODE SNIPPETS in descriptions so memory is actionable, no
 For conventions not already seeded, discover them from linting configs, code patterns, and test structure.
 Store via memory_store with domain="conventions". Include specific file paths as evidence.
 
-== STEP 7: Verify ==
+== STEP 7: Rebuild the code graph ==
+After indexing source files, call graph_rebuild once to run graphify and
+populate the entity/relationship tables with Leiden communities.
+
+== STEP 8: Verify ==
 Call brain_search with 3 different queries to verify Brain has indexed documents.
 Call memory_recall to verify conventions are stored.
-Report the final count to the user: "Indexed X documents into Brain, Y expertise entries in Memory."
+Call prism_status to confirm the graph is in sync.
+Report the final count to the user: "Indexed X documents, Y entities, Z communities.
+PRISM sync hook installed — restart Claude to activate auto-sync."
 
-BEGIN NOW with Step 1. Do not ask the user for permission — execute the steps."""
+BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps."""
 
             return [TextContent(type="text", text=instructions)]
 
@@ -565,6 +1204,56 @@ BEGIN NOW with Step 1. Do not ask the user for permission — execute the steps.
                 limit=arguments.get("limit", 10),
             )
             return [TextContent(type="text", text=_json(results))]
+
+        if name == "graph_rebuild":
+            ctx = get_project(project_id)
+            summary = ctx.graph_svc.rebuild(
+                brain_db_path=str(ctx._data_dir / "brain.db")
+            )
+            return [TextContent(type="text", text=_json(summary))]
+
+        if name == "prism_status":
+            ctx = get_project(project_id)
+            status = ctx.graph_svc.sync_status(
+                brain_db_path=str(ctx._data_dir / "brain.db"),
+                file_hashes=arguments.get("file_hashes"),
+            )
+            return [TextContent(type="text", text=_json(status))]
+
+        if name == "prism_refresh":
+            ctx = get_project(project_id)
+            files = arguments.get("files") or {}
+            default_domain = arguments.get("domain") or "code"
+            indexed = 0
+            for path, content in files.items():
+                if not isinstance(content, str):
+                    continue
+                ctx.brain_svc.index_doc(
+                    path=path, content=content, domain=default_domain,
+                )
+                indexed += 1
+            summary = ctx.graph_svc.rebuild(
+                brain_db_path=str(ctx._data_dir / "brain.db")
+            )
+            summary["refreshed_files"] = indexed
+            return [TextContent(type="text", text=_json(summary))]
+
+        if name == "prism_install":
+            # Returns the client-side install manifest so the agent can
+            # Write the hook files into the user's project directly.
+            return [TextContent(type="text", text=_json(_install_manifest(project_id)))]
+
+        if name == "prism_sync":
+            ctx = get_project(project_id)
+            brain_path = str(ctx._data_dir / "brain.db")
+            backfilled = ctx.graph_svc.backfill_from_brain(brain_path)
+            summary = ctx.graph_svc.rebuild(brain_db_path=brain_path)
+            summary["backfilled_via_sync"] = backfilled
+            return [TextContent(type="text", text=_json(summary))]
+
+        if name == "prism_guide":
+            section = (arguments or {}).get("section", "").strip().lower() or None
+            return [TextContent(type="text", text=_prism_guide(section))]
 
         # ------------------------------------------------------------------
         # Memory tools

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -71,6 +71,41 @@ TOOLS: list[Tool] = [
         },
     ),
     Tool(
+        name="brain_search_feedback",
+        description=(
+            "Record thumbs-up (signal='up') or thumbs-down (signal='down') "
+            "on a single doc_id returned by a prior brain_search call. Uses "
+            "the search_id the caller receives on each brain_search result. "
+            "Feedback is persisted to the search_feedback table and "
+            "aggregated on the /retrievals UI. Use this after you've worked "
+            "with a search result to record whether it was actually useful "
+            "— the data feeds future retrieval tuning."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "search_id": {
+                    "type": "integer",
+                    "description": "The search_id returned on each brain_search result",
+                },
+                "doc_id": {
+                    "type": "string",
+                    "description": "Which retrieved doc_id the feedback is about",
+                },
+                "signal": {
+                    "type": "string",
+                    "enum": ["up", "down"],
+                    "description": "up = useful, down = not useful",
+                },
+                "note": {
+                    "type": "string",
+                    "description": "Optional short reason (why it was good/bad)",
+                },
+            },
+            "required": ["search_id", "doc_id", "signal"],
+        },
+    ),
+    Tool(
         name="brain_list",
         description="List all documents indexed in Brain. Returns doc_id, domain, and content length for each.",
         inputSchema={
@@ -1188,6 +1223,18 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 "domain": domain,
                 "content_length": len(content),
                 "entities": len(entities),
+            }))]
+
+        if name == "brain_search_feedback":
+            feedback_id = brain_svc.record_search_feedback(
+                search_id=int(arguments["search_id"]),
+                doc_id=str(arguments["doc_id"]),
+                signal=str(arguments["signal"]),
+                note=arguments.get("note"),
+            )
+            return [TextContent(type="text", text=_json({
+                "recorded": feedback_id is not None,
+                "feedback_id": feedback_id,
             }))]
 
         if name == "brain_list":

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -113,6 +113,84 @@ TOOLS: list[Tool] = [
         },
     ),
     Tool(
+        name="brain_find_symbol",
+        description=(
+            "Return the chunk(s) for a named function/class/method — the "
+            "token-efficient alternative to Read-ing the whole parent "
+            "file. Example: brain_find_symbol('_fts5_search') returns a "
+            "~40-line chunk with file, line range, and body instead of "
+            "the 2500-line brain_engine.py. Optional kind filter: "
+            "function | class | method | module."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string",
+                         "description": "entity name (function, class, method)"},
+                "kind": {"type": "string",
+                         "description": "optional filter: function|class|method|module"},
+                "limit": {"type": "integer", "default": 10},
+            },
+            "required": ["name"],
+        },
+    ),
+    Tool(
+        name="brain_outline",
+        description=(
+            "Return the symbol outline of a source file — list of "
+            "entity_name/entity_kind/line_start/line_end with NO bodies. "
+            "Costs ~200 tokens for a file that would be 15K tokens to "
+            "Read. Use this to orient before deciding which specific "
+            "chunks to fetch via brain_find_symbol."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source_file": {"type": "string",
+                                 "description": "file path as indexed"},
+            },
+            "required": ["source_file"],
+        },
+    ),
+    Tool(
+        name="brain_find_references",
+        description=(
+            "Return the call sites of a named entity via the graph. "
+            "Each result is {caller_name, caller_kind, caller_file, "
+            "relation}. Use find_symbol() on a caller_name to fetch its "
+            "chunk content. Replaces 'grep for foo(' with a semantic "
+            "query that respects function boundaries."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "limit": {"type": "integer", "default": 20},
+            },
+            "required": ["name"],
+        },
+    ),
+    Tool(
+        name="brain_call_chain",
+        description=(
+            "Bounded BFS over the call graph starting at ``entity``. "
+            "Returns a flat edge list [{from, to, kind, relation, hop}] "
+            "so you can reconstruct 'what does this entity transitively "
+            "call'. Use to understand flow without Reading multiple "
+            "files."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entity": {"type": "string"},
+                "depth": {"type": "integer", "default": 2,
+                          "description": "max hops (default 2)"},
+                "limit": {"type": "integer", "default": 50},
+            },
+            "required": ["entity"],
+        },
+    ),
+    Tool(
         name="brain_list",
         description="List all documents indexed in Brain. Returns doc_id, domain, and content length for each.",
         inputSchema={
@@ -1286,6 +1364,33 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 "recorded": feedback_id is not None,
                 "feedback_id": feedback_id,
             }))]
+
+        if name == "brain_find_symbol":
+            results = brain_svc.find_symbol(
+                name=arguments["name"],
+                kind=arguments.get("kind"),
+                limit=arguments.get("limit", 10),
+            )
+            return [TextContent(type="text", text=_json(results))]
+
+        if name == "brain_outline":
+            results = brain_svc.outline(source_file=arguments["source_file"])
+            return [TextContent(type="text", text=_json(results))]
+
+        if name == "brain_find_references":
+            results = brain_svc.find_references(
+                name=arguments["name"],
+                limit=arguments.get("limit", 20),
+            )
+            return [TextContent(type="text", text=_json(results))]
+
+        if name == "brain_call_chain":
+            results = brain_svc.call_chain(
+                entity=arguments["entity"],
+                depth=arguments.get("depth", 2),
+                limit=arguments.get("limit", 50),
+            )
+            return [TextContent(type="text", text=_json(results))]
 
         if name == "brain_list":
             docs = brain_svc.list_docs(

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -16,7 +16,14 @@ from mcp.types import Tool, TextContent
 TOOLS: list[Tool] = [
     Tool(
         name="brain_search",
-        description="Search the project knowledge base using hybrid BM25 + vector + graph search",
+        description=(
+            "Search the project knowledge base using hybrid BM25 + vector + graph "
+            "search. Each result carries a `search_id` — after you've read or "
+            "edited a result's source_file (or deliberately skipped it), call "
+            "`brain_search_feedback(search_id, doc_id, signal='up'|'down')` to "
+            "record whether the result was useful. That feedback is persisted "
+            "to the searches/search_feedback tables for retrieval tuning."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
@@ -974,43 +981,86 @@ if __name__ == "__main__":
 '''
 
 
+def _load_asset(filename: str) -> str:
+    """Read a shipped hook script from app/assets/. The plugin-side copy in
+    ``plugins/prism-devtools/hooks/`` must be kept in sync with the copy in
+    ``services/prism-service/app/assets/``; the assets version is the one
+    served to MCP-only clients via prism_install."""
+    from pathlib import Path as _P
+    try:
+        return (_P(__file__).parent.parent / "assets" / filename).read_text(
+            encoding="utf-8"
+        )
+    except Exception:
+        return ""
+
+
+_FEEDBACK_HOOK_SCRIPT = _load_asset("feedback_signal_hook.py")
+
+
 def _install_manifest(project_id: str) -> dict:
     """Return the install manifest the agent should apply on first onboard.
     The PRISM service is the single source of truth — if the hook logic
     changes in a future release, a re-onboard serves the new version."""
     hook_script = _HOOK_SCRIPT.replace("__PRISM_VERSION__", PRISM_VERSION)
+    hooks_json = {
+        "SessionStart": [
+            {
+                "type": "command",
+                "command": "python .claude/hooks/prism-sync.py",
+                "timeout": 30000,
+            },
+        ],
+        "PostToolUse": [
+            {
+                "matcher": "mcp__prism__brain_search|Read|Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python .claude/hooks/prism-feedback-signal.py",
+                        "description": (
+                            "Implicit retrieval feedback: correlate "
+                            "brain_search results with Read/Edit and emit "
+                            "brain_search_feedback automatically."
+                        ),
+                    },
+                ],
+            },
+        ],
+    }
     return {
         "prism_version": PRISM_VERSION,
         "version_notes": PRISM_VERSION_NOTES,
         "project_id": project_id,
         "instructions_for_agent": [
             "Use the Write tool to create each entry in install_files.",
-            "If .claude/hooks.json already exists, MERGE the SessionStart "
-            "array instead of overwriting.",
-            "After writing, tell the user: 'Restart Claude so the "
-            "SessionStart hook activates.'",
-            "The hook will auto-sync Brain/Graph on every future session "
-            "— no manual prism_sync needed.",
+            "If .claude/hooks.json already exists, MERGE each top-level "
+            "array (SessionStart, PostToolUse) by appending — do not "
+            "overwrite the whole file.",
+            "After writing, tell the user: 'Restart Claude so the new "
+            "PRISM hooks activate.'",
+            "The SessionStart hook auto-syncs Brain/Graph. The PostToolUse "
+            "hook correlates brain_search results with Read/Edit and "
+            "emits implicit feedback via brain_search_feedback — no manual "
+            "thumbs-ups needed.",
         ],
         "install_files": [
             {
                 "path": ".claude/hooks.json",
                 "action": "create_or_merge",
-                "merge_key": "SessionStart",
-                "content": json.dumps({
-                    "SessionStart": [
-                        {
-                            "type": "command",
-                            "command": "python .claude/hooks/prism-sync.py",
-                            "timeout": 30000,
-                        },
-                    ],
-                }, indent=2),
+                "merge_keys": ["SessionStart", "PostToolUse"],
+                "content": json.dumps(hooks_json, indent=2),
             },
             {
                 "path": ".claude/hooks/prism-sync.py",
                 "action": "create",
                 "content": hook_script,
+                "mode": "0755",
+            },
+            {
+                "path": ".claude/hooks/prism-feedback-signal.py",
+                "action": "create",
+                "content": _FEEDBACK_HOOK_SCRIPT,
                 "mode": "0755",
             },
         ],

--- a/services/prism-service/app/project_context.py
+++ b/services/prism-service/app/project_context.py
@@ -23,6 +23,7 @@ class ProjectContext:
 
         # Lazy service instances
         self._brain_svc = None
+        self._graph_svc = None
         self._task_svc = None
         self._workflow_svc = None
         self._memory_svc = None
@@ -38,7 +39,19 @@ class ProjectContext:
                 graph_db=str(self._data_dir / "graph.db"),
                 scores_db=str(self._data_dir / "scores.db"),
             )
+            # Wire graph service for source-file staging
+            self._brain_svc.graph_svc = self.graph_svc
         return self._brain_svc
+
+    @property
+    def graph_svc(self):
+        if self._graph_svc is None:
+            from app.services.graph_service import GraphService
+            self._graph_svc = GraphService(
+                project_data_dir=str(self._data_dir),
+                graph_db_path=str(self._data_dir / "graph.db"),
+            )
+        return self._graph_svc
 
     @property
     def task_svc(self):

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os as _os
 import sqlite3
 import sys
 from typing import Optional
@@ -10,6 +11,37 @@ from typing import Optional
 import re as _re
 
 _CAMEL_RE = _re.compile(r'(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])')
+
+
+def _build_context_header(
+    source_file: str,
+    entity_name: Optional[str],
+    entity_kind: Optional[str],
+    line_start: Optional[int] = None,
+    line_end: Optional[int] = None,
+) -> str:
+    """Short structural prefix prepended to a chunk before embedding/BM25.
+
+    Anthropic Contextual Retrieval: anchoring a chunk in its parent document
+    (path, qualified name, line range) cuts retrieval failures 35-67% without
+    any LLM call. We use structural metadata we already carry per chunk.
+    """
+    lines = [f"File: {source_file}"]
+    if entity_name == "__file__":
+        lines.append("Scope: entire file")
+    elif entity_name == "__module__":
+        lines.append("Scope: module-level code outside any function or class")
+    elif entity_kind == "window":
+        if line_start and line_end:
+            lines.append(f"Scope: window over lines {line_start}-{line_end}")
+        else:
+            lines.append("Scope: sliding window")
+    elif entity_name and entity_kind:
+        qual = f"{entity_kind} {entity_name}"
+        if line_start and line_end:
+            qual += f" (lines {line_start}-{line_end})"
+        lines.append(f"Scope: {qual}")
+    return "\n".join(lines)
 
 
 def _expand_identifiers(text: str) -> str:
@@ -210,8 +242,28 @@ class BrainService:
                 first_doc_id = doc_id
 
             chunk_content = chunk["content"]
+            # Contextual prefix (PRISM_CONTEXT_PREFIX=on default): prepend a
+            # short header with file path + entity scope so the embedder and
+            # BM25 see chunks anchored in their parent document. Hash and the
+            # chunker's raw content are unchanged so drift detection still
+            # aligns with on-disk sha256.
+            if _os.environ.get(
+                "PRISM_CONTEXT_PREFIX", "on"
+            ).strip().lower() != "off":
+                header = _build_context_header(
+                    path,
+                    chunk.get("entity_name"),
+                    chunk.get("entity_kind"),
+                    chunk.get("line_start"),
+                    chunk.get("line_end"),
+                )
+                indexed_content = (
+                    f"{header}\n\n{chunk_content}" if header else chunk_content
+                )
+            else:
+                indexed_content = chunk_content
             # Expand PascalCase/camelCase per chunk for FTS matching.
-            expanded = _expand_identifiers(chunk_content)
+            expanded = _expand_identifiers(indexed_content)
             # Hash RAW chunk content so prism_status drift detection still
             # lines up with on-disk sha256 when the file is single-chunk.
             chash = _hashlib.sha256(chunk_content.encode("utf-8")).hexdigest()
@@ -228,7 +280,7 @@ class BrainService:
             )
 
             if vector_on:
-                vec = self._brain._embed(chunk_content)
+                vec = self._brain._embed(indexed_content)
                 if vec is not None:
                     blob = struct.pack(f"{len(vec)}f", *vec)
                     try:

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -198,6 +198,41 @@ class BrainService:
             return []
         return self._brain.graph_query(entity, relation=relation, limit=limit)
 
+    def find_symbol(
+        self,
+        name: str,
+        kind: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """Find chunks matching entity_name; token-efficient alternative to Read."""
+        if not self._available or self._brain is None:
+            return []
+        return self._brain.find_symbol(name=name, kind=kind, limit=limit)
+
+    def outline(self, source_file: str) -> list[dict]:
+        """Return symbol outline of a file — metadata only, ~200 tokens."""
+        if not self._available or self._brain is None:
+            return []
+        return self._brain.outline(source_file=source_file)
+
+    def find_references(
+        self, name: str, limit: int = 20,
+    ) -> list[dict]:
+        """Return callers of ``name`` from the graph (caller_name/kind/file)."""
+        if not self._available or self._brain is None:
+            return []
+        return self._brain.find_references(name=name, limit=limit)
+
+    def call_chain(
+        self, entity: str, depth: int = 2, limit: int = 50,
+    ) -> list[dict]:
+        """Bounded BFS over the call graph from ``entity``."""
+        if not self._available or self._brain is None:
+            return []
+        return self._brain.call_chain(
+            entity=entity, depth=depth, limit=limit,
+        )
+
     def ingest(self, sources: list[str]) -> int:
         """Ingest source files into the knowledge base."""
         if not self._available or self._brain is None:

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -178,14 +178,40 @@ class BrainService:
         # Expand PascalCase/camelCase for better FTS matching
         expanded_content = _expand_identifiers(content)
 
+        # Hash the RAW content (not expanded) so callers can diff against
+        # on-disk sha256 for drift detection via prism_status.
+        import hashlib as _hashlib
+        content_hash = _hashlib.sha256(content.encode("utf-8")).hexdigest()
+
         # Delete first so the AFTER INSERT trigger fires for FTS sync
         brain_conn.execute("DELETE FROM docs WHERE id = ?", (doc_id,))
         brain_conn.execute(
             "INSERT INTO docs "
-            "(id, source_file, content, domain, indexed_at, entity_name, entity_kind) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (doc_id, path, expanded_content, domain, now, filename, "file"),
+            "(id, source_file, content, domain, indexed_at, "
+            " entity_name, entity_kind, content_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (doc_id, path, expanded_content, domain, now,
+             filename, "file", content_hash),
         )
+
+        # Populate vector index so semantic search sees MCP-ingested docs.
+        if getattr(self._brain, "vector_enabled", False):
+            vec = self._brain._embed(content)
+            if vec is not None:
+                import struct
+                blob = struct.pack(f"{len(vec)}f", *vec)
+                try:
+                    brain_conn.execute(
+                        "DELETE FROM docs_vec WHERE doc_id = ?", (doc_id,)
+                    )
+                    brain_conn.execute(
+                        "INSERT INTO docs_vec (doc_id, embedding) VALUES (?, ?)",
+                        (doc_id, blob),
+                    )
+                except Exception as e:
+                    print(f"index_doc vec insert failed: {e!r}",
+                          file=sys.stderr, flush=True)
+
         brain_conn.commit()
 
         # Index entities into graph.db if provided
@@ -200,6 +226,18 @@ class BrainService:
                         (ent_name, ent_kind, path),
                     )
             graph_conn.commit()
+
+        # Stage source file for the graphify code-graph pass.
+        # graph_svc is wired in by ProjectContext when available; if the doc
+        # has a known source-code suffix, stage_doc writes it to the project's
+        # graphify-src/ dir so a later graph_rebuild picks it up.
+        graph_svc = getattr(self, "graph_svc", None)
+        if graph_svc is not None:
+            try:
+                graph_svc.stage_doc(path, content)
+            except Exception as e:
+                print(f"index_doc: graph staging failed: {e!r}",
+                      file=sys.stderr, flush=True)
 
         return doc_id
 

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -139,6 +139,33 @@ class BrainService:
             return []
         return self._brain.get_recent_searches(limit=limit)
 
+    def record_search_feedback(
+        self,
+        search_id: int,
+        doc_id: str,
+        signal: str,
+        note: Optional[str] = None,
+    ) -> Optional[int]:
+        """Write one thumbs-up/thumbs-down on a search result doc."""
+        if not self._available or self._brain is None:
+            return None
+        return self._brain.record_search_feedback(
+            search_id=search_id, doc_id=doc_id,
+            signal=signal, note=note,
+        )
+
+    def search_feedback(self, search_id: int) -> list[dict]:
+        """Return all feedback rows tied to ``search_id``."""
+        if not self._available or self._brain is None:
+            return []
+        return self._brain.get_search_feedback(search_id=search_id)
+
+    def feedback_stats(self) -> dict:
+        """Aggregate up/down counts + worst-offender docs."""
+        if not self._available or self._brain is None:
+            return {"up": 0, "down": 0, "worst": []}
+        return self._brain.feedback_stats()
+
     def list_docs(
         self, domain: Optional[str] = None, limit: int = 100,
     ) -> list[dict]:

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -152,69 +152,98 @@ class BrainService:
         domain: str = "code",
         entities: list[dict] | None = None,
     ) -> str:
-        """Index a document directly from content (no filesystem access needed).
+        """Index a document, chunked at function/class boundaries when possible.
 
-        Claude reads the file on the host and sends content via MCP.
-        Brain stores and indexes it for future search.
+        Code files (suffix in _TS_LANG_MAP): chunked via Brain._chunk_source_file
+        into per-function/class docs with ``path::EntityName`` ids, each with
+        its own embedding. Prose (md/txt): single whole-file doc with
+        ``path::main`` (legacy id format preserved for backward-compat).
 
-        Uses the Brain engine's own DB connections so FTS triggers fire.
-
-        Returns the doc_id.
+        Replaces any prior chunks for the same source_file so re-indexing
+        leaves no stale rows. Returns the first chunk's doc_id.
         """
         from datetime import datetime, timezone
-
-        doc_id = f"{path}::main"
-        now = datetime.now(timezone.utc).isoformat()
-        filename = path.rsplit("/", 1)[-1] if "/" in path else path
+        import hashlib as _hashlib
+        import struct
 
         if not self._available or self._brain is None:
-            return doc_id  # silently skip if Brain not available
+            return f"{path}::main"
 
-        # Use the Brain engine's own connections so search sees the new data.
-        # self._brain is the Brain engine instance.
-        # self._brain._brain is its sqlite3 connection to brain.db.
         brain_conn = self._brain._brain
+        now = datetime.now(timezone.utc).isoformat()
+        vector_on = getattr(self._brain, "vector_enabled", False)
 
-        # Expand PascalCase/camelCase for better FTS matching
-        expanded_content = _expand_identifiers(content)
-
-        # Hash the RAW content (not expanded) so callers can diff against
-        # on-disk sha256 for drift detection via prism_status.
-        import hashlib as _hashlib
-        content_hash = _hashlib.sha256(content.encode("utf-8")).hexdigest()
-
-        # Delete first so the AFTER INSERT trigger fires for FTS sync
-        brain_conn.execute("DELETE FROM docs WHERE id = ?", (doc_id,))
-        brain_conn.execute(
-            "INSERT INTO docs "
-            "(id, source_file, content, domain, indexed_at, "
-            " entity_name, entity_kind, content_hash) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (doc_id, path, expanded_content, domain, now,
-             filename, "file", content_hash),
-        )
-
-        # Populate vector index so semantic search sees MCP-ingested docs.
-        if getattr(self._brain, "vector_enabled", False):
-            vec = self._brain._embed(content)
-            if vec is not None:
-                import struct
-                blob = struct.pack(f"{len(vec)}f", *vec)
+        # Purge any prior rows for this source file (by source_file column,
+        # plus the legacy path::main and path-only ids) so a re-index leaves
+        # no stale chunks behind.
+        stale = brain_conn.execute(
+            "SELECT id FROM docs WHERE source_file = ? OR id = ? OR id = ?",
+            (path, path, f"{path}::main"),
+        ).fetchall()
+        stale_ids = [r[0] for r in stale]
+        if stale_ids:
+            ph = ",".join("?" * len(stale_ids))
+            if vector_on:
                 try:
                     brain_conn.execute(
-                        "DELETE FROM docs_vec WHERE doc_id = ?", (doc_id,)
+                        f"DELETE FROM docs_vec WHERE doc_id IN ({ph})",
+                        stale_ids,
                     )
-                    brain_conn.execute(
-                        "INSERT INTO docs_vec (doc_id, embedding) VALUES (?, ?)",
-                        (doc_id, blob),
-                    )
-                except Exception as e:
-                    print(f"index_doc vec insert failed: {e!r}",
-                          file=sys.stderr, flush=True)
+                except Exception:
+                    pass
+            brain_conn.execute(
+                f"DELETE FROM docs WHERE id IN ({ph})", stale_ids,
+            )
+
+        # Chunk via Brain's native chunker (tree-sitter for .py, regex
+        # fallback for .ts/.tsx/.js/.jsx/.cs, whole-file for everything else).
+        chunks = self._brain._chunk_source_file(path, content)
+
+        first_doc_id = ""
+        for chunk in chunks:
+            doc_id = chunk["doc_id"]
+            # Non-code files come back with doc_id == filepath (no "::").
+            # Normalise to the legacy path::main form for prose compat.
+            if "::" not in doc_id:
+                doc_id = f"{path}::main"
+            if not first_doc_id:
+                first_doc_id = doc_id
+
+            chunk_content = chunk["content"]
+            # Expand PascalCase/camelCase per chunk for FTS matching.
+            expanded = _expand_identifiers(chunk_content)
+            # Hash RAW chunk content so prism_status drift detection still
+            # lines up with on-disk sha256 when the file is single-chunk.
+            chash = _hashlib.sha256(chunk_content.encode("utf-8")).hexdigest()
+
+            brain_conn.execute(
+                "INSERT INTO docs "
+                "(id, source_file, content, domain, indexed_at, "
+                " entity_name, entity_kind, content_hash, "
+                " line_start, line_end) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (doc_id, path, expanded, domain, now,
+                 chunk["entity_name"], chunk["entity_kind"], chash,
+                 chunk["line_start"], chunk["line_end"]),
+            )
+
+            if vector_on:
+                vec = self._brain._embed(chunk_content)
+                if vec is not None:
+                    blob = struct.pack(f"{len(vec)}f", *vec)
+                    try:
+                        brain_conn.execute(
+                            "INSERT INTO docs_vec (doc_id, embedding) "
+                            "VALUES (?, ?)",
+                            (doc_id, blob),
+                        )
+                    except Exception as e:
+                        print(f"index_doc vec insert failed: {e!r}",
+                              file=sys.stderr, flush=True)
 
         brain_conn.commit()
 
-        # Index entities into graph.db if provided
+        # Index caller-supplied entities into graph.db (unchanged).
         if entities:
             graph_conn = self._brain._graph
             for ent in entities:
@@ -222,15 +251,13 @@ class BrainService:
                 ent_kind = ent.get("kind", "unknown")
                 if ent_name:
                     graph_conn.execute(
-                        "INSERT OR IGNORE INTO entities (name, kind, file) VALUES (?, ?, ?)",
+                        "INSERT OR IGNORE INTO entities (name, kind, file) "
+                        "VALUES (?, ?, ?)",
                         (ent_name, ent_kind, path),
                     )
             graph_conn.commit()
 
-        # Stage source file for the graphify code-graph pass.
-        # graph_svc is wired in by ProjectContext when available; if the doc
-        # has a known source-code suffix, stage_doc writes it to the project's
-        # graphify-src/ dir so a later graph_rebuild picks it up.
+        # Stage source for graphify's code-graph pass (unchanged).
         graph_svc = getattr(self, "graph_svc", None)
         if graph_svc is not None:
             try:
@@ -239,7 +266,7 @@ class BrainService:
                 print(f"index_doc: graph staging failed: {e!r}",
                       file=sys.stderr, flush=True)
 
-        return doc_id
+        return first_doc_id or f"{path}::main"
 
     # ------------------------------------------------------------------
     # Status

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -133,6 +133,12 @@ class BrainService:
             story_file=story_file, persona=persona, limit=limit,
         )
 
+    def recent_searches(self, limit: int = 50) -> list[dict]:
+        """Return the most recent ``limit`` search events from brain.db."""
+        if not self._available or self._brain is None:
+            return []
+        return self._brain.get_recent_searches(limit=limit)
+
     def list_docs(
         self, domain: Optional[str] = None, limit: int = 100,
     ) -> list[dict]:

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -1,0 +1,693 @@
+"""Graph service — wraps graphify CLI for code knowledge graph extraction.
+
+graphify provides:
+  * Tree-sitter AST pass (6+ languages, deterministic, no LLM needed)
+  * Cross-file call graph edges with EXTRACTED/INFERRED/AMBIGUOUS confidence
+  * Leiden community detection (Newman-style clustering)
+  * Rationale tag extraction (# WHY:, # HACK:, # NOTE:)
+
+PRISM stages MCP-ingested source files into a per-project directory, invokes
+`graphify update <dir>` (the LLM-free pass), and parses the resulting
+`graphify-out/graph.json` into the project's `graph.db`. The existing
+Brain engine `_graph_search` then queries the richer tables.
+
+Design choices:
+  * Staging dir lives under the project's data dir on the mounted volume,
+    so it survives container restart but is project-isolated.
+  * Rebuild is explicit (via MCP tool `graph_rebuild`) rather than per-ingest:
+    graphify is cheap on small repos but re-running per doc is wasteful.
+  * Tree-sitter fallback in brain_engine remains for projects that haven't
+    called graph_rebuild yet.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+# Map of common source-code suffixes that graphify knows how to parse.
+# Ingested docs with these suffixes will be staged for the graph pass.
+GRAPHIFY_CODE_SUFFIXES = {
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".cs",
+    ".go", ".rs", ".java", ".rb", ".php", ".cpp", ".c", ".h", ".hpp",
+    ".md",  # graphify also picks up heading structure from markdown
+}
+
+
+def _graph_schema_migrations(conn: sqlite3.Connection) -> None:
+    """Add graphify-specific columns + communities table.
+    Safe to call repeatedly — each ALTER is idempotent."""
+    # entities extensions
+    ent_cols = {row[1] for row in conn.execute("PRAGMA table_info(entities)").fetchall()}
+    for col, sql in (
+        ("graphify_id",     "ALTER TABLE entities ADD COLUMN graphify_id TEXT"),
+        ("label",           "ALTER TABLE entities ADD COLUMN label TEXT"),
+        ("file_type",       "ALTER TABLE entities ADD COLUMN file_type TEXT"),
+        ("community",       "ALTER TABLE entities ADD COLUMN community INTEGER"),
+        ("source_location", "ALTER TABLE entities ADD COLUMN source_location TEXT"),
+    ):
+        if col not in ent_cols:
+            try:
+                conn.execute(sql); conn.commit()
+            except sqlite3.OperationalError:
+                pass
+
+    # relationships extensions
+    rel_cols = {row[1] for row in conn.execute("PRAGMA table_info(relationships)").fetchall()}
+    for col, sql in (
+        ("confidence",        "ALTER TABLE relationships ADD COLUMN confidence TEXT"),
+        ("confidence_score",  "ALTER TABLE relationships ADD COLUMN confidence_score REAL"),
+        ("weight",            "ALTER TABLE relationships ADD COLUMN weight REAL"),
+        ("source_location",   "ALTER TABLE relationships ADD COLUMN source_location TEXT"),
+    ):
+        if col not in rel_cols:
+            try:
+                conn.execute(sql); conn.commit()
+            except sqlite3.OperationalError:
+                pass
+
+    # Communities — human-readable labels derived from dominant content
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS communities ("
+            "  id INTEGER PRIMARY KEY,"
+            "  label TEXT,"
+            "  size INTEGER,"
+            "  top_files TEXT,"       # JSON array
+            "  top_entities TEXT"     # JSON array
+            ")"
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+    # index on graphify_id for fast upsert
+    try:
+        conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_ent_graphify_id "
+                     "ON entities(graphify_id) WHERE graphify_id IS NOT NULL")
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Community label derivation
+# ---------------------------------------------------------------------------
+
+import re as _re
+from collections import Counter as _Counter
+
+_WORD_RE = _re.compile(r"[A-Za-z][A-Za-z0-9]*")
+
+
+def _basename_stem(path: str) -> str:
+    """'services/prism-service/app/engines/brain_engine.py' -> 'brain_engine'."""
+    if not path:
+        return ""
+    tail = path.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
+    return tail.rsplit(".", 1)[0]
+
+
+def _humanize(stem: str) -> str:
+    """brain_engine -> brain engine; BrainEngine -> brain engine.
+    Trims trailing punctuation and caps to a readable length."""
+    if not stem:
+        return ""
+    # split camelCase/PascalCase
+    s = _re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", " ", stem)
+    s = s.replace("_", " ").replace("-", " ")
+    words = [w.lower().rstrip(".,:;") for w in s.split()]
+    # Drop leading/trailing noise words
+    result = " ".join(w for w in words if w)
+    # Keep first ~6 words so hub descriptors from docstrings stay compact
+    first_six = result.split(" ", 6)
+    if len(first_six) > 6:
+        result = " ".join(first_six[:6])
+    # Hard cap on total chars
+    if len(result) > 42:
+        result = result[:39].rstrip() + "…"
+    return result
+
+
+_GENERIC_ENTITY_NAMES = {
+    "__init__", "init", "main", "run", "setup", "config", "module",
+    "self", "cls", "args", "kwargs", "value", "result", "data",
+}
+
+
+def _pick_hub_entity(entities_ranked: list[tuple[dict, int]]) -> str:
+    """Pick a meaningful entity name from the highest-degree nodes.
+
+    Two passes:
+      1. Strict: skip dunders, single-letter, generic placeholders.
+      2. Relaxed: accept anything non-empty. Guarantees sibling communities
+         from the same dominant file still get distinct labels.
+    """
+    def _clean(name: str) -> str:
+        return (name or "").strip().lstrip(".").rstrip("()").replace("()", "")
+
+    # Strict pass
+    for node, deg in entities_ranked:
+        name = _clean(node.get("label") or node.get("id") or "")
+        if (deg > 0 and name and not name.startswith("__")
+                and len(name) > 1
+                and name.lower() not in _GENERIC_ENTITY_NAMES):
+            return name
+    # Relaxed pass — include degree 0 and dunders; avoid only empty strings
+    for node, deg in entities_ranked:
+        name = _clean(node.get("label") or node.get("id") or "")
+        if name and len(name) > 1:
+            return name
+    return ""
+
+
+def _derive_community_label(
+    nodes: list[dict],
+    in_degree: dict,
+) -> tuple[str, list[str], list[str]]:
+    """Return (label, top_files, top_entities) for a community.
+
+    Heuristic:
+      * Primary descriptor = dominant source-file basename.
+      * Secondary descriptor = highest-degree NON-GENERIC entity in the
+        community. Appended as "<file> · <hub>" to distinguish sibling
+        communities that share a huge dominant file (e.g. brain_engine.py
+        splits into 9 sub-clusters — each now gets named by its hub entity).
+    """
+    file_counts: _Counter = _Counter()
+    for n in nodes:
+        sf = n.get("source_file") or ""
+        if sf:
+            file_counts[_basename_stem(sf)] += 1
+
+    total = sum(file_counts.values()) or 1
+    top = file_counts.most_common(4)
+    top_files = [t[0] for t in top]
+
+    # Rank entities in this community by in-degree (connectedness)
+    entity_scores = sorted(
+        ((n, in_degree.get(n.get("id", ""), 0)) for n in nodes),
+        key=lambda x: -x[1],
+    )
+    top_entities = [
+        n.get("label") or n.get("id", "")
+        for n, _ in entity_scores[:5]
+        if (n.get("label") or n.get("id"))
+    ]
+    hub = _pick_hub_entity(entity_scores)
+
+    if top:
+        first, first_n = top[0]
+        first_frac = first_n / total
+        if first_frac >= 0.55:
+            base = _humanize(first)
+            # For mega-files (most of the community from one file), append
+            # the hub entity so sibling communities from the same file stay
+            # distinguishable.
+            label = f"{base} · {_humanize(hub)}" if hub else base
+        elif len(top) >= 2 and (top[0][1] + top[1][1]) / total >= 0.70:
+            label = f"{_humanize(top[0][0])} + {_humanize(top[1][0])}"
+            if hub:
+                label = f"{label} · {_humanize(hub)}"
+        else:
+            # dispersed — use hub entity if we have one, else top file
+            if hub:
+                label = _humanize(hub)
+            else:
+                label = _humanize(top[0][0]) or "mixed"
+    else:
+        label = _humanize(hub) if hub else "misc"
+
+    return label, top_files, top_entities
+
+
+class GraphService:
+    """Per-project graphify runner + graph.db importer.
+
+    Instantiate with the project's data dir (where brain.db / graph.db live).
+    Call `stage_doc()` from brain_index_doc to write source files into the
+    graphify staging area; call `rebuild()` to re-run graphify and re-import.
+    """
+
+    def __init__(self, project_data_dir: str, graph_db_path: str) -> None:
+        self._project_dir = Path(project_data_dir)
+        self._staging_dir = self._project_dir / "graphify-src"
+        self._staging_dir.mkdir(parents=True, exist_ok=True)
+        self._graph_db = graph_db_path
+
+    # ------------------------------------------------------------------
+    # Ingestion: stage doc content to disk for graphify to read
+    # ------------------------------------------------------------------
+
+    def stage_doc(self, path: str, content: str) -> bool:
+        """Write `content` to staging dir at `path`. Returns True if staged."""
+        suffix = "." + path.rsplit(".", 1)[-1].lower() if "." in path else ""
+        if suffix not in GRAPHIFY_CODE_SUFFIXES:
+            return False
+        # Normalize path (no absolute, no ..)
+        rel = Path(path).as_posix().lstrip("/")
+        if ".." in Path(rel).parts:
+            return False
+        dest = self._staging_dir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            dest.write_text(content, encoding="utf-8")
+            return True
+        except OSError:
+            return False
+
+    def unstage_doc(self, path: str) -> bool:
+        rel = Path(path).as_posix().lstrip("/")
+        dest = self._staging_dir / rel
+        if dest.exists():
+            try:
+                dest.unlink()
+                return True
+            except OSError:
+                pass
+        return False
+
+    # ------------------------------------------------------------------
+    # graphify invocation
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Backfill staging from the Brain docs table when it's empty. Protects
+    # against the "old project upgraded before graphify existed" case where
+    # docs were ingested long ago but nothing was staged for the code graph.
+    # ------------------------------------------------------------------
+
+    def backfill_from_brain(self, brain_db_path: str) -> int:
+        """Stage every code-suffix doc from the Brain docs table.
+        Returns the number of files staged. Safe to call repeatedly —
+        will overwrite existing staged content with latest from docs."""
+        try:
+            conn = sqlite3.connect(brain_db_path)
+            conn.row_factory = sqlite3.Row
+        except sqlite3.Error:
+            return 0
+        n = 0
+        try:
+            rows = conn.execute(
+                "SELECT id, source_file, content FROM docs"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+        finally:
+            conn.close()
+        for row in rows:
+            # doc_id is typically "<path>::main"; source_file is the raw path
+            path = row["source_file"] or row["id"].removesuffix("::main")
+            if self.stage_doc(path, row["content"] or ""):
+                n += 1
+        return n
+
+    def sync_status(self, brain_db_path: str,
+                    file_hashes: dict | None = None) -> dict:
+        """Report whether the graph is in sync with docs. Non-mutating.
+
+        If `file_hashes` is provided ({path: sha256}), we also compare
+        disk state against Brain's stored content_hash for each path and
+        return a precise `drifted` list:
+          [{path, reason: 'missing'|'content_changed'}]
+        This is the signal the SessionStart hook uses to decide which
+        files to re-push via prism_refresh.
+        """
+        import sqlite3 as _sq3
+        try:
+            from app.__version__ import PRISM_VERSION as _ver
+        except Exception:
+            _ver = "unknown"
+        out: dict = {"prism_version": _ver,
+                     "docs": 0, "code_docs": 0, "staged_files": 0,
+                     "entities": 0, "entities_with_graphify_id": 0,
+                     "relationships": 0, "communities": 0,
+                     "stale": False, "reasons": [],
+                     "drifted": [], "drift_checked": False}
+        try:
+            b = _sq3.connect(brain_db_path); b.row_factory = _sq3.Row
+            out["docs"] = b.execute("SELECT COUNT(*) FROM docs").fetchone()[0]
+            out["code_docs"] = sum(1 for r in b.execute(
+                "SELECT source_file FROM docs"
+            ) if (r["source_file"] or "").lower().rsplit(".", 1)[-1]
+               in {s.lstrip(".") for s in GRAPHIFY_CODE_SUFFIXES})
+            b.close()
+        except _sq3.Error:
+            pass
+        try:
+            out["staged_files"] = sum(
+                1 for p in self._staging_dir.rglob("*")
+                if p.is_file() and "graphify-out" not in p.parts
+                and "cache" not in p.parts
+            )
+        except OSError:
+            pass
+        try:
+            g = _sq3.connect(self._graph_db); g.row_factory = _sq3.Row
+            out["entities"] = g.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+            try:
+                out["entities_with_graphify_id"] = g.execute(
+                    "SELECT COUNT(*) FROM entities WHERE graphify_id IS NOT NULL"
+                ).fetchone()[0]
+                out["relationships"] = g.execute(
+                    "SELECT COUNT(*) FROM relationships"
+                ).fetchone()[0]
+                out["communities"] = g.execute(
+                    "SELECT COUNT(DISTINCT community) FROM entities "
+                    "WHERE community IS NOT NULL"
+                ).fetchone()[0]
+            except _sq3.OperationalError:
+                pass
+            g.close()
+        except _sq3.Error:
+            pass
+
+        # Staleness heuristics (count-based fallbacks)
+        if out["code_docs"] > 0 and out["staged_files"] == 0:
+            out["stale"] = True
+            out["reasons"].append(
+                f"{out['code_docs']} code docs in Brain but staging dir is "
+                f"empty — call prism_sync to backfill + rebuild"
+            )
+        if out["entities"] > 0 and out["entities_with_graphify_id"] == 0:
+            out["stale"] = True
+            out["reasons"].append(
+                "graph.db has entities but none carry graphify_id — legacy "
+                "tree-sitter output; call graph_rebuild to refresh"
+            )
+        if out["code_docs"] > 0 and out["staged_files"] < out["code_docs"] // 2:
+            out["stale"] = True
+            out["reasons"].append(
+                f"only {out['staged_files']}/{out['code_docs']} code docs "
+                f"are staged — call prism_sync"
+            )
+
+        # Content-hash drift detection — precise per-file staleness. Given
+        # {path: sha256} from the caller, diff against docs.content_hash and
+        # report exactly which files need re-ingestion.
+        if file_hashes:
+            out["drift_checked"] = True
+            stored: dict[str, str] = {}
+            try:
+                b = _sq3.connect(brain_db_path); b.row_factory = _sq3.Row
+                for r in b.execute(
+                    "SELECT source_file, content_hash FROM docs "
+                    "WHERE content_hash IS NOT NULL"
+                ):
+                    sf = r["source_file"] or ""
+                    if sf:
+                        stored[sf] = r["content_hash"]
+                b.close()
+            except _sq3.Error:
+                pass
+
+            for path, sha in file_hashes.items():
+                got = stored.get(path)
+                if got is None:
+                    out["drifted"].append({"path": path, "reason": "missing"})
+                elif got != sha:
+                    out["drifted"].append({"path": path, "reason": "content_changed"})
+
+            if out["drifted"]:
+                out["stale"] = True
+                out["reasons"].append(
+                    f"{len(out['drifted'])} file(s) drifted vs disk — call "
+                    f"prism_refresh with their current content"
+                )
+
+        return out
+
+    def rebuild(self, brain_db_path: str | None = None) -> dict:
+        """Run `graphify update <staging>` and import resulting graph.json.
+
+        If `brain_db_path` is provided and staging is empty, backfill it from
+        the Brain docs table first. Prevents the "stale graph after upgrade"
+        case where docs exist but nothing was ever staged for the graph.
+
+        Returns a summary: {nodes, edges, communities, imported_entities,
+        imported_relationships, backfilled}.
+        """
+        result: dict = {"nodes": 0, "edges": 0, "communities": 0,
+                        "imported_entities": 0, "imported_relationships": 0,
+                        "backfilled": 0}
+
+        # Auto-backfill if staging is empty
+        if brain_db_path and not any(self._staging_dir.rglob("*")):
+            result["backfilled"] = self.backfill_from_brain(brain_db_path)
+
+        if not any(self._staging_dir.rglob("*")):
+            result["message"] = "no staged source files yet"
+            return result
+
+        # graphify CLI writes graph.json into <target>/graphify-out/ regardless
+        # of cwd, so we just pass the staging dir as target.
+        proc = subprocess.run(
+            ["graphify", "update", str(self._staging_dir)],
+            cwd=str(self._project_dir),
+            capture_output=True, text=True, timeout=600,
+        )
+        if proc.returncode != 0:
+            result["error"] = (proc.stderr or proc.stdout or "").strip()[:500]
+            return result
+
+        graph_json_path = self._staging_dir / "graphify-out" / "graph.json"
+        if not graph_json_path.exists():
+            result["error"] = "graphify ran but no graph.json produced"
+            return result
+
+        try:
+            data = json.loads(graph_json_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            result["error"] = f"graph.json parse failed: {e!r}"
+            return result
+
+        return self._import_graph_json(data, result)
+
+    # ------------------------------------------------------------------
+    # graph.json -> graph.db import
+    # ------------------------------------------------------------------
+
+    def _import_graph_json(self, data: dict, result: dict) -> dict:
+        nodes = data.get("nodes", [])
+        links = data.get("links", [])
+        result["nodes"] = len(nodes)
+        result["edges"] = len(links)
+        result["communities"] = len({n.get("community") for n in nodes
+                                      if n.get("community") is not None})
+
+        # Total degree (in + out) for community label derivation — captures
+        # both "called-by" hubs and "calls-a-lot" orchestrators.
+        in_degree: dict = {}
+        for link in links:
+            src = link.get("source") or link.get("_src")
+            tgt = link.get("target") or link.get("_tgt")
+            if src:
+                in_degree[src] = in_degree.get(src, 0) + 1
+            if tgt:
+                in_degree[tgt] = in_degree.get(tgt, 0) + 1
+
+        conn = sqlite3.connect(self._graph_db)
+        conn.row_factory = sqlite3.Row
+        try:
+            _graph_schema_migrations(conn)
+            # Wipe + re-import: the graph is a full snapshot, not an incremental diff
+            conn.execute("DELETE FROM relationships")
+            conn.execute("DELETE FROM entities")
+
+            # Import nodes → entities. Use graphify's id as the natural key.
+            id_map: dict[str, int] = {}
+            for node in nodes:
+                gid = node.get("id", "")
+                if not gid:
+                    continue
+                label = node.get("label", gid)
+                file_type = node.get("file_type", "")
+                community = node.get("community")
+                source_file = node.get("source_file", "")
+                source_location = node.get("source_location", "")
+                # Derive "kind" from file_type or label for legacy queries
+                kind = file_type or "node"
+                cur = conn.execute(
+                    "INSERT INTO entities "
+                    "(name, kind, file, line, graphify_id, label, file_type, "
+                    " community, source_location) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT(name, file) DO UPDATE SET "
+                    "  kind=excluded.kind, "
+                    "  graphify_id=excluded.graphify_id, "
+                    "  label=excluded.label, "
+                    "  file_type=excluded.file_type, "
+                    "  community=excluded.community, "
+                    "  source_location=excluded.source_location",
+                    (label, kind, source_file, _extract_line(source_location),
+                     gid, label, file_type, community, source_location),
+                )
+                # Retrieve id (RETURNING not universally available pre-3.35)
+                row = conn.execute(
+                    "SELECT id FROM entities WHERE graphify_id = ?", (gid,)
+                ).fetchone()
+                if row:
+                    id_map[gid] = row["id"]
+                    result["imported_entities"] += 1
+
+            # Import links → relationships
+            for link in links:
+                src_gid = link.get("source") or link.get("_src")
+                tgt_gid = link.get("target") or link.get("_tgt")
+                src_id = id_map.get(src_gid)
+                tgt_id = id_map.get(tgt_gid)
+                if src_id is None or tgt_id is None:
+                    continue
+                relation = link.get("relation", "related")
+                confidence = link.get("confidence", "EXTRACTED")
+                confidence_score = float(link.get("confidence_score", 1.0))
+                weight = float(link.get("weight", 1.0))
+                source_location = link.get("source_location", "")
+                try:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO relationships "
+                        "(source_id, target_id, relation, confidence, "
+                        " confidence_score, weight, source_location) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        (src_id, tgt_id, relation, confidence,
+                         confidence_score, weight, source_location),
+                    )
+                    result["imported_relationships"] += 1
+                except sqlite3.IntegrityError:
+                    pass
+
+            # -- Derive + persist community labels -----------------------
+            from collections import defaultdict
+            buckets: dict[int, list[dict]] = defaultdict(list)
+            for n in nodes:
+                cid = n.get("community")
+                if cid is not None:
+                    buckets[int(cid)].append(n)
+
+            conn.execute("DELETE FROM communities")
+            labels_out: dict[int, str] = {}
+            for cid, cnodes in buckets.items():
+                label, top_files, top_entities = _derive_community_label(
+                    cnodes, in_degree
+                )
+                # de-duplicate labels across communities by suffixing (N)
+                base = label
+                n_taken = sum(1 for v in labels_out.values() if v == base
+                              or v.startswith(base + " ("))
+                final_label = base if n_taken == 0 else f"{base} ({n_taken + 1})"
+                labels_out[cid] = final_label
+                conn.execute(
+                    "INSERT OR REPLACE INTO communities "
+                    "(id, label, size, top_files, top_entities) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (cid, final_label, len(cnodes),
+                     json.dumps(top_files), json.dumps(top_entities)),
+                )
+
+            conn.commit()
+            result["community_labels"] = labels_out
+        finally:
+            conn.close()
+
+        # Rewrite graphify's graph.html to replace "Community N" with our labels
+        self._rewrite_visual_labels(labels_out)
+
+        return result
+
+    # Extra CSS injected into graphify's graph.html — tames the sidebar
+    # scrollbars (they default to the OS chrome which looks terrible embedded
+    # inside a dark-themed iframe) and tightens line-height.
+    _VISUAL_CSS_INJECT = """
+<style id="prism-visual-overrides">
+  ::-webkit-scrollbar { width: 6px; height: 6px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: #2a2a4e; border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: #4E79A7; }
+  ::-webkit-scrollbar-corner { background: transparent; }
+  * { scrollbar-color: #2a2a4e transparent; scrollbar-width: thin; }
+  #communities-list, #neighbors-list, #search-results {
+      scrollbar-width: thin !important;
+  }
+  .legend-item, #communities-list > div {
+      line-height: 1.35 !important;
+  }
+</style>"""
+
+    def _rewrite_visual_labels(self, labels: dict[int, str]) -> None:
+        """Patch graphify's generated graph.html in-place:
+          * replace "Community N" with humanized labels
+          * inject scrollbar + line-height CSS so the embed looks polished
+
+        Safe no-op if labels is empty or file is missing.
+        """
+        html_path = self._staging_dir / "graphify-out" / "graph.html"
+        if not html_path.exists():
+            return
+        try:
+            html = html_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+
+        changed = False
+
+        # 1) Label rewrites — sort by longest cid first so "Community 10"
+        #    doesn't get clobbered by the "Community 1" rule.
+        for cid in sorted(labels.keys(), key=lambda x: -len(str(x))):
+            lbl = labels[cid]
+            if not lbl:
+                continue
+            patterns = [
+                (f">Community {cid}<",
+                 f">{lbl} <span style=\"opacity:.5;font-size:10px\">#{cid}</span><"),
+                (f'"Community {cid}"', f'"{lbl} (#{cid})"'),
+                (f"'Community {cid}'", f"'{lbl} (#{cid})'"),
+                (f"Community {cid}</",
+                 f"{lbl} <span style=\"opacity:.5;font-size:10px\">#{cid}</span></"),
+            ]
+            for needle, repl in patterns:
+                if needle in html:
+                    html = html.replace(needle, repl)
+                    changed = True
+
+        # 2) Inject our style block once, right before </head>.
+        if 'id="prism-visual-overrides"' not in html:
+            if "</head>" in html:
+                html = html.replace(
+                    "</head>", self._VISUAL_CSS_INJECT + "\n</head>", 1
+                )
+                changed = True
+
+        if changed:
+            try:
+                html_path.write_text(html, encoding="utf-8")
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def clear_staging(self) -> None:
+        if self._staging_dir.exists():
+            try:
+                shutil.rmtree(self._staging_dir)
+            except OSError:
+                pass
+        self._staging_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _extract_line(source_location: str) -> Optional[int]:
+    """Parse 'L42' or 'L42-L50' to int 42; return None on failure."""
+    if not source_location:
+        return None
+    try:
+        s = source_location.lstrip("L").split("-", 1)[0].lstrip("L")
+        return int(s)
+    except (ValueError, AttributeError):
+        return None

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -80,10 +80,22 @@ def _graph_schema_migrations(conn: sqlite3.Connection) -> None:
             "  label TEXT,"
             "  size INTEGER,"
             "  top_files TEXT,"       # JSON array
-            "  top_entities TEXT"     # JSON array
+            "  top_entities TEXT,"    # JSON array
+            "  summary TEXT"          # 1-2 sentence prose summary
             ")"
         )
         conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+    # Migrate existing DBs: add summary column if missing.
+    try:
+        cols = {row[1] for row in conn.execute(
+            "PRAGMA table_info(communities)"
+        ).fetchall()}
+        if "summary" not in cols:
+            conn.execute("ALTER TABLE communities ADD COLUMN summary TEXT")
+            conn.commit()
     except sqlite3.OperationalError:
         pass
 
@@ -225,6 +237,67 @@ def _derive_community_label(
         label = _humanize(hub) if hub else "misc"
 
     return label, top_files, top_entities
+
+
+def _derive_community_summary(
+    top_files: list[str],
+    top_entities: list[str],
+    brain_db_path: str | None,
+    max_chars: int = 280,
+) -> str:
+    """Return a short prose summary for a community.
+
+    Looks up the top entities in the Brain ``docs`` table and concatenates
+    the first line of each chunk (which includes any prepended docstring
+    from ``_chunk_python_treesitter``). Falls back to a structural summary
+    when Brain content is unavailable.
+    """
+    structural = ""
+    if top_files:
+        head = ", ".join(top_files[:2])
+        structural = f"Covers {head}."
+    if not brain_db_path or not top_entities:
+        if top_entities:
+            structural += " Hubs: " + ", ".join(top_entities[:3]) + "."
+        return structural[:max_chars].strip()
+
+    import sqlite3 as _sq
+    snippets: list[str] = []
+    try:
+        conn = _sq.connect(brain_db_path)
+        conn.row_factory = _sq.Row
+        try:
+            for ename in top_entities[:4]:
+                if not ename:
+                    continue
+                row = conn.execute(
+                    "SELECT content FROM docs WHERE entity_name = ? "
+                    "AND entity_kind IN ('function','class','method') "
+                    "LIMIT 1",
+                    (ename,),
+                ).fetchone()
+                if not row:
+                    continue
+                first = (row["content"] or "").strip().splitlines()
+                first = next((ln.strip() for ln in first if ln.strip()), "")
+                first = first.lstrip('"').lstrip("'").rstrip(".")[:80]
+                if first:
+                    snippets.append(f"{ename}: {first}")
+                if sum(len(s) for s in snippets) > max_chars:
+                    break
+        finally:
+            conn.close()
+    except Exception:
+        pass
+
+    body = ". ".join(snippets)
+    if structural and body:
+        out = f"{structural} {body}."
+    elif body:
+        out = body + "."
+    else:
+        out = structural or " ".join(top_entities[:3])
+    return out[:max_chars].strip()
 
 
 class GraphService:
@@ -467,13 +540,18 @@ class GraphService:
             result["error"] = f"graph.json parse failed: {e!r}"
             return result
 
-        return self._import_graph_json(data, result)
+        return self._import_graph_json(data, result, brain_db_path)
 
     # ------------------------------------------------------------------
     # graph.json -> graph.db import
     # ------------------------------------------------------------------
 
-    def _import_graph_json(self, data: dict, result: dict) -> dict:
+    def _import_graph_json(
+        self,
+        data: dict,
+        result: dict,
+        brain_db_path: str | None = None,
+    ) -> dict:
         nodes = data.get("nodes", [])
         links = data.get("links", [])
         result["nodes"] = len(nodes)
@@ -582,12 +660,16 @@ class GraphService:
                               or v.startswith(base + " ("))
                 final_label = base if n_taken == 0 else f"{base} ({n_taken + 1})"
                 labels_out[cid] = final_label
+                summary = _derive_community_summary(
+                    top_files, top_entities, brain_db_path,
+                )
                 conn.execute(
                     "INSERT OR REPLACE INTO communities "
-                    "(id, label, size, top_files, top_entities) "
-                    "VALUES (?, ?, ?, ?, ?)",
+                    "(id, label, size, top_files, top_entities, summary) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
                     (cid, final_label, len(cnodes),
-                     json.dumps(top_files), json.dumps(top_entities)),
+                     json.dumps(top_files), json.dumps(top_entities),
+                     summary),
                 )
 
             conn.commit()

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -262,6 +262,7 @@ def _derive_community_summary(
         return structural[:max_chars].strip()
 
     import sqlite3 as _sq
+    import re as _re
     snippets: list[str] = []
     try:
         conn = _sq.connect(brain_db_path)
@@ -270,11 +271,17 @@ def _derive_community_summary(
             for ename in top_entities[:4]:
                 if not ename:
                     continue
+                # Graphify entity labels can carry call syntax or punctuation
+                # (".execute()", "Brain._get", "_make_brain_in()"). Brain.db
+                # stores bare identifiers, so normalize before lookup.
+                clean = _re.sub(r"[()\s]", "", ename)
+                clean = clean.lstrip(".").split(".")[-1]
+                if not clean or clean.endswith(".py") or clean.endswith(".md"):
+                    continue
                 row = conn.execute(
                     "SELECT content FROM docs WHERE entity_name = ? "
-                    "AND entity_kind IN ('function','class','method') "
                     "LIMIT 1",
-                    (ename,),
+                    (clean,),
                 ).fetchone()
                 if not row:
                     continue
@@ -282,7 +289,7 @@ def _derive_community_summary(
                 first = next((ln.strip() for ln in first if ln.strip()), "")
                 first = first.lstrip('"').lstrip("'").rstrip(".")[:80]
                 if first:
-                    snippets.append(f"{ename}: {first}")
+                    snippets.append(f"{clean}: {first}")
                 if sum(len(s) for s in snippets) > max_chars:
                     break
         finally:

--- a/services/prism-service/app/ui/components/nav.py
+++ b/services/prism-service/app/ui/components/nav.py
@@ -28,8 +28,15 @@ def create_nav():
     # Force light background globally
     ui.add_head_html(f'<style>{_GLOBAL_CSS}</style>')
 
-    # Ensure a project is set in user storage
-    if 'project' not in app.storage.user:
+    # URL ?project= wins so deep-links render the right project on first paint
+    try:
+        from nicegui import context as _ctx
+        _qs_proj = _ctx.client.request.query_params.get('project')
+    except Exception:
+        _qs_proj = None
+    if _qs_proj:
+        app.storage.user['project'] = _qs_proj
+    elif 'project' not in app.storage.user:
         app.storage.user['project'] = 'default'
 
     current = app.storage.user['project']
@@ -51,6 +58,7 @@ def create_nav():
             for label, href in [
                 ('Dashboard', '/'),
                 ('Brain', '/brain'),
+                ('Graph', '/graph'),
                 ('Memory', '/memory'),
                 ('Tasks', '/tasks'),
                 ('Conductor', '/conductor'),
@@ -68,6 +76,13 @@ def _switch_project(project_id: str):
     ui.navigate.reload()
 
 
-def page_container():
-    """Wrap page content in a clean, readable container."""
+def page_container(wide: bool = False):
+    """Wrap page content in a clean, readable container.
+
+    Standard (default) caps at max-w-7xl (~1280px) for comfortable reading.
+    `wide=True` removes the cap so graph-dominated pages can breathe on
+    wide monitors.
+    """
+    if wide:
+        return ui.column().classes('w-full mx-auto px-6 py-4 gap-4')
     return ui.column().classes('w-full max-w-7xl mx-auto px-6 py-6 gap-6')

--- a/services/prism-service/app/ui/components/nav.py
+++ b/services/prism-service/app/ui/components/nav.py
@@ -63,6 +63,7 @@ def create_nav():
                 ('Tasks', '/tasks'),
                 ('Conductor', '/conductor'),
                 ('Sessions', '/sessions'),
+                ('Retrievals', '/retrievals'),
             ]:
                 ui.link(label, href).classes(
                     'text-white no-underline px-3 py-1 rounded '

--- a/services/prism-service/app/ui/dashboard.py
+++ b/services/prism-service/app/ui/dashboard.py
@@ -214,45 +214,288 @@ def _build_health(container, health):
 
 # -- Page registration ----------------------------------------------------
 
+def _build_pipeline_vertical(container, steps: list[dict]):
+    """Compact vertical variant of the pipeline for the dashboard sidebar."""
+    container.clear()
+    with container:
+        for step in steps:
+            status = step.get("status", "pending")
+            step_type = step.get("type", "agent")
+            agent = step.get("agent")
+
+            if status == "completed":
+                dot_color = "#10b981"
+                badge_cls = "bg-green-100 text-green-800"
+                badge = "Done"
+            elif status == "current":
+                dot_color = "#2563eb"
+                badge_cls = "bg-blue-100 text-blue-800"
+                badge = "Active"
+            elif step_type == "gate":
+                dot_color = "#d97706"
+                badge_cls = "bg-amber-100 text-amber-800"
+                badge = "Gate"
+            else:
+                dot_color = "#cbd5e1"
+                badge_cls = "bg-gray-100 text-gray-500"
+                badge = "Pending"
+
+            with ui.row().classes("w-full items-center gap-3 py-1.5"):
+                ui.html(
+                    f'<div style="width:10px;height:10px;border-radius:50%;'
+                    f'background:{dot_color};flex-shrink:0"></div>'
+                )
+                with ui.column().classes("flex-1 gap-0"):
+                    ui.label(_step_display_name(step["id"])).classes(
+                        "text-sm font-medium text-gray-900 leading-tight"
+                    )
+                    if agent:
+                        ui.label(_AGENT_LABELS.get(agent, agent.upper())).classes(
+                            "text-[10px] text-gray-400 uppercase tracking-wide"
+                        )
+                ui.html(
+                    f'<span class="text-[10px] font-medium px-2 py-0.5 '
+                    f'rounded-full {badge_cls}">{badge}</span>'
+                )
+
+
+def _build_kpi_grid(container, kpis: list[dict]):
+    """Render a 2-column small KPI grid."""
+    container.clear()
+    with container:
+        with ui.row().classes("w-full flex-wrap gap-2"):
+            for k in kpis:
+                with ui.card().classes(
+                    "flex-1 min-w-[130px] p-3 bg-white shadow-sm rounded-lg "
+                    "border border-gray-200"
+                ):
+                    ui.label(k["label"]).classes(
+                        "text-[10px] text-gray-500 uppercase tracking-wide"
+                    )
+                    ui.label(str(k["value"])).classes(
+                        "text-xl font-bold text-gray-900 leading-none mt-1"
+                    )
+                    if k.get("hint"):
+                        ui.label(k["hint"]).classes(
+                            "text-[10px] text-gray-400 mt-1"
+                        )
+
+
+def _collect_kpis(proj: str) -> list[dict]:
+    """Pull counts from brain/graph/memory/task DBs for the selected project."""
+    import sqlite3
+    from pathlib import Path as _P
+    root = _P(f"/data/projects/{proj}")
+
+    def _one(db: str, sql: str, default=0):
+        p = root / db
+        if not p.exists():
+            return default
+        try:
+            c = sqlite3.connect(str(p))
+            v = c.execute(sql).fetchone()
+            c.close()
+            return v[0] if v else default
+        except Exception:
+            return default
+
+    brain_docs   = _one("brain.db", "SELECT COUNT(*) FROM docs")
+    entities     = _one("graph.db", "SELECT COUNT(*) FROM entities")
+    rels         = _one("graph.db", "SELECT COUNT(*) FROM relationships")
+    communities  = _one("graph.db",
+                        "SELECT COUNT(DISTINCT community) FROM entities "
+                        "WHERE community IS NOT NULL")
+    memories     = _one("mulch.db", "SELECT COUNT(*) FROM expertise")
+    tasks_active = _one("tasks.db",
+                        "SELECT COUNT(*) FROM tasks "
+                        "WHERE status IN ('pending','in_progress')")
+
+    return [
+        {"label": "Brain docs",   "value": brain_docs},
+        {"label": "Entities",     "value": entities},
+        {"label": "Relationships","value": rels},
+        {"label": "Communities",  "value": communities},
+        {"label": "Memories",     "value": memories},
+        {"label": "Open tasks",   "value": tasks_active},
+    ]
+
+
 @ui.page("/")
 def dashboard_page():
-    """Main PRISM dashboard."""
+    """Main PRISM dashboard — graph-centric layout."""
     create_nav()
 
-    with page_container():
-        # -- Pipeline section --
-        ui.label("Workflow Pipeline").classes("text-lg font-semibold text-gray-900")
-        pipeline_container = ui.row().classes("w-full overflow-x-auto")
+    # Resolve active project (URL param > session > default)
+    from nicegui import context as _ctx
+    _qs_proj = None
+    try:
+        _qs_proj = _ctx.client.request.query_params.get('project')
+    except Exception:
+        pass
+    _proj = _qs_proj or app.storage.user.get('project', 'default')
+    if _qs_proj:
+        app.storage.user['project'] = _qs_proj
+    from pathlib import Path as _Path
+    _html = _Path(f"/data/projects/{_proj}/graphify-src/graphify-out/graph.html")
 
-        # -- Metrics section --
-        ui.label("Metrics").classes("text-lg font-semibold text-gray-900")
-        metrics_container = ui.row().classes("w-full flex-wrap gap-4")
+    with page_container(wide=True):
 
-        # -- Governance health section --
-        with ui.card().classes(
-            "w-full bg-white shadow-sm rounded-lg p-5"
-        ) as health_wrapper:
-            ui.label("Governance Health").classes(
-                "text-lg font-semibold text-gray-900 mb-3"
-            )
-            health_container = ui.column().classes("w-full gap-1")
+        # --- Search bar -------------------------------------------------
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-3"):
+            with ui.row().classes("w-full items-center gap-3"):
+                search_input = ui.input(
+                    placeholder="Search concepts in this project (brain_search)…"
+                ).props("outlined dense clearable").classes("flex-grow")
+                search_btn = ui.button("Search", icon="search").props(
+                    "color=primary no-caps"
+                )
+        search_results = ui.column().classes("w-full gap-2")
+
+        async def do_search():
+            query = (search_input.value or "").strip()
+            search_results.clear()
+            if not query:
+                return
+            from app.project_context import get_project
+            svc = get_project(_proj).brain_svc
+            try:
+                results = svc.search(query, limit=8)
+            except Exception as e:
+                with search_results:
+                    ui.label(f"error: {e}").classes("text-sm text-red-600")
+                return
+            with search_results:
+                if not results:
+                    ui.label("no matches").classes("text-sm text-gray-500")
+                    return
+                for r in results:
+                    did = (r.get("doc_id") or "").removesuffix("::main")
+                    score = r.get("rrf_score", r.get("score", 0)) or 0
+                    snippet = (r.get("content") or "")[:220].replace("\n", " ")
+                    with ui.card().classes(
+                        "w-full bg-gray-50 rounded-lg p-3 "
+                        "border-l-4 border-blue-400"
+                    ):
+                        with ui.row().classes("items-center justify-between w-full"):
+                            ui.label(did).classes(
+                                "text-sm font-mono text-gray-800"
+                            )
+                            ui.label(f"{float(score):.3f}").classes(
+                                "text-xs text-gray-500"
+                            )
+                        if snippet:
+                            ui.label(snippet).classes(
+                                "text-xs text-gray-600 mt-1"
+                            )
+
+        search_btn.on("click", do_search)
+        search_input.on("keydown.enter", do_search)
+
+        # --- Main two-column layout -------------------------------------
+        with ui.row().classes("w-full gap-4 items-stretch flex-nowrap"):
+
+            # LEFT: the graph takes ~3/4 of the width
+            with ui.column().classes("gap-2").style("flex: 3 1 0; min-width: 0;"):
+                with ui.card().classes(
+                    "w-full bg-white shadow-sm rounded-lg p-3 flex-grow"
+                ).style("min-height: calc(100vh - 220px);"):
+                    with ui.row().classes(
+                        "w-full items-center justify-between mb-2"
+                    ):
+                        ui.label("Code Graph").classes(
+                            "text-lg font-semibold text-gray-900"
+                        )
+                        with ui.row().classes("gap-3 items-center"):
+                            ui.link("Full page →", f"/graph?project={_proj}").classes(
+                                "text-sm text-indigo-600 hover:underline"
+                            )
+                            if _html.exists():
+                                ui.link(
+                                    "Open visual ↗",
+                                    f"/graphify-visual/{_proj}/graph.html",
+                                    new_tab=True,
+                                ).classes("text-sm text-indigo-600 hover:underline")
+                    if _html.exists():
+                        ui.element("iframe").props(
+                            f'src="/graphify-visual/{_proj}/graph.html"'
+                        ).style(
+                            # Header (~56px) + search (~70px) + padding = ~260px.
+                            # Floor at 600px on short viewports so sidebar still
+                            # has room to scroll.
+                            "width: 100%; "
+                            "height: max(600px, calc(100vh - 260px)); "
+                            "border: 0; border-radius: 6px; "
+                            "background: #0f0f1a; display: block;"
+                        )
+                    else:
+                        with ui.column().classes(
+                            "w-full h-64 items-center justify-center "
+                            "bg-gray-50 rounded-lg border border-dashed border-gray-300"
+                        ):
+                            ui.icon("hub", size="xl").classes("text-gray-300")
+                            ui.label(
+                                "No graph yet for this project — "
+                                "go to Graph → Rebuild."
+                            ).classes("text-sm text-gray-400 mt-1")
+
+            # RIGHT column: KPIs + pipeline + governance
+            with ui.column().classes("gap-3").style("flex: 1 1 0; min-width: 260px;"):
+
+                # KPIs
+                ui.label("Metrics").classes(
+                    "text-sm font-semibold text-gray-700 uppercase tracking-wide"
+                )
+                kpi_container = ui.column().classes("w-full gap-2")
+
+                # Pipeline
+                with ui.card().classes(
+                    "w-full bg-white shadow-sm rounded-lg p-4"
+                ):
+                    with ui.row().classes(
+                        "w-full items-center justify-between mb-2"
+                    ):
+                        ui.label("Workflow").classes(
+                            "text-sm font-semibold text-gray-700 "
+                            "uppercase tracking-wide"
+                        )
+                        workflow_status_badge = ui.html("")
+                    pipeline_container = ui.column().classes("w-full gap-0")
+
+                # Governance
+                with ui.card().classes(
+                    "w-full bg-white shadow-sm rounded-lg p-4"
+                ):
+                    ui.label("Governance").classes(
+                        "text-sm font-semibold text-gray-700 "
+                        "uppercase tracking-wide mb-2"
+                    )
+                    health_container = ui.column().classes("w-full gap-1")
 
     # -- Refresh logic -----------------------------------------------------
-
     def refresh():
         from app.project_context import get_project
-        _ctx = get_project(app.storage.user.get('project', 'default'))
-        workflow_svc = _ctx.workflow_svc
-        governance = _ctx.governance
+        current_proj = app.storage.user.get('project', 'default')
+        _ctx = get_project(current_proj)
 
-        steps = workflow_svc.get_steps()
-        state = workflow_svc.get_state()
-        health = governance.get_health_report()
+        steps = _ctx.workflow_svc.get_steps()
+        state = _ctx.workflow_svc.get_state()
+        health = _ctx.governance.get_health_report()
 
-        _build_pipeline(pipeline_container, steps)
-        _build_metrics(metrics_container, state)
+        _build_pipeline_vertical(pipeline_container, steps)
         _build_health(health_container, health)
+        _build_kpi_grid(kpi_container, _collect_kpis(current_proj))
 
-    # Initial render + 2-second auto-refresh
+        # Update workflow status badge
+        if state and state.active:
+            workflow_status_badge.content = (
+                '<span class="text-[10px] font-medium px-2 py-0.5 '
+                'rounded-full bg-blue-100 text-blue-800">in progress</span>'
+            )
+        else:
+            workflow_status_badge.content = (
+                '<span class="text-[10px] font-medium px-2 py-0.5 '
+                'rounded-full bg-gray-100 text-gray-500">idle</span>'
+            )
+
     refresh()
-    ui.timer(2.0, refresh)
+    ui.timer(3.0, refresh)

--- a/services/prism-service/app/ui/graph_page.py
+++ b/services/prism-service/app/ui/graph_page.py
@@ -1,0 +1,351 @@
+"""Graph page — visualise graphify-populated entities and relationships."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from collections import Counter
+
+from fastapi import HTTPException
+from fastapi.responses import FileResponse
+from nicegui import app, ui
+
+from app.project_context import get_project
+from app.ui.components.nav import create_nav, page_container
+
+
+_SAFE_PROJECT_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+_ALLOWED_VISUAL_FILES = {"graph.html", "GRAPH_REPORT.md"}
+
+
+@app.get("/graphify-visual/{project_id}/{filename}")
+def _graphify_visual(project_id: str, filename: str):
+    """Serve graphify's graph.html (or GRAPH_REPORT.md) for the given project.
+    Project slug is strictly validated to prevent path traversal."""
+    if not _SAFE_PROJECT_RE.match(project_id or ""):
+        raise HTTPException(status_code=400, detail="invalid project id")
+    if filename not in _ALLOWED_VISUAL_FILES:
+        raise HTTPException(status_code=404, detail="not found")
+    ctx = get_project(project_id)
+    path = ctx._data_dir / "graphify-src" / "graphify-out" / filename
+    if not path.exists() or not path.is_file():
+        raise HTTPException(status_code=404, detail="graph.html not generated yet")
+    media = "text/html" if filename.endswith(".html") else "text/markdown"
+    return FileResponse(str(path), media_type=media)
+
+
+def _project_id() -> str:
+    return app.storage.user.get("project", "default")
+
+
+def _graph_conn() -> sqlite3.Connection:
+    ctx = get_project(_project_id())
+    conn = sqlite3.connect(str(ctx._data_dir / "graph.db"))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _summary() -> dict:
+    conn = _graph_conn()
+    try:
+        entities = conn.execute("SELECT COUNT(*) FROM entities").fetchone()[0]
+        rels = conn.execute("SELECT COUNT(*) FROM relationships").fetchone()[0]
+        communities = 0
+        by_kind: Counter = Counter()
+        by_community: list[tuple[int, int, str]] = []  # (id, size, label)
+        has_graphify = False
+        try:
+            communities = conn.execute(
+                "SELECT COUNT(DISTINCT community) FROM entities "
+                "WHERE community IS NOT NULL"
+            ).fetchone()[0]
+            for r in conn.execute(
+                "SELECT kind, COUNT(*) AS n FROM entities GROUP BY kind"
+            ):
+                by_kind[r["kind"] or "unknown"] = r["n"]
+            # Join community labels where available
+            try:
+                rows = conn.execute(
+                    "SELECT e.community AS cid, COUNT(*) AS n, c.label AS label "
+                    "FROM entities e "
+                    "LEFT JOIN communities c ON c.id = e.community "
+                    "WHERE e.community IS NOT NULL "
+                    "GROUP BY e.community "
+                    "ORDER BY n DESC LIMIT 16"
+                ).fetchall()
+            except sqlite3.OperationalError:
+                rows = conn.execute(
+                    "SELECT community AS cid, COUNT(*) AS n, NULL AS label "
+                    "FROM entities WHERE community IS NOT NULL "
+                    "GROUP BY community ORDER BY n DESC LIMIT 16"
+                ).fetchall()
+            for r in rows:
+                by_community.append(
+                    (int(r["cid"]), int(r["n"]), r["label"] or f"community {r['cid']}")
+                )
+            has_graphify = bool(conn.execute(
+                "SELECT 1 FROM entities WHERE graphify_id IS NOT NULL LIMIT 1"
+            ).fetchone())
+        except sqlite3.OperationalError:
+            pass
+    finally:
+        conn.close()
+    return {
+        "entities": entities, "relationships": rels,
+        "communities": communities, "by_kind": dict(by_kind),
+        "by_community": by_community, "has_graphify": has_graphify,
+    }
+
+
+def _entities_rows(community: int | None, kind: str | None, limit: int = 200) -> list[dict]:
+    conn = _graph_conn()
+    try:
+        where = []
+        args: list = []
+        if community is not None:
+            where.append("community = ?"); args.append(community)
+        if kind:
+            where.append("kind = ?"); args.append(kind)
+        sql = "SELECT name, kind, community, file, source_location, file_type FROM entities"
+        if where:
+            sql += " WHERE " + " AND ".join(where)
+        sql += " ORDER BY community, name LIMIT ?"
+        args.append(limit)
+        try:
+            rows = [dict(r) for r in conn.execute(sql, args).fetchall()]
+        except sqlite3.OperationalError:
+            rows = [dict(r) for r in conn.execute(
+                "SELECT name, kind, file FROM entities LIMIT ?", (limit,)
+            ).fetchall()]
+    finally:
+        conn.close()
+    return rows
+
+
+def _relationships_rows(min_confidence: float = 0.0, limit: int = 200) -> list[dict]:
+    conn = _graph_conn()
+    try:
+        try:
+            rows = [dict(r) for r in conn.execute(
+                "SELECT r.relation, r.confidence, r.confidence_score, r.weight, "
+                "       e1.name AS source, e2.name AS target "
+                "FROM relationships r "
+                "JOIN entities e1 ON r.source_id = e1.id "
+                "JOIN entities e2 ON r.target_id = e2.id "
+                "WHERE COALESCE(r.confidence_score, 1.0) >= ? "
+                "ORDER BY r.confidence_score DESC, e1.name "
+                "LIMIT ?", (min_confidence, limit)
+            ).fetchall()]
+        except sqlite3.OperationalError:
+            rows = [dict(r) for r in conn.execute(
+                "SELECT r.relation, e1.name AS source, e2.name AS target "
+                "FROM relationships r "
+                "JOIN entities e1 ON r.source_id = e1.id "
+                "JOIN entities e2 ON r.target_id = e2.id LIMIT ?", (limit,)
+            ).fetchall()]
+    finally:
+        conn.close()
+    return rows
+
+
+@ui.page("/graph")
+def graph_page():
+    create_nav()
+
+    with page_container():
+        ui.label("Graph — Code Knowledge Graph").classes(
+            "text-2xl font-semibold text-gray-900"
+        )
+        ui.label(
+            "Populated by graphify (tree-sitter AST pass + Leiden community "
+            "detection). Trigger a rebuild with the button below after "
+            "bulk-ingesting source files via brain_index_doc."
+        ).classes("text-sm text-gray-600")
+
+        summary = _summary()
+
+        # --- Interactive visual (graphify's graph.html) ---
+        ctx = get_project(_project_id())
+        html_path = ctx._data_dir / "graphify-src" / "graphify-out" / "graph.html"
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-3"):
+            with ui.row().classes("w-full items-center justify-between"):
+                ui.label("Interactive visual").classes(
+                    "text-sm font-medium text-gray-700"
+                )
+                if html_path.exists():
+                    ui.link(
+                        "Open in new tab",
+                        f"/graphify-visual/{_project_id()}/graph.html",
+                        new_tab=True,
+                    ).classes("text-sm text-indigo-600 hover:underline")
+            if html_path.exists():
+                ui.element("iframe").props(
+                    f'src="/graphify-visual/{_project_id()}/graph.html"'
+                ).style(
+                    "width: 100%; height: 600px; border: 0; "
+                    "border-radius: 6px; background: #0f0f1a; display: block;"
+                )
+            else:
+                with ui.column().classes(
+                    "w-full h-40 items-center justify-center "
+                    "bg-gray-50 rounded-lg border border-dashed border-gray-300"
+                ):
+                    ui.icon("hub", size="xl").classes("text-gray-300")
+                    ui.label("No graph.html yet — click Rebuild below.").classes(
+                        "text-sm text-gray-400 mt-1"
+                    )
+
+        # --- Summary stats ---
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+            with ui.row().classes("gap-8 flex-wrap items-start"):
+                for label, val in [
+                    ("Entities", summary["entities"]),
+                    ("Relationships", summary["relationships"]),
+                    ("Communities", summary["communities"]),
+                ]:
+                    with ui.column().classes("items-center gap-1"):
+                        ui.label(str(val)).classes("text-3xl font-bold text-gray-900")
+                        ui.label(label).classes(
+                            "text-xs text-gray-500 uppercase tracking-wide"
+                        )
+                with ui.column().classes("items-center gap-1"):
+                    if summary["has_graphify"]:
+                        ui.html('<span class="text-xs font-medium px-2.5 py-1 rounded-full '
+                                'bg-green-100 text-green-800">graphify active</span>')
+                    else:
+                        ui.html('<span class="text-xs font-medium px-2.5 py-1 rounded-full '
+                                'bg-yellow-100 text-yellow-800">tree-sitter legacy</span>')
+                    ui.label("Source").classes(
+                        "text-xs text-gray-500 uppercase tracking-wide"
+                    )
+
+            ui.separator().classes("my-4")
+
+            async def do_rebuild():
+                rebuild_btn.disable()
+                ui.notify("Running graphify update…", type="info")
+                try:
+                    ctx = get_project(_project_id())
+                    r = ctx.graph_svc.rebuild()
+                    if r.get("error"):
+                        ui.notify(f"Rebuild: {r['error'][:200]}", type="warning")
+                    else:
+                        ui.notify(
+                            f"Rebuilt: {r.get('nodes',0)} nodes, "
+                            f"{r.get('edges',0)} edges, "
+                            f"{r.get('communities',0)} communities",
+                            type="positive",
+                        )
+                    ui.navigate.reload()
+                except Exception as exc:
+                    ui.notify(f"Rebuild failed: {exc}", type="negative")
+                finally:
+                    rebuild_btn.enable()
+
+            rebuild_btn = ui.button("Rebuild graph (graphify)", icon="hub").props(
+                "color=primary no-caps"
+            )
+            rebuild_btn.on("click", do_rebuild)
+
+        # --- Kind distribution ---
+        if summary["by_kind"]:
+            with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+                ui.label("Nodes by kind").classes(
+                    "text-sm font-medium text-gray-700 mb-2"
+                )
+                with ui.row().classes("gap-2 flex-wrap"):
+                    for k, n in sorted(summary["by_kind"].items(),
+                                        key=lambda x: -x[1]):
+                        ui.html(
+                            f'<span class="text-xs font-medium px-2.5 py-1 rounded-full '
+                            f'bg-indigo-50 text-indigo-700">{k}: {n}</span>'
+                        )
+
+        # --- Community distribution ---
+        if summary["by_community"]:
+            with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+                ui.label("Communities (labeled by dominant content)").classes(
+                    "text-sm font-medium text-gray-700 mb-2"
+                )
+                with ui.row().classes("gap-2 flex-wrap"):
+                    for cid, n, label in summary["by_community"]:
+                        ui.html(
+                            f'<span class="text-xs font-medium px-2.5 py-1 '
+                            f'rounded-full bg-emerald-50 text-emerald-700" '
+                            f'title="community id: {cid}">{label} — {n}</span>'
+                        )
+
+        # --- Entities table ---
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+            ui.label("Entities").classes(
+                "text-lg font-semibold text-gray-900 mb-2"
+            )
+            ent_rows = _entities_rows(community=None, kind=None, limit=300)
+            # Decorate rows with community label
+            labels_map: dict[int, str] = {}
+            conn = _graph_conn()
+            try:
+                try:
+                    for r in conn.execute("SELECT id, label FROM communities"):
+                        labels_map[int(r["id"])] = r["label"] or ""
+                except sqlite3.OperationalError:
+                    pass
+            finally:
+                conn.close()
+            for row in ent_rows:
+                cid = row.get("community")
+                if cid is not None and cid in labels_map:
+                    row["community_label"] = f"{labels_map[cid]} (#{cid})"
+                elif cid is not None:
+                    row["community_label"] = f"community {cid}"
+                else:
+                    row["community_label"] = ""
+
+            ent_cols = [
+                {"name": "name", "label": "Name", "field": "name", "sortable": True},
+                {"name": "kind", "label": "Kind", "field": "kind", "sortable": True,
+                 "style": "width: 100px"},
+                {"name": "community_label", "label": "Cluster",
+                 "field": "community_label", "sortable": True,
+                 "style": "width: 200px"},
+                {"name": "file_type", "label": "Type", "field": "file_type",
+                 "sortable": True, "style": "width: 90px"},
+                {"name": "source_location", "label": "Loc", "field": "source_location",
+                 "style": "width: 90px"},
+                {"name": "file", "label": "File", "field": "file"},
+            ]
+            if ent_rows:
+                t = ui.table(columns=ent_cols, rows=ent_rows, row_key="name",
+                             pagination={"rowsPerPage": 15}).classes("w-full")
+                t.props("flat dense separator=horizontal")
+            else:
+                ui.label("No entities yet — call graph_rebuild or ingest source "
+                         "files first.").classes("text-sm text-gray-400")
+
+        # --- Relationships table ---
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+            ui.label("Relationships").classes(
+                "text-lg font-semibold text-gray-900 mb-2"
+            )
+            rel_rows = _relationships_rows(min_confidence=0.0, limit=300)
+            rel_cols = [
+                {"name": "source", "label": "Source", "field": "source",
+                 "sortable": True},
+                {"name": "relation", "label": "Relation", "field": "relation",
+                 "sortable": True, "style": "width: 120px"},
+                {"name": "target", "label": "Target", "field": "target",
+                 "sortable": True},
+                {"name": "confidence", "label": "Confidence", "field": "confidence",
+                 "sortable": True, "style": "width: 110px"},
+                {"name": "confidence_score", "label": "Score",
+                 "field": "confidence_score", "sortable": True,
+                 "style": "width: 80px"},
+                {"name": "weight", "label": "Weight", "field": "weight",
+                 "sortable": True, "style": "width: 80px"},
+            ]
+            if rel_rows:
+                t = ui.table(columns=rel_cols, rows=rel_rows,
+                             pagination={"rowsPerPage": 15}).classes("w-full")
+                t.props("flat dense separator=horizontal")
+            else:
+                ui.label("No relationships yet.").classes("text-sm text-gray-400")

--- a/services/prism-service/app/ui/graph_page.py
+++ b/services/prism-service/app/ui/graph_page.py
@@ -52,7 +52,7 @@ def _summary() -> dict:
         rels = conn.execute("SELECT COUNT(*) FROM relationships").fetchone()[0]
         communities = 0
         by_kind: Counter = Counter()
-        by_community: list[tuple[int, int, str]] = []  # (id, size, label)
+        by_community: list[tuple[int, int, str, str]] = []  # (id, size, label, summary)
         has_graphify = False
         try:
             communities = conn.execute(
@@ -63,10 +63,11 @@ def _summary() -> dict:
                 "SELECT kind, COUNT(*) AS n FROM entities GROUP BY kind"
             ):
                 by_kind[r["kind"] or "unknown"] = r["n"]
-            # Join community labels where available
+            # Join community labels + summaries where available
             try:
                 rows = conn.execute(
-                    "SELECT e.community AS cid, COUNT(*) AS n, c.label AS label "
+                    "SELECT e.community AS cid, COUNT(*) AS n, "
+                    "c.label AS label, c.summary AS summary "
                     "FROM entities e "
                     "LEFT JOIN communities c ON c.id = e.community "
                     "WHERE e.community IS NOT NULL "
@@ -75,13 +76,20 @@ def _summary() -> dict:
                 ).fetchall()
             except sqlite3.OperationalError:
                 rows = conn.execute(
-                    "SELECT community AS cid, COUNT(*) AS n, NULL AS label "
+                    "SELECT community AS cid, COUNT(*) AS n, "
+                    "NULL AS label, NULL AS summary "
                     "FROM entities WHERE community IS NOT NULL "
                     "GROUP BY community ORDER BY n DESC LIMIT 16"
                 ).fetchall()
             for r in rows:
+                label = r["label"] or f"community {r['cid']}"
+                summary = ""
+                try:
+                    summary = r["summary"] or ""
+                except (IndexError, KeyError):
+                    pass
                 by_community.append(
-                    (int(r["cid"]), int(r["n"]), r["label"] or f"community {r['cid']}")
+                    (int(r["cid"]), int(r["n"]), label, summary)
                 )
             has_graphify = bool(conn.execute(
                 "SELECT 1 FROM entities WHERE graphify_id IS NOT NULL LIMIT 1"
@@ -226,7 +234,9 @@ def graph_page():
                 ui.notify("Running graphify update…", type="info")
                 try:
                     ctx = get_project(_project_id())
-                    r = ctx.graph_svc.rebuild()
+                    r = ctx.graph_svc.rebuild(
+                        brain_db_path=str(ctx._data_dir / "brain.db")
+                    )
                     if r.get("error"):
                         ui.notify(f"Rebuild: {r['error'][:200]}", type="warning")
                     else:
@@ -268,11 +278,17 @@ def graph_page():
                     "text-sm font-medium text-gray-700 mb-2"
                 )
                 with ui.row().classes("gap-2 flex-wrap"):
-                    for cid, n, label in summary["by_community"]:
+                    for cid, n, label, summ in summary["by_community"]:
+                        # Hover shows the prose summary; escape quotes so it
+                        # stays inside the HTML title attribute cleanly.
+                        title_text = (
+                            summ.replace('"', "&quot;") if summ else
+                            f"community id: {cid}"
+                        )
                         ui.html(
                             f'<span class="text-xs font-medium px-2.5 py-1 '
                             f'rounded-full bg-emerald-50 text-emerald-700" '
-                            f'title="community id: {cid}">{label} — {n}</span>'
+                            f'title="{title_text}">{label} — {n}</span>'
                         )
 
         # --- Entities table ---

--- a/services/prism-service/app/ui/retrievals_page.py
+++ b/services/prism-service/app/ui/retrievals_page.py
@@ -97,6 +97,9 @@ def _build_table(container, rows: list[dict]) -> None:
              "align": "right"},
             {"name": "top", "label": "Top hit", "field": "top",
              "align": "left"},
+            {"name": "up", "label": "👍", "field": "up", "align": "right"},
+            {"name": "down", "label": "👎", "field": "down",
+             "align": "right"},
         ]
         data = []
         for r in rows:
@@ -107,6 +110,8 @@ def _build_table(container, rows: list[dict]) -> None:
                     top_hit = parsed[0].get("doc_id") or "-"
             except Exception:
                 pass
+            up = int(r.get("up_count") or 0)
+            down = int(r.get("down_count") or 0)
             data.append({
                 "id": r.get("id"),
                 "ts": _fmt_ts(r.get("ts") or ""),
@@ -115,6 +120,8 @@ def _build_table(container, rows: list[dict]) -> None:
                 "n": r.get("n_results", 0),
                 "lat": f"{r.get('latency_ms', 0)} ms",
                 "top": top_hit[:80] if top_hit else "-",
+                "up": str(up) if up else "",
+                "down": str(down) if down else "",
             })
         ui.table(columns=columns, rows=data, row_key="id").classes("w-full")
 
@@ -131,14 +138,74 @@ def retrievals_page():
         )
         summary_box = ui.column().classes("w-full")
         with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+            ui.label("Rate the latest search").classes(
+                "text-lg font-semibold text-gray-900 mb-2"
+            )
+            rate_box = ui.column().classes("w-full")
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
             ui.label("Recent searches").classes(
                 "text-lg font-semibold text-gray-900 mb-4"
             )
             table_box = ui.column().classes("w-full")
 
+    def record(search_id: int, doc_id: str, signal: str):
+        """Feedback callback wired to the 👍/👎 buttons."""
+        fb = _brain_svc().record_search_feedback(
+            search_id=search_id, doc_id=doc_id, signal=signal,
+        )
+        if fb:
+            ui.notify(f"Recorded {signal} on {doc_id[:40]}", type="positive")
+        else:
+            ui.notify("Failed to record feedback", type="warning")
+        refresh()
+
+    def _build_rater(container, rows: list[dict]) -> None:
+        container.clear()
+        with container:
+            if not rows:
+                ui.label("No searches to rate yet.").classes(
+                    "text-sm text-gray-500"
+                )
+                return
+            latest = rows[0]
+            sid = int(latest.get("id") or 0)
+            try:
+                parsed = json.loads(latest.get("final_top") or "[]")
+            except Exception:
+                parsed = []
+            ui.label(
+                f"Search #{sid} · {_fmt_ts(latest.get('ts') or '')} · "
+                f"{(latest.get('query') or '')[:100]}"
+            ).classes("text-sm text-gray-600 mb-2")
+            if not parsed:
+                ui.label("(empty result set — nothing to rate)").classes(
+                    "text-sm text-gray-400"
+                )
+                return
+            for i, hit in enumerate(parsed[:5]):
+                did = hit.get("doc_id") or "?"
+                with ui.row().classes("items-center gap-2 w-full"):
+                    ui.label(f"#{i+1}").classes(
+                        "text-xs text-gray-400 w-8"
+                    )
+                    ui.label(did[:90]).classes(
+                        "text-sm text-gray-800 flex-1"
+                    )
+                    ui.button(
+                        "👍",
+                        on_click=lambda _=None, s=sid, d=did:
+                            record(s, d, "up"),
+                    ).props("flat dense").classes("text-sm")
+                    ui.button(
+                        "👎",
+                        on_click=lambda _=None, s=sid, d=did:
+                            record(s, d, "down"),
+                    ).props("flat dense").classes("text-sm")
+
     def refresh():
         rows = _brain_svc().recent_searches(limit=100)
         _build_summary(summary_box, rows)
+        _build_rater(rate_box, rows)
         _build_table(table_box, rows)
 
     refresh()

--- a/services/prism-service/app/ui/retrievals_page.py
+++ b/services/prism-service/app/ui/retrievals_page.py
@@ -1,0 +1,145 @@
+"""Retrievals observability page — recent searches with per-query details.
+
+Lets you answer: why did retrieval miss (or hit) on a given query, which
+stack flags were in effect, and how long did it take. Data comes from
+the ``searches`` table populated by ``Brain.search`` on every call.
+"""
+
+import json
+
+from nicegui import ui, app
+
+from app.project_context import get_project
+from app.ui.components.nav import create_nav, page_container
+
+
+def _brain_svc():
+    return get_project(app.storage.user.get("project", "default")).brain_svc
+
+
+def _fmt_ts(ts: str) -> str:
+    if not ts:
+        return "-"
+    return ts[:19].replace("T", " ")
+
+
+def _flags(row: dict) -> str:
+    bits = []
+    bits.append("prefix" if row.get("context_prefix") else "no-prefix")
+    bits.append("agg" if row.get("chunk_agg") else "no-agg")
+    rr = row.get("rerank") or "off"
+    if rr != "off":
+        bits.append(f"rerank={rr}")
+    mode = row.get("mode") or "hybrid"
+    if mode != "hybrid":
+        bits.append(f"mode={mode}")
+    return " · ".join(bits)
+
+
+def _build_summary(container, rows: list[dict]) -> None:
+    container.clear()
+    with container:
+        n = len(rows)
+        lats = [r.get("latency_ms", 0) or 0 for r in rows]
+        lats = [x for x in lats if x]
+        avg = sum(lats) / len(lats) if lats else 0
+        p95 = sorted(lats)[int(len(lats) * 0.95)] if len(lats) >= 20 else (
+            max(lats) if lats else 0
+        )
+        empty = sum(1 for r in rows if (r.get("n_results") or 0) == 0)
+        cards = [
+            ("Searches", str(n), "search", "#4f46e5"),
+            ("Avg latency", f"{avg:.0f} ms", "timer", "#0d9488"),
+            ("p95 latency", f"{p95} ms", "speed", "#7c3aed"),
+            ("Empty result", f"{empty}", "inbox", "#dc2626"),
+        ]
+        with ui.row().classes("w-full gap-5 flex-wrap"):
+            for title, value, icon, color in cards:
+                with ui.card().classes(
+                    "flex-1 min-w-[180px] bg-white shadow-sm rounded-lg p-5"
+                ):
+                    with ui.row().classes("items-center gap-2 mb-3"):
+                        ui.icon(icon, color=color).classes("text-2xl")
+                        ui.label(title).classes(
+                            "text-xs text-gray-500 uppercase tracking-wide"
+                            " font-medium"
+                        )
+                    ui.label(value).classes(
+                        "text-2xl font-bold text-gray-900"
+                    )
+
+
+def _build_table(container, rows: list[dict]) -> None:
+    container.clear()
+    with container:
+        if not rows:
+            with ui.card().classes(
+                "w-full bg-white shadow-sm rounded-lg p-8 text-center"
+            ):
+                ui.icon("search_off", color="gray").classes(
+                    "text-4xl mb-3"
+                )
+                ui.label("No searches recorded yet").classes(
+                    "text-base font-medium text-gray-500"
+                )
+                ui.label(
+                    "Any brain_search MCP call will appear here."
+                ).classes("text-sm text-gray-400 mt-2")
+            return
+        columns = [
+            {"name": "ts", "label": "When", "field": "ts", "align": "left"},
+            {"name": "query", "label": "Query", "field": "query",
+             "align": "left"},
+            {"name": "flags", "label": "Flags", "field": "flags",
+             "align": "left"},
+            {"name": "n", "label": "N", "field": "n", "align": "right"},
+            {"name": "lat", "label": "Latency", "field": "lat",
+             "align": "right"},
+            {"name": "top", "label": "Top hit", "field": "top",
+             "align": "left"},
+        ]
+        data = []
+        for r in rows:
+            top_hit = "-"
+            try:
+                parsed = json.loads(r.get("final_top") or "[]")
+                if parsed:
+                    top_hit = parsed[0].get("doc_id") or "-"
+            except Exception:
+                pass
+            data.append({
+                "id": r.get("id"),
+                "ts": _fmt_ts(r.get("ts") or ""),
+                "query": (r.get("query") or "")[:80],
+                "flags": _flags(r),
+                "n": r.get("n_results", 0),
+                "lat": f"{r.get('latency_ms', 0)} ms",
+                "top": top_hit[:80] if top_hit else "-",
+            })
+        ui.table(columns=columns, rows=data, row_key="id").classes("w-full")
+
+
+@ui.page("/retrievals")
+def retrievals_page():
+    """Recent brain_search events with per-query details."""
+    ui.colors(primary="#4f46e5")
+    create_nav()
+
+    with page_container():
+        ui.label("Retrievals").classes(
+            "text-2xl font-semibold text-gray-900"
+        )
+        summary_box = ui.column().classes("w-full")
+        with ui.card().classes("w-full bg-white shadow-sm rounded-lg p-5"):
+            ui.label("Recent searches").classes(
+                "text-lg font-semibold text-gray-900 mb-4"
+            )
+            table_box = ui.column().classes("w-full")
+
+    def refresh():
+        rows = _brain_svc().recent_searches(limit=100)
+        _build_summary(summary_box, rows)
+        _build_table(table_box, rows)
+
+    refresh()
+    ui.timer(5.0, refresh)

--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       # Default 0.002 so ~3 consistent thumbs overcome a typical RRF gap.
       # Set to "off" to disable feedback-driven re-ranking entirely.
       - PRISM_FEEDBACK_WEIGHT=${PRISM_FEEDBACK_WEIGHT:-0.002}
+      # Drift auto-reindex interval (seconds). 0 disables the loop.
+      - PRISM_DRIFT_INTERVAL=${PRISM_DRIFT_INTERVAL:-1800}
       # Keep torch/HF caches on the mounted volume so bad loads can't brick Docker
       - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache
       - TORCH_HOME=/data/torch-home

--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -8,4 +8,13 @@ services:
       - ./data:/data
     environment:
       - PRISM_DATA_DIR=/data
+      # MiniLM is the +11pt LongMemEval default (vs potion baseline).
+      # Override per project if needed: potion | minilm | bge-small | jina-code
+      - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}
+      # hybrid (default) | vector | bm25 — which search indices contribute
+      - PRISM_SEARCH_MODE=${PRISM_SEARCH_MODE:-hybrid}
+      # Keep torch/HF caches on the mounted volume so bad loads can't brick Docker
+      - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache
+      - TORCH_HOME=/data/torch-home
+      - HF_HOME=/data/hf-home
     restart: unless-stopped

--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}
       # hybrid (default) | vector | bm25 — which search indices contribute
       - PRISM_SEARCH_MODE=${PRISM_SEARCH_MODE:-hybrid}
+      # Cross-encoder reranker: off (default) | bge-v2 | jina-v2 | ms-marco-minilm
+      - PRISM_RERANK=${PRISM_RERANK:-off}
+      - PRISM_RERANK_TOPN=${PRISM_RERANK_TOPN:-50}
+      # Contextual chunk prefixing (Anthropic-style): on (default) | off
+      - PRISM_CONTEXT_PREFIX=${PRISM_CONTEXT_PREFIX:-on}
       # Keep torch/HF caches on the mounted volume so bad loads can't brick Docker
       - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache
       - TORCH_HOME=/data/torch-home

--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       - PRISM_RERANK_TOPN=${PRISM_RERANK_TOPN:-50}
       # Contextual chunk prefixing (Anthropic-style): on (default) | off
       - PRISM_CONTEXT_PREFIX=${PRISM_CONTEXT_PREFIX:-on}
+      # Feedback consumption weight: per-thumb adjustment to rrf_score.
+      # Default 0.002 so ~3 consistent thumbs overcome a typical RRF gap.
+      # Set to "off" to disable feedback-driven re-ranking entirely.
+      - PRISM_FEEDBACK_WEIGHT=${PRISM_FEEDBACK_WEIGHT:-0.002}
       # Keep torch/HF caches on the mounted volume so bad loads can't brick Docker
       - TORCHINDUCTOR_CACHE_DIR=/data/torch-inductor-cache
       - TORCH_HOME=/data/torch-home

--- a/services/prism-service/requirements.txt
+++ b/services/prism-service/requirements.txt
@@ -1,4 +1,21 @@
+# Install torch from the CPU-only wheels index to avoid CUDA bloat
+--extra-index-url https://download.pytorch.org/whl/cpu
+
 nicegui>=2.0
 mcp>=1.0
 uvicorn
 plotly
+
+# Vector search (fully local, no API / tokens required)
+model2vec>=0.3
+sqlite-vec>=0.1
+numpy
+tokenizers
+
+# Pluggable neural embedders (selected via PRISM_EMBEDDER env var)
+torch>=2.2,<3
+sentence-transformers>=2.7
+
+# Code knowledge graph (tree-sitter AST + Leiden clustering + edge confidence).
+# We use graphify's `update` subcommand which is LLM-free and local-only.
+graphifyy>=0.1

--- a/services/prism-service/requirements.txt
+++ b/services/prism-service/requirements.txt
@@ -19,3 +19,8 @@ sentence-transformers>=2.7
 # Code knowledge graph (tree-sitter AST + Leiden clustering + edge confidence).
 # We use graphify's `update` subcommand which is LLM-free and local-only.
 graphifyy>=0.1
+
+# AST chunking for Python / TypeScript / JavaScript / C# / Go etc.
+# Without these the chunker falls back to regex which loses structural info.
+tree-sitter>=0.21,<1
+tree-sitter-languages>=1.10


### PR DESCRIPTION
## Summary

- **Retrieval stack upgrades**: multi-granular chunking, contextual prefix (proven +0.30 R@1 on SWE-bench), cross-encoder reranker wired + disproved (kept opt-in), community prose summaries, source_file + rerank_score + feedback_adj exposed on every result.
- **Feedback loop closed end-to-end**: `searches` + `search_feedback` tables, `/retrievals` UI with thumbs, `brain_search_feedback` MCP tool, PostToolUse hook that correlates Read/Edit with prior searches and auto-emits thumbs-up, and `Brain.search` consuming the accumulated signal to re-rank future queries.
- **Semantic code navigation**: four new MCP tools — `brain_find_symbol`, `brain_outline`, `brain_find_references`, `brain_call_chain`. Claude can query a function-level chunk (~40 lines, contextual-prefixed) instead of Read-ing a 2500-line file. ~20× token reduction on code exploration.
- **Multi-language chunker**: Python, TypeScript, JavaScript, C# all chunk via tree-sitter with parent-class context and method-level doc_ids. Nested methods are first-class chunks. Regex fallback kept for tree-sitter-unavailable installs.
- **Ops**: drift auto-reindex timer (with guard so it never wipes an unmounted-project index), chunk-suffix regression pytest, install manifest extended to ship both the sync hook and the feedback hook.
- **Research-driven decisions**: reranker disproved by direct SWE-bench A/B; LSP integration parked after 2026 research consensus showed it's IDE-shaped and hurts autonomous-agent retrieval.

## Validated numbers

| Bench | Before | After |
|---|---|---|
| LongMemEval 50Q smoke R@5 | 0.524 (potion) / 0.800 (minilm) | **0.940** |
| SWE-bench Lite n=10 R@10 | ~0.45 (potion) / ~0.80 (minilm+graphify) | **0.900** |
| SWE-bench Lite n=10 R@1 | — | **0.600** |

Attribution A/Bs recorded in `benchmarks/EXPERIMENTS.md`:
- Contextual prefix: +0.30 R@1 (load-bearing on code)
- bge-reranker-v2-m3: **–0.20 R@1** (disproved; kept opt-in only)

## What's new by area

- `services/prism-service/app/engines/brain_engine.py` — multi-granular chunker, contextual prefix, reranker, observability schema, feedback consumption, semantic accessors, multi-language tree-sitter, drift purge guard.
- `services/prism-service/app/services/brain_service.py` — thin pass-throughs for every new accessor.
- `services/prism-service/app/services/graph_service.py` — community prose summaries.
- `services/prism-service/app/mcp/tools.py` — new MCP tools: `brain_search_feedback`, `brain_find_symbol`, `brain_outline`, `brain_find_references`, `brain_call_chain`. Install manifest extended to serve both hooks.
- `services/prism-service/app/ui/retrievals_page.py` (new) — `/retrievals` page with summary cards, rater panel, feedback-augmented table.
- `services/prism-service/app/assets/feedback_signal_hook.py` (new) — canonical hook body served by `prism_install`.
- `plugins/prism-devtools/hooks/feedback_signal_hook.py` (new) — plugin-side copy of the hook; wired in `hooks.json` under PostToolUse.
- `benchmarks/EXPERIMENTS.md` — six new log entries with deltas + decisions.
- `benchmarks/tests/test_chunk_suffix_strip.py` (new) — regression pytest for the bench-matcher chunk-suffix bug.
- `benchmarks/longmemeval/run.py`, `benchmarks/swebench/run.py` — fixed stale `::main`-only matcher.

## Known follow-ups (still queued in PRISM tasks)

- HyDE / query decomposition — candidate-gen work targeting the LongMemEval 0.94 smoke ceiling. Deferred pending full-500Q evidence.
- Scale SWE-bench to n=30 — overnight run, removes the n=10 statistical caveat.
- PathRAG — parked; its context-reduction value mostly overlaps with what semantic accessors already deliver.
- LSP integration — parked with research evidence (memory `lsp-is-wrong-tool-for-agents-2026`).

## Test plan

- [ ] Build `services/prism-service` Docker image and confirm tree-sitter-languages loads for Python / c_sharp / typescript / javascript
- [ ] `brain_index_doc` a Python file with class methods → `brain_find_symbol("method_name", kind="method")` returns the method chunk
- [ ] Same for a C# file (method_declaration inside namespaced class) and a TS file (method_definition inside class)
- [ ] Call `brain_search` → result dicts carry `search_id`, `source_file`, `rerank_score`, `feedback_adj`
- [ ] Exercise the PostToolUse feedback hook: `brain_search` then `Read` a returned `source_file` → row lands in `search_feedback`, next `brain_search` shows `feedback_adj` on the re-ranked result
- [ ] `prism_install` returns three files (hooks.json + prism-sync.py + prism-feedback-signal.py)
- [ ] Hit `/retrievals` UI → 200, table populates from real searches
- [ ] Run `benchmarks/tests/test_chunk_suffix_strip.py` → 2 tests pass in <1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)