### PR TITLE
brain: prism_install ships Stop/SubagentStop/Skill recorders

### DIFF
--- a/services/prism-service/app/assets/skill_usage_hook.py
+++ b/services/prism-service/app/assets/skill_usage_hook.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""PRISM PostToolUse hook — records skill invocations via MCP.
+
+Fires after any tool call. If the tool is Skill, records the skill name
+against the current session via record_skill_usage. All other tools are
+ignored (cheap no-op). Always exits 0; never blocks Claude Code.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+def _project_root() -> Path:
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return cur
+
+
+def _mcp_url_and_project(root: Path) -> Optional[tuple[str, str]]:
+    cfg = root / ".mcp.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for s in (data.get("mcpServers") or {}).values():
+        url = s.get("url", "")
+        if "/mcp" in url and "project=" in url:
+            base, q = url.split("?", 1)
+            project = [p.split("=", 1)[1] for p in q.split("&")
+                       if p.startswith("project=")][0]
+            return base.rstrip("/"), project
+    return None
+
+
+def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
+    url = f"{base}/?project={project}"
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": tool, "arguments": args},
+    }).encode()
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=4).read()
+    except Exception:
+        pass
+
+
+def main() -> int:
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        return 0
+    if (data.get("tool_name") or "") != "Skill":
+        return 0
+    session_id = data.get("session_id") or ""
+    if not session_id:
+        return 0
+    skill_name = ((data.get("tool_input") or {}).get("skill")
+                  or (data.get("tool_input") or {}).get("name") or "")
+    if not skill_name:
+        return 0
+    root = _project_root()
+    conn = _mcp_url_and_project(root)
+    if conn is None:
+        return 0
+    base, project = conn
+    _mcp_call(base, project, "record_skill_usage", {
+        "session_id": session_id,
+        "skill_name": skill_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/services/prism-service/app/assets/stop_record_hook.py
+++ b/services/prism-service/app/assets/stop_record_hook.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""PRISM Stop hook — records session outcome via MCP.
+
+Fires when Claude Code finishes a response. Parses the session
+transcript for duration/tokens/files/skills metrics and upserts one
+session_outcomes row on the PRISM service via record_session_outcome.
+
+Thin MCP-only implementation — no plugin, no local DB, no workflow
+logic. Reads .mcp.json for the MCP endpoint. Always exits 0; never
+blocks Claude Code.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+_READ_TOOLS = {"Read", "Glob", "Grep"}
+_WRITE_TOOLS = {"Edit", "Write", "NotebookEdit"}
+
+
+def _project_root() -> Path:
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return cur
+
+
+def _mcp_url_and_project(root: Path) -> Optional[tuple[str, str]]:
+    cfg = root / ".mcp.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for s in (data.get("mcpServers") or {}).values():
+        url = s.get("url", "")
+        if "/mcp" in url and "project=" in url:
+            base, q = url.split("?", 1)
+            project = [p.split("=", 1)[1] for p in q.split("&")
+                       if p.startswith("project=")][0]
+            return base.rstrip("/"), project
+    return None
+
+
+def _mcp_call(base: str, project: str, tool: str, args: dict,
+              timeout: float = 4.0) -> None:
+    url = f"{base}/?project={project}"
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": tool, "arguments": args},
+    }).encode()
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=timeout).read()
+    except Exception:
+        pass
+
+
+def _parse_transcript(transcript_path: str) -> dict:
+    """Walk the jsonl transcript once; return aggregated metrics."""
+    empty = {"files_read": 0, "files_modified": 0, "skills_invoked": 0,
+             "duration_s": 0, "tokens_used": 0}
+    if not transcript_path:
+        return empty
+    tp = Path(transcript_path).expanduser()
+    if not tp.exists():
+        return empty
+
+    files_read = files_modified = skills_invoked = total_tokens = 0
+    first_ts: Optional[datetime] = None
+    last_ts: Optional[datetime] = None
+    try:
+        with tp.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                usage = entry.get("usage")
+                if not usage and isinstance(entry.get("message"), dict):
+                    usage = entry["message"].get("usage")
+                if isinstance(usage, dict):
+                    total_tokens += int(usage.get("input_tokens") or 0)
+                    total_tokens += int(usage.get("output_tokens") or 0)
+                ts_str = entry.get("timestamp") or entry.get("ts")
+                if isinstance(ts_str, str):
+                    try:
+                        ts_dt = datetime.fromisoformat(ts_str.rstrip("Z"))
+                        if first_ts is None:
+                            first_ts = ts_dt
+                        last_ts = ts_dt
+                    except ValueError:
+                        pass
+                msg = entry.get("message", entry)
+                content = msg.get("content", []) if isinstance(msg, dict) else []
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "tool_use":
+                        continue
+                    name = block.get("name", "")
+                    if name in _READ_TOOLS:
+                        files_read += 1
+                    elif name in _WRITE_TOOLS:
+                        files_modified += 1
+                    elif name == "Skill":
+                        skills_invoked += 1
+    except (OSError, IOError):
+        return empty
+
+    duration_s = 0
+    if first_ts and last_ts:
+        duration_s = max(0, int((last_ts - first_ts).total_seconds()))
+    return {"files_read": files_read, "files_modified": files_modified,
+            "skills_invoked": skills_invoked, "duration_s": duration_s,
+            "tokens_used": total_tokens}
+
+
+def main() -> int:
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        return 0
+    session_id = data.get("session_id") or ""
+    if not session_id:
+        return 0
+    root = _project_root()
+    conn = _mcp_url_and_project(root)
+    if conn is None:
+        return 0
+    base, project = conn
+    metrics = _parse_transcript(data.get("transcript_path", ""))
+    _mcp_call(base, project, "record_session_outcome", {
+        "session_id": session_id,
+        "duration_s": metrics["duration_s"],
+        "tokens_used": metrics["tokens_used"],
+        "files_read": metrics["files_read"],
+        "files_modified": metrics["files_modified"],
+        "skills_invoked": metrics["skills_invoked"],
+    })
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/services/prism-service/app/assets/subagent_record_hook.py
+++ b/services/prism-service/app/assets/subagent_record_hook.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""PRISM SubagentStop hook — thin MCP-only outcome recorder.
+
+Fires when a sub-agent finishes. Records a row in the subagent_outcomes
+table via record_subagent_outcome. Does NOT enforce SFR certificate
+sections — that logic lives in the workflow-aware plugin recorder.
+
+Captures: validator name, parsed recommendation (APPROVE/REVISE/PASS/
+FAIL), evidence count (file:line citations in last message), tokens,
+duration.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+
+def _project_root() -> Path:
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return cur
+
+
+def _mcp_url_and_project(root: Path) -> Optional[tuple[str, str]]:
+    cfg = root / ".mcp.json"
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for s in (data.get("mcpServers") or {}).values():
+        url = s.get("url", "")
+        if "/mcp" in url and "project=" in url:
+            base, q = url.split("?", 1)
+            project = [p.split("=", 1)[1] for p in q.split("&")
+                       if p.startswith("project=")][0]
+            return base.rstrip("/"), project
+    return None
+
+
+def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
+    url = f"{base}/?project={project}"
+    payload = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": tool, "arguments": args},
+    }).encode()
+    req = urllib.request.Request(
+        url, data=payload,
+        headers={"Content-Type": "application/json",
+                 "Accept": "application/json, text/event-stream"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=4).read()
+    except Exception:
+        pass
+
+
+def _parse_recommendation(text: str) -> str:
+    m = re.search(r"\b(APPROVE|REVISE|PASS|FAIL)\b", text or "", re.IGNORECASE)
+    return m.group(1).upper() if m else ""
+
+
+def _count_evidence(text: str) -> int:
+    return len(re.findall(r"[\w./\\-]+:\d+", text or ""))
+
+
+def main() -> int:
+    try:
+        data = json.loads(sys.stdin.read() or "{}")
+    except Exception:
+        return 0
+    agent_name = data.get("agent_name") or data.get("subagent_type") or ""
+    if not agent_name:
+        return 0
+    last_message = data.get("last_assistant_message") or ""
+    tokens_used = int(data.get("tokens_used") or 0)
+    duration_s = float(data.get("duration_s") or 0.0)
+
+    root = _project_root()
+    conn = _mcp_url_and_project(root)
+    if conn is None:
+        return 0
+    base, project = conn
+
+    prompt_id = data.get("prompt_id") or f"{agent_name}/default"
+    _mcp_call(base, project, "record_subagent_outcome", {
+        "prompt_id": prompt_id,
+        "validator": agent_name,
+        "recommendation": _parse_recommendation(last_message) or "COMPLETED",
+        "evidence_count": _count_evidence(last_message),
+        "certificate_complete": 0,
+        "certificate_blocked": 0,
+        "timed_out": 0,
+        "tokens_used": tokens_used,
+        "duration_s": duration_s,
+    })
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -1249,6 +1249,9 @@ def _load_asset(filename: str) -> str:
 
 
 _FEEDBACK_HOOK_SCRIPT = _load_asset("feedback_signal_hook.py")
+_STOP_HOOK_SCRIPT = _load_asset("stop_record_hook.py")
+_SUBAGENT_HOOK_SCRIPT = _load_asset("subagent_record_hook.py")
+_SKILL_HOOK_SCRIPT = _load_asset("skill_usage_hook.py")
 
 
 def _install_manifest(project_id: str) -> dict:
@@ -1279,6 +1282,49 @@ def _install_manifest(project_id: str) -> dict:
                     },
                 ],
             },
+            {
+                "matcher": "Skill",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python .claude/hooks/prism-skill-usage.py",
+                        "description": (
+                            "Record skill invocations to scores.db via "
+                            "record_skill_usage — populates /skills."
+                        ),
+                    },
+                ],
+            },
+        ],
+        "Stop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python .claude/hooks/prism-stop.py",
+                        "description": (
+                            "Record session-level metrics (duration, "
+                            "tokens, files, skills) via "
+                            "record_session_outcome — populates /sessions."
+                        ),
+                    },
+                ],
+            },
+        ],
+        "SubagentStop": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python .claude/hooks/prism-subagent.py",
+                        "description": (
+                            "Record sub-agent outcome (recommendation, "
+                            "evidence count, timing) via "
+                            "record_subagent_outcome."
+                        ),
+                    },
+                ],
+            },
         ],
     }
     return {
@@ -1288,20 +1334,22 @@ def _install_manifest(project_id: str) -> dict:
         "instructions_for_agent": [
             "Use the Write tool to create each entry in install_files.",
             "If .claude/hooks.json already exists, MERGE each top-level "
-            "array (SessionStart, PostToolUse) by appending — do not "
-            "overwrite the whole file.",
+            "array (SessionStart, PostToolUse, Stop, SubagentStop) by "
+            "appending — do not overwrite the whole file.",
             "After writing, tell the user: 'Restart Claude so the new "
             "PRISM hooks activate.'",
-            "The SessionStart hook auto-syncs Brain/Graph. The PostToolUse "
-            "hook correlates brain_search results with Read/Edit and "
-            "emits implicit feedback via brain_search_feedback — no manual "
-            "thumbs-ups needed.",
+            "SessionStart syncs Brain/Graph drift. PostToolUse covers two "
+            "things: implicit retrieval feedback (brain_search → Read/Edit) "
+            "and skill-usage recording. Stop records session outcomes "
+            "(populates /sessions). SubagentStop records sub-agent outcomes.",
         ],
         "install_files": [
             {
                 "path": ".claude/hooks.json",
                 "action": "create_or_merge",
-                "merge_keys": ["SessionStart", "PostToolUse"],
+                "merge_keys": [
+                    "SessionStart", "PostToolUse", "Stop", "SubagentStop",
+                ],
                 "content": json.dumps(hooks_json, indent=2),
             },
             {
@@ -1316,12 +1364,32 @@ def _install_manifest(project_id: str) -> dict:
                 "content": _FEEDBACK_HOOK_SCRIPT,
                 "mode": "0755",
             },
+            {
+                "path": ".claude/hooks/prism-stop.py",
+                "action": "create",
+                "content": _STOP_HOOK_SCRIPT,
+                "mode": "0755",
+            },
+            {
+                "path": ".claude/hooks/prism-subagent.py",
+                "action": "create",
+                "content": _SUBAGENT_HOOK_SCRIPT,
+                "mode": "0755",
+            },
+            {
+                "path": ".claude/hooks/prism-skill-usage.py",
+                "action": "create",
+                "content": _SKILL_HOOK_SCRIPT,
+                "mode": "0755",
+            },
         ],
         "verification_steps": [
             "After Claude restart, re-invoke any tool and confirm no errors.",
             "Call prism_status with no args — expect stale: false.",
             "Edit any indexed source file, restart Claude, check the hook "
             "logs for '[prism-sync] refreshed 1 drifted file(s)'.",
+            "Finish a Claude response, reload /sessions — expect a new row "
+            "for the session_id just recorded.",
         ],
     }
 


### PR DESCRIPTION
## Summary

Pure-MCP clients (no plugin installed) were hitting an empty `/sessions` page because the install manifest returned by `prism_install` only covered SessionStart drift-sync and retrieval feedback. The MCP tools `record_session_outcome`, `record_subagent_outcome`, `record_skill_usage` existed but nothing called them.

This PR extends the self-describing install so the manifest includes three more thin hooks:

- `stop_record_hook.py` — Stop hook. Parses session transcript for duration/tokens/files/skills, calls `record_session_outcome`. Populates `/sessions`.
- `subagent_record_hook.py` — SubagentStop hook. Records recommendation (APPROVE/REVISE/PASS/FAIL), evidence count, timing via `record_subagent_outcome`. No SFR block logic — that stays in the workflow-aware plugin recorder.
- `skill_usage_hook.py` — PostToolUse(Skill) hook. Calls `record_skill_usage`.

Each hook is ~80–150 lines, reads `.mcp.json` for the endpoint, silent on failure, always exits 0.

`_install_manifest` in `app/mcp/tools.py` now emits:
- Five hook files under `.claude/hooks/` (existing two plus the three new ones)
- `.claude/hooks.json` with SessionStart + PostToolUse (two matchers) + Stop + SubagentStop blocks

## Why this wasn't on the `feat/multi-granular-chunking` PR

#17 was already broad (bulk refresh, WebGL viewer, hook-write migration, C# denoise). Kept this on a separate branch for review focus.

## Related issue

Diagnosed during a session where `/sessions` stayed empty after the MCP-routed hook migration. Smoke-tested locally: after staging the hooks in `.claude/hooks/` and merging `.claude/hooks.json`, a manual Stop-event simulation inserted a new `session_outcomes` row via MCP.

## Test plan

- [ ] Call `prism_install` on a fresh project — manifest returns 6 install_files (hooks.json + 5 hook scripts).
- [ ] Apply manifest, restart Claude, finish a response — new row in `session_outcomes`.
- [ ] Invoke a Skill in the session — new row in `skill_usage`.
- [ ] Spawn a sub-agent — new row in `subagent_outcomes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)