### PR TITLE
LL-09: MCP-response augmentation — reflection-pending nudge middleware (stacked on LL-06)

### DIFF
--- a/services/prism-service/app/assets/stop_record_hook.py
+++ b/services/prism-service/app/assets/stop_record_hook.py
@@ -5,9 +5,9 @@ Fires when Claude Code finishes a response. Parses the session
 transcript for duration/tokens/files/skills metrics and upserts one
 session_outcomes row on the PRISM service via record_session_outcome.
 
-Thin MCP-only implementation — no plugin, no local DB, no workflow
-logic. Reads .mcp.json for the MCP endpoint. Always exits 0; never
-blocks Claude Code.
+Thin MCP-only recorder — no local DB, no workflow logic. Reads
+.mcp.json for the MCP endpoint. Always exits 0; never blocks Claude
+Code.
 """
 
 from __future__ import annotations

--- a/services/prism-service/app/assets/subagent_record_hook.py
+++ b/services/prism-service/app/assets/subagent_record_hook.py
@@ -3,7 +3,8 @@
 
 Fires when a sub-agent finishes. Records a row in the subagent_outcomes
 table via record_subagent_outcome. Does NOT enforce SFR certificate
-sections — that logic lives in the workflow-aware plugin recorder.
+sections — that logic lives in the workflow-aware recorder shipped
+by prism-devtools.
 
 Captures: validator name, parsed recommendation (APPROVE/REVISE/PASS/
 FAIL), evidence count (file:line citations in last message), tokens,

--- a/services/prism-service/app/config.py
+++ b/services/prism-service/app/config.py
@@ -28,6 +28,13 @@ DRIFT_INTERVAL_SECONDS = int(
     os.environ.get("PRISM_DRIFT_INTERVAL", "1800"),  # 30 min default
 )
 
+# Quality timer (LL-04) — how often to score merged tasks against git
+# truth. 6h default so the 14d durability window has time to accumulate
+# revert/churn/follow-up signals. 0 disables.
+QUALITY_INTERVAL_SECONDS = int(
+    os.environ.get("PRISM_QUALITY_INTERVAL", "21600"),  # 6h default
+)
+
 # Shelf-life defaults per domain (days)
 DOMAIN_SHELF_LIFE: dict[str, int] = {
     "default": 30,

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -32,6 +32,37 @@ class BrainCorruptError(Exception):
     """Raised when a Brain database file fails SQLite integrity check."""
 
 
+def encode_task_text(text: str) -> Optional[bytes]:
+    """Encode arbitrary text via the loaded MiniLM embedder and return
+    packed float32 bytes suitable for storing in a SQLite BLOB column.
+
+    Reused by TaskService (LL-03) so the learning loop's task-similarity
+    retrieval lives on the same vectors Brain uses for document search.
+    Returns ``None`` when no embedder is loaded — callers must handle
+    the offline case gracefully. First 2048 chars only (model ctx cap).
+    """
+    global _MODEL
+    if _MODEL is None:
+        return None
+    try:
+        import numpy as _np
+        vec = _MODEL.encode([text[:2048]])[0]
+        return _np.asarray(vec, dtype=_np.float32).tobytes()
+    except Exception:
+        return None
+
+
+def decode_task_embedding(blob: Optional[bytes]) -> Optional[list[float]]:
+    """Reverse of :func:`encode_task_text` — packed bytes → list[float]."""
+    if not blob:
+        return None
+    try:
+        import numpy as _np
+        return _np.frombuffer(blob, dtype=_np.float32).tolist()
+    except Exception:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Optional dependency detection
 # ---------------------------------------------------------------------------

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -63,6 +63,48 @@ def decode_task_embedding(blob: Optional[bytes]) -> Optional[list[float]]:
         return None
 
 
+def _similar_task_ids(
+    tasks_conn: sqlite3.Connection,
+    query_task_id: str,
+    k: int = 20,
+) -> list[tuple[str, float]]:
+    """Return the top-k task_ids by cosine similarity to ``query_task_id``.
+
+    Excludes the query task itself. Returns ``[(task_id, cosine), ...]``
+    sorted by cosine descending. Tasks without an embedding (or with a
+    mismatched-dim embedding) are skipped.
+    """
+    import math
+    row = tasks_conn.execute(
+        "SELECT embedding FROM tasks WHERE id=?", (query_task_id,)
+    ).fetchone()
+    if row is None:
+        return []
+    q_blob = row[0] if not hasattr(row, "keys") else row["embedding"]
+    q_vec = decode_task_embedding(q_blob)
+    if not q_vec:
+        return []
+    q_norm = math.sqrt(sum(x * x for x in q_vec)) or 1.0
+
+    out: list[tuple[str, float]] = []
+    for r in tasks_conn.execute(
+        "SELECT id, embedding FROM tasks "
+        "WHERE id != ? AND embedding IS NOT NULL",
+        (query_task_id,),
+    ).fetchall():
+        tid = r[0] if not hasattr(r, "keys") else r["id"]
+        blob = r[1] if not hasattr(r, "keys") else r["embedding"]
+        v = decode_task_embedding(blob)
+        if not v or len(v) != len(q_vec):
+            continue
+        dot = sum(a * b for a, b in zip(q_vec, v))
+        n = math.sqrt(sum(x * x for x in v)) or 1.0
+        sim = dot / (q_norm * n)
+        out.append((tid, sim))
+    out.sort(key=lambda t: t[1], reverse=True)
+    return out[:k]
+
+
 # ---------------------------------------------------------------------------
 # Optional dependency detection
 # ---------------------------------------------------------------------------
@@ -488,10 +530,17 @@ class Brain:
         brain_db: str = "/data/brain.db",
         graph_db: str = "/data/graph.db",
         scores_db: str = "/data/scores.db",
+        tasks_db: Optional[str] = None,
     ) -> None:
         self._brain_db_path = brain_db
         self._graph_db_path = graph_db
         self._scores_db_path = scores_db
+        # Optional read-only handle to the project's tasks.db. Used by
+        # LL-06's best_prompt(similar_to_task_id=...) to pull the
+        # embedding BLOB and compute cosine similarity across tasks.
+        # Falls back to global score_aggregates when not configured.
+        self._tasks_db_path: Optional[str] = tasks_db
+        self._tasks: Optional[sqlite3.Connection] = None
         self._current_step_id: Optional[str] = None
         self.last_result_count: int = 0
 
@@ -501,6 +550,11 @@ class Brain:
         self._brain = self._connect(brain_db)
         self._graph = self._connect(graph_db)
         self._scores = self._connect(scores_db)
+        if tasks_db is not None:
+            try:
+                self._tasks = self._connect(tasks_db)
+            except sqlite3.DatabaseError:
+                self._tasks = None
 
         for label, db in (
             (brain_db, self._brain),
@@ -3093,17 +3147,40 @@ class Brain:
     # Prompt management
     # ------------------------------------------------------------------
 
+    # LL-06: sample-threshold for per-variant observation count on the
+    # similar-task path. Below 5 observations, a variant's average is
+    # too noisy to influence ranking.
+    _SIMILAR_TASK_K = 20
+    _VARIANT_SAMPLE_THRESHOLD = 5
+    # Cosine-similarity floor for a neighbor to count at all. Below
+    # this, the task is "not actually similar" and including it would
+    # let cross-cluster noise dominate when both clusters are in the
+    # top-k (the weighted mean normalizes the weight factor out).
+    _MIN_SIMILARITY = 0.3
+
     def best_prompt(
         self,
         persona: str,
         step_id: str,
         difficulty: Optional[str] = None,
+        similar_to_task_id: Optional[str] = None,
     ) -> str:
         """Return highest-scoring prompt variant ID for persona/step.
 
-        When difficulty is provided, prefers variants that have performed
-        well on runs of that difficulty level, falling back to overall best.
+        When ``similar_to_task_id`` is provided and the LL-06 similarity
+        path has enough data, rank variants by their CUPED-adjusted
+        quality on the top-20 most similar past tasks (by cosine on
+        task embeddings). Otherwise falls through to the historical
+        difficulty / score_aggregates path.
         """
+        # LL-06 similar-task path
+        if similar_to_task_id and self._tasks is not None:
+            pick = self._best_prompt_by_similar_task(
+                persona, step_id, similar_to_task_id,
+            )
+            if pick is not None:
+                return pick
+
         if difficulty:
             row = self._scores.execute(
                 "SELECT prompt_id, AVG(score) AS avg_score, COUNT(*) AS cnt "
@@ -3123,6 +3200,67 @@ class Brain:
             (persona, step_id),
         ).fetchone()
         return row["prompt_id"] if row else f"{persona}/default"
+
+    def _best_prompt_by_similar_task(
+        self,
+        persona: str,
+        step_id: str,
+        task_id: str,
+    ) -> Optional[str]:
+        """LL-06 core — rank variants by CUPED-weighted quality on the
+        top-k cosine-similar past tasks. Returns None when no variant
+        has crossed the sample threshold (caller falls back)."""
+        neighbors = _similar_task_ids(
+            self._tasks, task_id, k=self._SIMILAR_TASK_K,
+        )
+        # Drop neighbors below the similarity floor so cross-cluster
+        # tasks with high quality don't dominate via the weighted mean.
+        neighbors = [
+            (tid, sim) for tid, sim in neighbors
+            if sim >= self._MIN_SIMILARITY
+        ]
+        if not neighbors:
+            return None
+        sim_map = {tid: sim for tid, sim in neighbors}
+        placeholders = ",".join("?" * len(sim_map))
+        # Join task_variants × task_quality_rollup on the similar-task
+        # set. Prefer cuped_score; fall back to quality_score when
+        # CUPED hasn't been computed yet.
+        rows = self._scores.execute(
+            f"SELECT tv.task_id, tv.prompt_id, "
+            f"       COALESCE(qr.cuped_score, qr.quality_score) AS score "
+            f"FROM task_variants tv "
+            f"JOIN task_quality_rollup qr ON qr.task_id = tv.task_id "
+            f"WHERE tv.persona=? AND tv.step_id=? "
+            f"  AND tv.task_id IN ({placeholders})",
+            (persona, step_id, *sim_map.keys()),
+        ).fetchall()
+        if not rows:
+            return None
+
+        # Weighted average per prompt_id.
+        agg: dict[str, dict[str, float]] = {}
+        for r in rows:
+            w = max(0.0, float(sim_map.get(r["task_id"], 0.0)))
+            entry = agg.setdefault(
+                r["prompt_id"], {"weighted": 0.0, "weight": 0.0, "n": 0}
+            )
+            score = float(r["score"] or 0.0)
+            entry["weighted"] += score * w
+            entry["weight"] += w
+            entry["n"] += 1
+
+        # Sample-threshold gate: a variant with fewer than
+        # VARIANT_SAMPLE_THRESHOLD observations across similar tasks
+        # is correlational noise, not signal. Filter them out.
+        eligible = {
+            pid: (e["weighted"] / e["weight"]) if e["weight"] > 0 else 0.0
+            for pid, e in agg.items()
+            if e["n"] >= self._VARIANT_SAMPLE_THRESHOLD
+        }
+        if not eligible:
+            return None
+        return max(eligible.items(), key=lambda kv: kv[1])[0]
 
     def get_prompt(self, persona: str, variant: str = "default") -> str:
         """Return prompt variant text from scores.db or shipped prompts."""

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -717,6 +717,117 @@ class Brain:
                 duration_s REAL DEFAULT 0.0,
                 timestamp TEXT DEFAULT (datetime('now'))
             );
+
+            -- ---- Learning-loop v5 tables (LL-01) ----------------------------
+            -- Ties Claude sessions to PRISM tasks so per-task rollup joins
+            -- through the full session history. Schema-only; populated by
+            -- later LL-04 / LL-07 subtasks.
+            CREATE TABLE IF NOT EXISTS task_sessions (
+                task_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                started_at TEXT,
+                ended_at TEXT,
+                PRIMARY KEY (task_id, session_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_task_sessions_session_id
+                ON task_sessions(session_id);
+            CREATE INDEX IF NOT EXISTS idx_task_sessions_task_id
+                ON task_sessions(task_id);
+
+            -- Which prompt variant was used for which (task, step). Feeds
+            -- Brain.best_prompt(similar_to_task_id=...) in LL-06.
+            CREATE TABLE IF NOT EXISTS task_variants (
+                task_id TEXT NOT NULL,
+                step_id TEXT NOT NULL,
+                prompt_id TEXT NOT NULL,
+                persona TEXT,
+                recorded_at TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (task_id, step_id, prompt_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_task_variants_task_id
+                ON task_variants(task_id);
+            CREATE INDEX IF NOT EXISTS idx_task_variants_prompt_id
+                ON task_variants(prompt_id);
+
+            -- Quantitative + qualitative rollup per task (one row per merged
+            -- task). `quality_score` is the Layer-A composite, `cuped_score`
+            -- is the operator-baseline-adjusted value, `qualitative_score`
+            -- is the Layer-B reflection overlay, `components_json` stores
+            -- the raw signals for auditability.
+            CREATE TABLE IF NOT EXISTS task_quality_rollup (
+                task_id TEXT PRIMARY KEY,
+                quality_score REAL,
+                qualitative_score REAL,
+                cuped_score REAL,
+                components_json TEXT,
+                scored_at TEXT DEFAULT (datetime('now'))
+            );
+
+            -- Per-operator rolling merge-rate baseline for CUPED
+            -- residualization (LL-05). Keeps operator skill from being
+            -- credited to the variant.
+            CREATE TABLE IF NOT EXISTS operator_baselines (
+                operator_id TEXT PRIMARY KEY,
+                window_start TEXT,
+                merge_rate REAL,
+                sample_n INTEGER DEFAULT 0,
+                updated_at TEXT DEFAULT (datetime('now'))
+            );
+
+            -- Layer-B queue. Stop hook fills this via janitor_mark_stale;
+            -- janitor_check dispenses; caller's prism-reflect subagent
+            -- submits back.
+            CREATE TABLE IF NOT EXISTS consolidation_candidates (
+                id TEXT PRIMARY KEY,
+                task_id TEXT,
+                session_id TEXT,
+                trigger TEXT,
+                scope_json TEXT,
+                status TEXT DEFAULT 'pending',
+                queued_at TEXT DEFAULT (datetime('now')),
+                staled_at TEXT,
+                dispensed_at TEXT,
+                completed_at TEXT,
+                retry_count INTEGER DEFAULT 0,
+                last_nudged_at TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_consolidation_candidates_session_id
+                ON consolidation_candidates(session_id);
+            CREATE INDEX IF NOT EXISTS idx_consolidation_candidates_task_id
+                ON consolidation_candidates(task_id);
+            CREATE INDEX IF NOT EXISTS idx_consolidation_candidates_status
+                ON consolidation_candidates(status);
+
+            -- Audit trail of every completed (or errored) reflection run.
+            -- Output JSON is preserved verbatim — invalidated memories can
+            -- still be traced back to the run that retired them.
+            CREATE TABLE IF NOT EXISTS consolidation_runs (
+                id TEXT PRIMARY KEY,
+                candidate_id TEXT,
+                run_at TEXT DEFAULT (datetime('now')),
+                output_json TEXT,
+                subagent_type TEXT,
+                confidence REAL,
+                schema_valid INTEGER DEFAULT 1
+            );
+            CREATE INDEX IF NOT EXISTS idx_consolidation_runs_candidate_id
+                ON consolidation_runs(candidate_id);
+
+            -- Memory metadata sidecar. The JSONL-under-mulch store remains
+            -- the source of truth for memory *content*; this SQL table
+            -- tracks the queryable metadata the janitor needs: session
+            -- attribution, recency, soft-invalidation status.
+            CREATE TABLE IF NOT EXISTS memory_meta (
+                memory_id TEXT PRIMARY KEY,
+                session_id TEXT,
+                last_recalled_at TEXT,
+                recall_count INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'active'
+            );
+            CREATE INDEX IF NOT EXISTS idx_memory_meta_session_id
+                ON memory_meta(session_id);
+            CREATE INDEX IF NOT EXISTS idx_memory_meta_status
+                ON memory_meta(status);
         """)
 
     # ------------------------------------------------------------------

--- a/services/prism-service/app/main.py
+++ b/services/prism-service/app/main.py
@@ -5,9 +5,9 @@ import threading
 
 from nicegui import ui, app
 
-from app.config import (DATA_DIR, PROJECTS_DIR,
+from app.config import (DATA_DIR, PROJECT_DIR, PROJECTS_DIR,
                          UI_PORT, MCP_PORT, GOVERNANCE_INTERVAL_SECONDS,
-                         DRIFT_INTERVAL_SECONDS)
+                         DRIFT_INTERVAL_SECONDS, QUALITY_INTERVAL_SECONDS)
 
 # Ensure base directories exist
 PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -74,6 +74,50 @@ def start_drift_timer():
         time.sleep(DRIFT_INTERVAL_SECONDS)
 
 
+def start_quality_timer():
+    """Score merged tasks against git truth on a cadence (LL-04).
+
+    Walks every project, calls ``score_merged_tasks`` so any task that
+    landed on main in the last 14 days gets a composite Layer-A quality
+    score written to ``task_quality_rollup``. PRISM_QUALITY_INTERVAL=0
+    disables entirely.
+    """
+    import sys as _sys
+    import time
+    if QUALITY_INTERVAL_SECONDS <= 0:
+        print("Quality timer disabled (PRISM_QUALITY_INTERVAL=0)",
+              file=_sys.stderr)
+        return
+    from app.project_context import get_project, get_all_projects
+    from app.services.scoring_service import score_merged_tasks
+    print(
+        f"Quality timer running every {QUALITY_INTERVAL_SECONDS}s",
+        file=_sys.stderr,
+    )
+    while True:
+        try:
+            for pid in get_all_projects():
+                try:
+                    ctx = get_project(pid)
+                    scored = score_merged_tasks(
+                        tasks_svc=ctx.task_svc,
+                        scores_db=str(ctx._data_dir / "scores.db"),
+                        repo_path=str(PROJECT_DIR),
+                    )
+                    if scored:
+                        print(
+                            f"[quality] {pid}: scored {len(scored)} merged "
+                            f"task(s)",
+                            file=_sys.stderr,
+                        )
+                except Exception as e:
+                    print(f"Quality cycle error ({pid}): {e}",
+                          file=_sys.stderr)
+        except Exception as e:
+            print(f"Quality timer error: {e}", file=_sys.stderr)
+        time.sleep(QUALITY_INTERVAL_SECONDS)
+
+
 # Import UI pages (they register routes with NiceGUI)
 from app.ui import (
     dashboard, brain_page, graph_page, memory_page,
@@ -93,6 +137,7 @@ async def startup():
         threading.Thread(target=start_mcp_server, daemon=True).start()
         threading.Thread(target=start_governance_timer, daemon=True).start()
         threading.Thread(target=start_drift_timer, daemon=True).start()
+        threading.Thread(target=start_quality_timer, daemon=True).start()
     except Exception as e:
         print(f"Startup error: {e}")
 

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -510,6 +510,14 @@ TOOLS: list[Tool] = [
                     "description": "semantic (fact/convention), episodic (specific incident/debug session), procedural (how-to/template). Default: semantic.",
                     "default": "semantic",
                 },
+                "session_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional. When provided, stamps the memory_meta "
+                        "sidecar row with this session so the janitor can "
+                        "tie memories back to the session that wrote them."
+                    ),
+                },
             },
             "required": ["domain", "name", "description", "type", "classification"],
         },
@@ -528,6 +536,126 @@ TOOLS: list[Tool] = [
                 "limit": {"type": "integer", "description": "Max results", "default": 5},
             },
             "required": ["query"],
+        },
+    ),
+    # ------------------------------------------------------------------
+    # LL-08 — Janitor / Layer-B queue endpoints. PRISM schedules the
+    # work; the caller's Claude does the LLM compute via the prism-
+    # reflect sub-agent. See services/janitor_service.py for the
+    # underlying semantics.
+    # ------------------------------------------------------------------
+    Tool(
+        name="janitor_enqueue",
+        description=(
+            "Enqueue a consolidation candidate. Idempotent on "
+            "(task_id, trigger) within a 10-min window. Fire-and-forget "
+            "from the Stop hook."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string"},
+                "session_id": {"type": "string"},
+                "trigger": {"type": "string",
+                             "description": "e.g. session_end, task_done, revert_detected, staleness_sweep"},
+                "scope": {
+                    "type": "object",
+                    "description": "{task_ids, memory_ids, file_paths} — what the session touched",
+                },
+            },
+            "required": ["trigger"],
+        },
+    ),
+    Tool(
+        name="janitor_mark_stale",
+        description=(
+            "Flip pending candidates whose scope overlaps the session's "
+            "activity to status=stale and requeue fresh siblings. Called "
+            "by the Stop hook so the next reflection sees current state."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+                "scope": {
+                    "type": "object",
+                    "description": "{task_ids, memory_ids, file_paths} session touched",
+                },
+            },
+            "required": ["session_id"],
+        },
+    ),
+    Tool(
+        name="janitor_check",
+        description=(
+            "Return {ready, brief}. Dispenses at most one pending "
+            "candidate per call — if ready, the brief is a subagent "
+            "work packet (question, context, mcps_available, "
+            "investigation_guidance, response_schema). Enforces the 1h "
+            "min queue age and 5-min abandon backoff."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {"session_id": {"type": "string"}},
+            "required": ["session_id"],
+        },
+    ),
+    Tool(
+        name="janitor_submit",
+        description=(
+            "Post the sub-agent's JSON output. Server validates the "
+            "response schema, writes consolidation_runs, enriches "
+            "task_quality_rollup.qualitative_score. Malformed → reject."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "candidate_id": {"type": "string"},
+                "output_json": {"type": "object"},
+            },
+            "required": ["candidate_id", "output_json"],
+        },
+    ),
+    Tool(
+        name="janitor_abandon",
+        description=(
+            "Give up on a dispensed candidate. Increments retry_count; "
+            "hard limit of 3 before status=abandoned."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "candidate_id": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            "required": ["candidate_id"],
+        },
+    ),
+    Tool(
+        name="janitor_status",
+        description=(
+            "Return queue depth by status + last-nudged timestamps. Used "
+            "by the /consolidation UI and by operators debugging why "
+            "nothing is dispensing."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="memory_invalidate",
+        description=(
+            "Soft-delete a memory by flipping its memory_meta row to "
+            "status=invalidated. Row is preserved for audit; the JSONL "
+            "content stays where it is. Called by the prism-reflect "
+            "sub-agent when a reflection determines a memory no longer "
+            "applies."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "memory_id": {"type": "string"},
+                "reason": {"type": "string"},
+            },
+            "required": ["memory_id"],
         },
     ),
     Tool(
@@ -1906,7 +2034,117 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 importance=arguments.get("importance", 5),
                 memory_type=arguments.get("memory_type", "semantic"),
             )
+            # LL-08: when the caller provides a session_id, stamp a
+            # memory_meta row so the janitor can later correlate this
+            # memory with the session that wrote it. JSONL remains the
+            # source of truth for content; memory_meta is a SQL sidecar
+            # for queryable metadata only.
+            sid = arguments.get("session_id")
+            if sid:
+                # Accept dict, dataclass, or pydantic-like: memory_svc
+                # returns an ExpertiseEntry dataclass today, but keep
+                # attribute+mapping lookup so a future shape change
+                # doesn't silently drop the stamp.
+                mem_id = None
+                for attr in ("id", "entry_id", "memory_id"):
+                    if isinstance(result, dict):
+                        mem_id = result.get(attr)
+                    else:
+                        mem_id = getattr(result, attr, None)
+                    if mem_id:
+                        break
+                if mem_id:
+                    import sqlite3 as _sq3
+                    _c = _sq3.connect(str(ctx._data_dir / "scores.db"))
+                    try:
+                        _c.execute(
+                            "INSERT OR REPLACE INTO memory_meta "
+                            "(memory_id, session_id, status) "
+                            "VALUES (?, ?, 'active')",
+                            (mem_id, sid),
+                        )
+                        _c.commit()
+                    finally:
+                        _c.close()
             return [TextContent(type="text", text=_json(result))]
+
+        if name == "memory_invalidate":
+            import sqlite3 as _sq3
+            mem_id = arguments["memory_id"]
+            reason = arguments.get("reason", "")
+            _c = _sq3.connect(str(ctx._data_dir / "scores.db"))
+            try:
+                # INSERT OR REPLACE so memories that never had a
+                # memory_meta row still get one (invalidated directly
+                # without having been session-tagged first).
+                _c.execute(
+                    "INSERT INTO memory_meta (memory_id, status) "
+                    "VALUES (?, 'invalidated') "
+                    "ON CONFLICT(memory_id) DO UPDATE SET status='invalidated'",
+                    (mem_id,),
+                )
+                _c.commit()
+            finally:
+                _c.close()
+            return [TextContent(type="text", text=_json({
+                "accepted": True, "memory_id": mem_id, "reason": reason,
+            }))]
+
+        # ------------------------------------------------------------------
+        # LL-08 — Janitor / Layer-B queue endpoints
+        # ------------------------------------------------------------------
+        if name == "janitor_enqueue":
+            cid = ctx.janitor_svc.enqueue(
+                task_id=arguments.get("task_id"),
+                session_id=arguments.get("session_id"),
+                trigger=arguments.get("trigger", "manual"),
+                scope=arguments.get("scope"),
+            )
+            return [TextContent(type="text", text=_json({"candidate_id": cid}))]
+
+        if name == "janitor_mark_stale":
+            staled = ctx.janitor_svc.mark_stale(
+                session_id=arguments["session_id"],
+                scope=arguments.get("scope"),
+            )
+            return [TextContent(type="text", text=_json({"staled": staled}))]
+
+        if name == "janitor_check":
+            res = ctx.janitor_svc.check(session_id=arguments["session_id"])
+            return [TextContent(type="text", text=_json(res))]
+
+        if name == "janitor_submit":
+            res = ctx.janitor_svc.submit(
+                candidate_id=arguments["candidate_id"],
+                output_json=arguments["output_json"],
+            )
+            return [TextContent(type="text", text=_json(res))]
+
+        if name == "janitor_abandon":
+            res = ctx.janitor_svc.abandon(
+                candidate_id=arguments["candidate_id"],
+                reason=arguments.get("reason", ""),
+            )
+            return [TextContent(type="text", text=_json(res))]
+
+        if name == "janitor_status":
+            _db = ctx.janitor_svc._db
+            rows = _db.execute(
+                "SELECT status, COUNT(*) AS n FROM consolidation_candidates "
+                "GROUP BY status"
+            ).fetchall()
+            counts = {r["status"]: r["n"] for r in rows}
+            recent_nudge = _db.execute(
+                "SELECT MAX(last_nudged_at) AS ts FROM consolidation_candidates"
+            ).fetchone()
+            return [TextContent(type="text", text=_json({
+                "pending": counts.get("pending", 0),
+                "dispensed": counts.get("dispensed", 0),
+                "completed": counts.get("completed", 0),
+                "abandoned": counts.get("abandoned", 0),
+                "stale": counts.get("stale", 0),
+                "last_nudge_at": recent_nudge["ts"] if recent_nudge else None,
+            }))]
 
         if name == "memory_recall":
             results = memory_svc.recall(

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, is_dataclass
+from pathlib import Path
 from typing import Any
 
 from mcp.types import Tool, TextContent
@@ -1580,7 +1581,97 @@ def check_and_clear_cancel(project_id: str) -> bool:
 # Tool handler
 # ---------------------------------------------------------------------------
 
+# Tools whose responses must never get a reflection nudge prepended —
+# either because they're part of the reflection pipeline itself (would
+# create a feedback loop) or because the caller needs the response
+# structure unchanged (install manifest, guide prose).
+_NO_AUGMENT_TOOLS: frozenset[str] = frozenset({
+    "janitor_enqueue", "janitor_mark_stale", "janitor_check",
+    "janitor_submit", "janitor_abandon", "janitor_status",
+    "memory_invalidate", "prism_install", "prism_guide",
+})
+
+
 async def handle_tool(name: str, arguments: dict, *, project_id: str = "default") -> list[TextContent]:
+    """Outer MCP entry point. Dispatches to :func:`_dispatch_tool`, then
+    lets :func:`_maybe_augment_with_nudge` prepend a pending-reflection
+    header when appropriate (LL-09)."""
+    result = await _dispatch_tool(name, arguments, project_id=project_id)
+    if name in _NO_AUGMENT_TOOLS:
+        return result
+    try:
+        return _maybe_augment_with_nudge(result, project_id=project_id)
+    except Exception:
+        # Augmentation is strictly advisory — any failure here must not
+        # affect the tool result the caller actually needs.
+        return result
+
+
+def _maybe_augment_with_nudge(
+    result: list[TextContent], *, project_id: str,
+) -> list[TextContent]:
+    """Prefix the first TextContent with a PRISM_REFLECTION_PENDING
+    header when a pending candidate exists for this project AND we
+    haven't nudged it in the last 5 minutes. Updates last_nudged_at on
+    the candidate. Disabled globally by PRISM_MCP_AUGMENT_NUDGES=false.
+    """
+    import os as _os
+    import sqlite3 as _sq3
+    from datetime import datetime, timedelta, timezone
+
+    if _os.environ.get("PRISM_MCP_AUGMENT_NUDGES", "").lower() == "false":
+        return result
+    if not result:
+        return result
+
+    from app.project_context import get_project
+    try:
+        ctx = get_project(project_id)
+    except Exception:
+        return result
+
+    scores_path = str(ctx._data_dir / "scores.db")
+    if not Path(scores_path).exists():
+        return result
+
+    now = datetime.now(timezone.utc)
+    cutoff = (now - timedelta(minutes=5)).isoformat()
+
+    conn = _sq3.connect(scores_path)
+    conn.row_factory = _sq3.Row
+    try:
+        # Oldest pending candidate not nudged in the last 5 min.
+        row = conn.execute(
+            "SELECT id, task_id FROM consolidation_candidates "
+            "WHERE status='pending' "
+            "  AND (last_nudged_at IS NULL OR last_nudged_at <= ?) "
+            "ORDER BY queued_at ASC LIMIT 1",
+            (cutoff,),
+        ).fetchone()
+        if row is None:
+            return result
+        cid = row["id"]
+        tid = row["task_id"] or ""
+        conn.execute(
+            "UPDATE consolidation_candidates SET last_nudged_at=? WHERE id=?",
+            (now.isoformat(), cid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    header = (
+        f"\u26a0\ufe0f PRISM_REFLECTION_PENDING candidate={cid} task={tid}\n"
+        "Before continuing, spawn the `prism-reflect` subagent. Call "
+        "`janitor_check` to fetch the brief, submit via `janitor_submit`.\n"
+        "---\n"
+    )
+    first = result[0]
+    augmented_text = header + (first.text or "")
+    return [TextContent(type="text", text=augmented_text)] + list(result[1:])
+
+
+async def _dispatch_tool(name: str, arguments: dict, *, project_id: str = "default") -> list[TextContent]:
     """Dispatch an MCP tool call to the appropriate service method.
 
     The *project_id* scopes all data access to the correct project.

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -194,7 +194,8 @@ TOOLS: list[Tool] = [
         name="record_session_outcome",
         description=(
             "Upsert one session_outcomes row for the current Claude Code "
-            "session. Called by the plugin's Stop hook. Fields: "
+            "session. Called by the Stop hook that prism_install ships. "
+            "Fields: "
             "session_id, duration_s, tokens_used, files_read, "
             "files_modified, skills_invoked. Persists to scores.db so "
             "the /sessions UI can render it."
@@ -215,8 +216,9 @@ TOOLS: list[Tool] = [
     Tool(
         name="record_skill_usage",
         description=(
-            "Record one skill invocation. Called by the plugin's "
-            "PostToolUse hook on Skill tool use. Feeds the Conductor's "
+            "Record one skill invocation. Called by the PostToolUse "
+            "hook that prism_install ships, on Skill tool use. Feeds "
+            "the Conductor's "
             "skill-ranking model."
         ),
         inputSchema={
@@ -234,8 +236,9 @@ TOOLS: list[Tool] = [
         name="record_outcome",
         description=(
             "Persist one PSP-scored execution outcome. Used by the "
-            "plugin's SubagentStop recorder and by workflow-step "
-            "recorders. Metrics dict accepts tokens_used, duration_s, "
+            "SubagentStop recorder that prism_install ships and by "
+            "workflow-step recorders. Metrics dict accepts tokens_used, "
+            "duration_s, "
             "retries, gate_passed, tests_passed, coverage_pct, "
             "traceability_pct, probe_accuracy."
         ),
@@ -1235,10 +1238,11 @@ if __name__ == "__main__":
 
 
 def _load_asset(filename: str) -> str:
-    """Read a shipped hook script from app/assets/. The plugin-side copy in
-    ``plugins/prism-devtools/hooks/`` must be kept in sync with the copy in
-    ``services/prism-service/app/assets/``; the assets version is the one
-    served to MCP-only clients via prism_install."""
+    """Read a shipped hook script from app/assets/. The copy shipped by
+    the ``prism-devtools`` Claude Code plugin at
+    ``plugins/prism-devtools/hooks/`` must be kept in sync with the copy
+    in ``services/prism-service/app/assets/``; the assets version is the
+    one served to MCP-only clients via ``prism_install``."""
     from pathlib import Path as _P
     try:
         return (_P(__file__).parent.parent / "assets" / filename).read_text(

--- a/services/prism-service/app/project_context.py
+++ b/services/prism-service/app/project_context.py
@@ -29,6 +29,7 @@ class ProjectContext:
         self._memory_svc = None
         self._conductor_svc = None
         self._governance = None
+        self._janitor_svc = None
 
     @property
     def brain_svc(self):
@@ -89,6 +90,15 @@ class ProjectContext:
                 scores_db=str(self._data_dir / "scores.db"),
             )
         return self._conductor_svc
+
+    @property
+    def janitor_svc(self):
+        if self._janitor_svc is None:
+            from app.services.janitor_service import JanitorService
+            self._janitor_svc = JanitorService(
+                scores_db=str(self._data_dir / "scores.db"),
+            )
+        return self._janitor_svc
 
     @property
     def governance(self):

--- a/services/prism-service/app/project_context.py
+++ b/services/prism-service/app/project_context.py
@@ -39,6 +39,7 @@ class ProjectContext:
                 brain_db=str(self._data_dir / "brain.db"),
                 graph_db=str(self._data_dir / "graph.db"),
                 scores_db=str(self._data_dir / "scores.db"),
+                tasks_db=str(self._data_dir / "tasks.db"),
             )
             # Wire graph service for source-file staging
             self._brain_svc.graph_svc = self.graph_svc

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -74,10 +74,14 @@ class BrainService:
     _brain = None
     _available: bool = False
 
-    def __init__(self, brain_db: str, graph_db: str, scores_db: str) -> None:
+    def __init__(
+        self, brain_db: str, graph_db: str, scores_db: str,
+        tasks_db: Optional[str] = None,
+    ) -> None:
         self._brain_db = brain_db
         self._graph_db = graph_db
         self._scores_db = scores_db
+        self._tasks_db = tasks_db
         self._init_brain()
 
     def _init_brain(self) -> None:
@@ -89,6 +93,7 @@ class BrainService:
                 brain_db=self._brain_db,
                 graph_db=self._graph_db,
                 scores_db=self._scores_db,
+                tasks_db=self._tasks_db,
             )
             self._available = True
         except Exception as exc:

--- a/services/prism-service/app/services/conductor_service.py
+++ b/services/prism-service/app/services/conductor_service.py
@@ -153,9 +153,9 @@ class ConductorService:
 
         Reads the ``session_outcomes`` table populated by
         ``record_session_outcome`` (served by the MCP and written by the
-        plugin's Stop hook). Maps DB columns onto the keys the
-        /sessions UI expects (id, session_id, duration, tokens,
-        files_modified, recorded_at).
+        Stop hook that prism_install ships). Maps DB columns onto the
+        keys the /sessions UI expects (id, session_id, duration,
+        tokens, files_modified, recorded_at).
         """
         try:
             conn = self._scores_conn()

--- a/services/prism-service/app/services/janitor_service.py
+++ b/services/prism-service/app/services/janitor_service.py
@@ -1,0 +1,373 @@
+"""JanitorService — queue, readiness policy, retry/backoff for the
+Layer-B caller-side reflection loop.
+
+Parent task: 37932f3f · LL-07.
+
+PRISM runs zero LLMs. This service schedules consolidation work; the
+actual LLM compute happens in the caller's Claude session via a sub-agent
+spawned from the brief returned by :meth:`check`. Results come back via
+:meth:`submit` (success) or :meth:`abandon` (retry or give up).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional
+
+
+# Readiness / backoff constants. Small, exported as class attributes so
+# tests can monkeypatch without reaching into the module.
+_MIN_QUEUE_AGE_S = 3600          # 1 hour — git-truth signals settle
+_ENQUEUE_DEBOUNCE_S = 600        # 10 min — idempotency window
+_ABANDON_BACKOFF_S = 300         # 5 min — don't redispense immediately
+_HARD_RETRY_LIMIT = 3            # 3 strikes → abandoned
+
+# Default MCP allow-list for the prism-reflect sub-agent. Read-only
+# tools only; the caller's Claude spawns the sub-agent with these.
+_DEFAULT_MCPS: tuple[str, ...] = (
+    "brain_search",
+    "brain_graph",
+    "brain_find_symbol",
+    "brain_find_references",
+    "brain_call_chain",
+    "memory_recall",
+    "task_list",
+)
+
+# The response schema the sub-agent must produce. Server validates on
+# submit; malformed output is rejected and the candidate stays queued.
+_RESPONSE_SCHEMA: dict[str, str] = {
+    "qualitative_score": "float 0-1",
+    "narrative": "string ~200 words",
+    "new_memories": "[{domain, name, description, type, classification}]",
+    "invalidate_memory_ids": "[{id, reason}]",
+    "confidence": "float 0-1",
+}
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _overlap(a: dict, b: dict) -> bool:
+    """Two scope dicts overlap if any shared list-valued key has a
+    non-empty intersection. Keys we care about: task_ids, memory_ids,
+    file_paths."""
+    for key in ("task_ids", "memory_ids", "file_paths"):
+        aset = set(a.get(key) or [])
+        bset = set(b.get(key) or [])
+        if aset & bset:
+            return True
+    return False
+
+
+class JanitorService:
+    """Queue + dispensing + retry policy for Layer-B reflection."""
+
+    # Exposed so tests can reach in without magic-number duplication.
+    MIN_QUEUE_AGE_S = _MIN_QUEUE_AGE_S
+    ENQUEUE_DEBOUNCE_S = _ENQUEUE_DEBOUNCE_S
+    ABANDON_BACKOFF_S = _ABANDON_BACKOFF_S
+    HARD_RETRY_LIMIT = _HARD_RETRY_LIMIT
+
+    def __init__(
+        self,
+        scores_db: str,
+        clock: Optional[Callable[[], datetime]] = None,
+    ) -> None:
+        self._db_path = scores_db
+        self._db = sqlite3.connect(scores_db, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._db.execute("PRAGMA journal_mode=WAL")
+        self._clock: Callable[[], datetime] = clock or _now_utc
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _iso(self, dt: Optional[datetime] = None) -> str:
+        return (dt or self._clock()).isoformat()
+
+    def _parse_iso(self, s: Optional[str]) -> Optional[datetime]:
+        if not s:
+            return None
+        try:
+            return datetime.fromisoformat(s)
+        except ValueError:
+            return None
+
+    def _scope_of(self, row: sqlite3.Row) -> dict:
+        try:
+            return json.loads(row["scope_json"] or "{}")
+        except (json.JSONDecodeError, TypeError):
+            return {}
+
+    # ------------------------------------------------------------------
+    # enqueue
+    # ------------------------------------------------------------------
+
+    def enqueue(
+        self,
+        task_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        trigger: str = "manual",
+        scope: Optional[dict] = None,
+    ) -> str:
+        """Insert a new candidate. Idempotent on (task_id, trigger) within
+        a 10-minute window — returns the existing id instead of inserting
+        a duplicate."""
+        now = self._clock()
+        if task_id is not None:
+            cutoff = (now - timedelta(seconds=self.ENQUEUE_DEBOUNCE_S)).isoformat()
+            existing = self._db.execute(
+                "SELECT id FROM consolidation_candidates "
+                "WHERE task_id=? AND trigger=? AND status='pending' "
+                "AND queued_at > ? "
+                "ORDER BY queued_at DESC LIMIT 1",
+                (task_id, trigger, cutoff),
+            ).fetchone()
+            if existing:
+                return existing["id"]
+        cid = str(uuid.uuid4())
+        self._db.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, session_id, trigger, scope_json, status, queued_at) "
+            "VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+            (
+                cid, task_id, session_id, trigger,
+                json.dumps(scope or {}),
+                self._iso(now),
+            ),
+        )
+        self._db.commit()
+        return cid
+
+    # ------------------------------------------------------------------
+    # mark_stale
+    # ------------------------------------------------------------------
+
+    def mark_stale(self, session_id: str, scope: Optional[dict] = None) -> list[str]:
+        """Flip pending candidates whose scope overlaps to 'stale' and
+        requeue a fresh sibling. Completed candidates are preserved.
+
+        Returns the list of candidate ids that were staled."""
+        if not scope:
+            return []
+        now = self._clock()
+        pending = self._db.execute(
+            "SELECT id, task_id, trigger, scope_json FROM consolidation_candidates "
+            "WHERE status='pending'"
+        ).fetchall()
+        staled: list[str] = []
+        for row in pending:
+            if _overlap(self._scope_of(row), scope):
+                staled.append(row["id"])
+        if not staled:
+            return staled
+
+        placeholders = ",".join("?" * len(staled))
+        self._db.execute(
+            f"UPDATE consolidation_candidates "
+            f"SET status='stale', staled_at=? "
+            f"WHERE id IN ({placeholders})",
+            (self._iso(now), *staled),
+        )
+        # Requeue a fresh copy for each staled candidate, preserving scope.
+        for row in pending:
+            if row["id"] not in staled:
+                continue
+            fresh_id = str(uuid.uuid4())
+            self._db.execute(
+                "INSERT INTO consolidation_candidates "
+                "(id, task_id, session_id, trigger, scope_json, status, queued_at) "
+                "VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+                (
+                    fresh_id, row["task_id"], session_id, row["trigger"],
+                    row["scope_json"], self._iso(now),
+                ),
+            )
+        self._db.commit()
+        return staled
+
+    # ------------------------------------------------------------------
+    # check — dispense a ready brief
+    # ------------------------------------------------------------------
+
+    def check(self, session_id: str) -> dict:
+        """Return {ready, brief}. Dispenses max one candidate per call."""
+        now = self._clock()
+        age_cutoff = (now - timedelta(seconds=self.MIN_QUEUE_AGE_S)).isoformat()
+        backoff_cutoff = (now - timedelta(seconds=self.ABANDON_BACKOFF_S)).isoformat()
+        row = self._db.execute(
+            "SELECT * FROM consolidation_candidates "
+            "WHERE status='pending' "
+            "  AND queued_at <= ? "
+            "  AND (dispensed_at IS NULL OR dispensed_at <= ?) "
+            "ORDER BY queued_at ASC LIMIT 1",
+            (age_cutoff, backoff_cutoff),
+        ).fetchone()
+        if row is None:
+            return {"ready": False, "brief": None}
+
+        # Claim it
+        self._db.execute(
+            "UPDATE consolidation_candidates "
+            "SET status='dispensed', dispensed_at=? WHERE id=?",
+            (self._iso(now), row["id"]),
+        )
+        self._db.commit()
+
+        brief = self._build_brief(row)
+        return {"ready": True, "brief": brief}
+
+    def _build_brief(self, row: sqlite3.Row) -> dict:
+        scope = self._scope_of(row)
+        task_id = row["task_id"]
+        # Pull quantitative score if Layer-A already scored the task.
+        quantitative_score: Optional[float] = None
+        try:
+            qrow = self._db.execute(
+                "SELECT quality_score, cuped_score FROM task_quality_rollup "
+                "WHERE task_id=?",
+                (task_id,),
+            ).fetchone()
+            if qrow is not None:
+                quantitative_score = qrow["cuped_score"] or qrow["quality_score"]
+        except sqlite3.OperationalError:
+            pass
+
+        # Scope is mostly trusted metadata (id lists, file paths). The
+        # transcript_excerpt, if present, is user-sourced and gets
+        # wrapped so the sub-agent treats it as data, not instructions.
+        transcript = scope.get("transcript_excerpt", "")
+        wrapped_transcript = (
+            f"<untrusted>{transcript}</untrusted>" if transcript else ""
+        )
+
+        context = {
+            "task_id": task_id,
+            "affected_files": scope.get("file_paths", []),
+            "affected_memory_ids": scope.get("memory_ids", []),
+            "affected_task_ids": scope.get("task_ids", []),
+            "quantitative_score": quantitative_score,
+            "transcript_excerpt": wrapped_transcript,
+        }
+        guidance_parts = []
+        if context["affected_files"]:
+            guidance_parts.append(
+                f"Use brain_graph / brain_call_chain to trace callers of "
+                f"methods in {context['affected_files']}."
+            )
+        if context["affected_memory_ids"]:
+            guidance_parts.append(
+                "Use memory_recall to check whether the affected memories "
+                "still apply given the current code."
+            )
+        guidance_parts.append(
+            "Use brain_search to find similar past patterns across tasks."
+        )
+        return {
+            "candidate_id": row["id"],
+            "question": (
+                f"Did the approach taken on task {task_id} produce "
+                f"durable, well-integrated code?"
+            ),
+            "context": context,
+            "mcps_available": list(_DEFAULT_MCPS),
+            "investigation_guidance": " ".join(guidance_parts),
+            "response_schema": dict(_RESPONSE_SCHEMA),
+        }
+
+    # ------------------------------------------------------------------
+    # submit
+    # ------------------------------------------------------------------
+
+    _REQUIRED_FIELDS = (
+        "qualitative_score", "narrative", "new_memories",
+        "invalidate_memory_ids", "confidence",
+    )
+
+    def submit(self, candidate_id: str, output_json: dict) -> dict:
+        """Validate, write consolidation_runs, enrich rollup, store
+        new memories, invalidate old ones. Returns {accepted, error?}."""
+        if not isinstance(output_json, dict):
+            return {"accepted": False, "error": "output_json must be a dict"}
+        missing = [f for f in self._REQUIRED_FIELDS if f not in output_json]
+        if missing:
+            return {
+                "accepted": False,
+                "error": f"missing required fields: {missing}",
+            }
+        row = self._db.execute(
+            "SELECT task_id FROM consolidation_candidates WHERE id=?",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            return {"accepted": False, "error": "unknown candidate_id"}
+        now = self._clock()
+        run_id = str(uuid.uuid4())
+        self._db.execute(
+            "INSERT INTO consolidation_runs "
+            "(id, candidate_id, run_at, output_json, subagent_type, "
+            " confidence, schema_valid) "
+            "VALUES (?, ?, ?, ?, ?, ?, 1)",
+            (
+                run_id, candidate_id, self._iso(now),
+                json.dumps(output_json), "prism-reflect",
+                float(output_json.get("confidence") or 0.0),
+            ),
+        )
+        # Enrich rollup — upsert qualitative_score onto the task.
+        task_id = row["task_id"]
+        if task_id:
+            qscore = float(output_json["qualitative_score"])
+            self._db.execute(
+                "INSERT INTO task_quality_rollup (task_id, qualitative_score) "
+                "VALUES (?, ?) "
+                "ON CONFLICT(task_id) DO UPDATE SET qualitative_score=excluded.qualitative_score",
+                (task_id, qscore),
+            )
+        # Mark candidate complete.
+        self._db.execute(
+            "UPDATE consolidation_candidates "
+            "SET status='completed', completed_at=? WHERE id=?",
+            (self._iso(now), candidate_id),
+        )
+        self._db.commit()
+        # Memory store/invalidate are delegated to the caller (MCP layer
+        # wires them up in LL-08). We expose the counts so observability
+        # tests can assert the structure; actual writes happen upstream.
+        return {
+            "accepted": True,
+            "run_id": run_id,
+            "memories_to_store": len(output_json.get("new_memories") or []),
+            "memories_to_invalidate": len(
+                output_json.get("invalidate_memory_ids") or []
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # abandon
+    # ------------------------------------------------------------------
+
+    def abandon(self, candidate_id: str, reason: str = "") -> dict:
+        """Increment retry_count; status stays 'pending' (subject to
+        backoff) until HARD_RETRY_LIMIT is hit."""
+        row = self._db.execute(
+            "SELECT retry_count FROM consolidation_candidates WHERE id=?",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            return {"accepted": False, "error": "unknown candidate_id"}
+        new_count = (row["retry_count"] or 0) + 1
+        status = "abandoned" if new_count >= self.HARD_RETRY_LIMIT else "pending"
+        self._db.execute(
+            "UPDATE consolidation_candidates "
+            "SET status=?, retry_count=? WHERE id=?",
+            (status, new_count, candidate_id),
+        )
+        self._db.commit()
+        return {"accepted": True, "status": status, "retry_count": new_count}

--- a/services/prism-service/app/services/scoring_service.py
+++ b/services/prism-service/app/services/scoring_service.py
@@ -85,6 +85,86 @@ def composite_score(components: dict[str, Any]) -> Optional[float]:
 
 
 # ======================================================================
+# LL-05 — CUPED residualization + per-operator baselines
+# ======================================================================
+
+
+def cuped_residualize(
+    quality_score: float,
+    operator_baseline: float,
+    global_baseline: float,
+    theta: float = 1.0,
+) -> float:
+    """CUPED adjustment: ``Y_cuped = Y - theta * (X - mean(X))``.
+
+    Deng/Xu/Kohavi/Walker 2013 — subtract the operator-specific
+    deviation from the global baseline before crediting the variant.
+    Keeps operator skill from inflating/deflating variant attribution.
+
+    When ``operator_baseline == global_baseline`` (e.g. unknown
+    operator defaulted to the global mean) the adjustment is zero and
+    this function degrades to the identity.
+
+    ``theta`` defaults to 1.0. Call :func:`recompute_theta` once a
+    project has ≥50 samples to replace with Cov(Y,X)/Var(X) for
+    maximal variance reduction.
+    """
+    return float(quality_score) - float(theta) * (
+        float(operator_baseline) - float(global_baseline)
+    )
+
+
+def compute_operator_baseline(
+    task_svc,
+    operator_id: str,
+    window_days: int = 90,
+    now: Optional[datetime] = None,
+) -> tuple[float, int]:
+    """Per-operator rolling merge rate + sample count.
+
+    Merge rate = (tasks with merge_sha) / (all tasks created in window)
+    for the given operator (``assigned_agent``). Unknown or new-operator
+    case returns ``(0.0, 0)``; callers typically treat that as "use the
+    global baseline" via :func:`cuped_residualize` degrading to identity.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = (now - timedelta(days=window_days)).isoformat()
+    row = task_svc._db.execute(
+        "SELECT "
+        "  COUNT(*) AS total, "
+        "  SUM(CASE WHEN merge_sha IS NOT NULL THEN 1 ELSE 0 END) AS merged "
+        "FROM tasks "
+        "WHERE assigned_agent = ? AND created_at >= ?",
+        (operator_id, cutoff),
+    ).fetchone()
+    total = int((row["total"] if row else 0) or 0)
+    if total == 0:
+        return 0.0, 0
+    merged = int((row["merged"] if row else 0) or 0)
+    return merged / total, total
+
+
+def recompute_theta(paired: Iterable[tuple[float, float]]) -> float:
+    """Variance-minimizing theta: ``Cov(Y,X) / Var(X)``.
+
+    ``paired`` yields (Y, X) pairs across recent tasks. Returns 1.0
+    fallback when there's not enough data or X has zero variance.
+    """
+    pairs = list(paired)
+    n = len(pairs)
+    if n < 50:
+        return 1.0
+    mean_y = sum(y for y, _ in pairs) / n
+    mean_x = sum(x for _, x in pairs) / n
+    var_x = sum((x - mean_x) ** 2 for _, x in pairs) / n
+    if var_x == 0.0:
+        return 1.0
+    cov_yx = sum((y - mean_y) * (x - mean_x) for y, x in pairs) / n
+    return cov_yx / var_x
+
+
+# ======================================================================
 # LL-04 — git walker + composite scorer wiring
 # ======================================================================
 

--- a/services/prism-service/app/services/scoring_service.py
+++ b/services/prism-service/app/services/scoring_service.py
@@ -1,15 +1,23 @@
 """Scoring service — Layer-A quantitative composite score for task outcomes.
 
-Pure functions only (no I/O). The daemon in LL-04 walks git + test state
-and hands pre-computed signals here; this module turns those signals
-into a single quality score that Brain.best_prompt can consume.
+The core :func:`composite_score` is a pure function (LL-02). The daemon
+helpers in LL-04 (:func:`detect_revert`, :func:`detect_churn`,
+:func:`detect_followup_fixes`, :func:`score_merged_tasks`) wrap git
+subprocess calls + task graph lookups; they do I/O but are still
+deterministic given the same filesystem and task DB.
 
-Parent task: 37932f3f · LL-02.
+Parent task: 37932f3f · LL-02 + LL-04.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+import json
+import os
+import sqlite3
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
 
 
 # Penalty coefficients. Kept as module constants so LL-05's CUPED layer
@@ -74,3 +82,242 @@ def composite_score(components: dict[str, Any]) -> Optional[float]:
     score -= _FOLLOWUP_PENALTY_PER_TASK * followups
 
     return max(0.0, min(1.0, score))
+
+
+# ======================================================================
+# LL-04 — git walker + composite scorer wiring
+# ======================================================================
+
+# GitClear / DORA standard: a change is "durable" if it wasn't reverted
+# or substantially rewritten within 14 days of landing.
+_DURABILITY_WINDOW_DAYS = 14
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _git(repo_path: str, *args: str) -> Optional[str]:
+    """Run git with captured output. Returns stdout on success,
+    ``None`` on any failure — callers treat a missing/corrupt repo as
+    "no data" rather than a crash."""
+    try:
+        out = subprocess.run(
+            ["git", *args], cwd=repo_path,
+            capture_output=True, text=True, check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    return out.stdout
+
+
+def _files_at_sha(repo_path: str, sha: str) -> list[str]:
+    """Return the list of file paths touched by a single commit."""
+    raw = _git(repo_path, "show", "--pretty=format:", "--name-only", sha)
+    if raw is None:
+        return []
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def _is_git_repo(repo_path: str) -> bool:
+    return _git(repo_path, "rev-parse", "--git-dir") is not None
+
+
+def detect_revert(
+    repo_path: str, merge_sha: str, merged_at: datetime, now: datetime,
+) -> bool:
+    """Was *this specific commit* reverted within 14 days of merge?
+
+    ``git revert`` writes a standard line into the revert commit body:
+    ``This reverts commit <sha>``. Grep for that within the window.
+    """
+    if not _is_git_repo(repo_path):
+        return False
+    window_end = merged_at + timedelta(days=_DURABILITY_WINDOW_DAYS)
+    # Only consider the window ending at min(now, merged_at+14d)
+    until = min(now, window_end)
+    if until <= merged_at:
+        return False
+    raw = _git(
+        repo_path, "log",
+        f"--since={_iso(merged_at)}",
+        f"--until={_iso(until)}",
+        f"--grep=^This reverts commit {merge_sha}",
+        "--format=%H",
+    )
+    return bool(raw and raw.strip())
+
+
+def detect_churn(
+    repo_path: str, merge_sha: str, merged_at: datetime, now: datetime,
+) -> int:
+    """Count files touched by ``merge_sha`` that were re-edited in any
+    commit within the 14-day durability window (exclusive of the merge
+    commit itself)."""
+    if not _is_git_repo(repo_path):
+        return 0
+    merge_files = set(_files_at_sha(repo_path, merge_sha))
+    if not merge_files:
+        return 0
+    window_end = merged_at + timedelta(days=_DURABILITY_WINDOW_DAYS)
+    until = min(now, window_end)
+    if until <= merged_at:
+        return 0
+    raw = _git(
+        repo_path, "log",
+        f"--since={_iso(merged_at)}",
+        f"--until={_iso(until)}",
+        f"^{merge_sha}",        # exclude the merge commit itself
+        "HEAD",
+        "--name-only",
+        "--pretty=format:",
+    )
+    if raw is None:
+        return 0
+    touched: set[str] = set()
+    for line in raw.splitlines():
+        line = line.strip()
+        if line and line in merge_files:
+            touched.add(line)
+    return len(touched)
+
+
+def detect_followup_fixes(
+    task_svc,
+    merged_files: list[str],
+    merged_at: datetime,
+    now: datetime,
+    exclude_task_id: Optional[str] = None,
+) -> int:
+    """Count PRISM tasks created within the 14-day window whose title or
+    description mentions at least one of the merged files. Follow-up
+    signal: after this task landed, new work got filed against the same
+    code, suggesting the solution didn't fully stick."""
+    if not merged_files:
+        return 0
+    window_end = merged_at + timedelta(days=_DURABILITY_WINDOW_DAYS)
+    until = min(now, window_end)
+    if until <= merged_at:
+        return 0
+
+    merge_file_set = set(merged_files)
+    count = 0
+    for t in task_svc.list():
+        if exclude_task_id and t.id == exclude_task_id:
+            continue
+        try:
+            created = datetime.fromisoformat(t.created_at)
+        except ValueError:
+            continue
+        if created <= merged_at or created > until:
+            continue
+        blob = f"{t.title}\n{t.description}"
+        if any(mf in blob for mf in merge_file_set):
+            count += 1
+    return count
+
+
+# ----------------------------------------------------------------------
+# Orchestrator — the piece the daemon in main.py actually calls
+# ----------------------------------------------------------------------
+
+
+def _gather_components(
+    task_id: str,
+    merge_sha: str,
+    merged_at: datetime,
+    repo_path: str,
+    task_svc,
+    now: datetime,
+) -> dict[str, Any]:
+    merge_files = _files_at_sha(repo_path, merge_sha) if _is_git_repo(repo_path) else []
+    return {
+        "merged_to_main": True,
+        "reverted_within_14d": detect_revert(repo_path, merge_sha, merged_at, now),
+        "files_re_edited_within_14d": detect_churn(repo_path, merge_sha, merged_at, now),
+        "followup_fix_tasks_within_14d": detect_followup_fixes(
+            task_svc, merge_files, merged_at, now, exclude_task_id=task_id,
+        ),
+        # Defaults for signals git can't provide; overridden by LL-10
+        # when workflow state has them.
+        "gate_retry_count": 0,
+        "tests_green_on_merge": True,
+        "merge_files": merge_files,
+    }
+
+
+def score_merged_tasks(
+    tasks_svc,
+    scores_db: str,
+    repo_path: str,
+    now: Optional[datetime] = None,
+) -> list[str]:
+    """Score every merged task that isn't yet in ``task_quality_rollup``.
+
+    Returns the list of task_ids that received a fresh score on this
+    pass. Idempotent: rescores only new rows, never clobbers existing
+    ones on the default path.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    # Find merged tasks not yet scored. Reach past the ORM because
+    # ``tasks`` has the new merge_sha/merged_at columns that the Task
+    # dataclass doesn't expose yet (LL-03 scope was embedding only).
+    rows = tasks_svc._db.execute(
+        "SELECT id, merge_sha, merged_at FROM tasks "
+        "WHERE merge_sha IS NOT NULL AND merged_at IS NOT NULL"
+    ).fetchall()
+    if not rows:
+        return []
+
+    # If the repo path isn't a git working tree, there's no truth to
+    # score against — skip the pass entirely. Logged by the daemon
+    # wrapper in main.py so operators see why nothing moved.
+    if not _is_git_repo(repo_path):
+        return []
+
+    scores_conn = sqlite3.connect(scores_db)
+    try:
+        already = {
+            r[0] for r in scores_conn.execute(
+                "SELECT task_id FROM task_quality_rollup "
+                "WHERE quality_score IS NOT NULL"
+            ).fetchall()
+        }
+        scored: list[str] = []
+        for r in rows:
+            if r["id"] in already:
+                continue
+            try:
+                merged_at = datetime.fromisoformat(r["merged_at"])
+            except ValueError:
+                continue
+            components = _gather_components(
+                task_id=r["id"],
+                merge_sha=r["merge_sha"],
+                merged_at=merged_at,
+                repo_path=repo_path,
+                task_svc=tasks_svc,
+                now=now,
+            )
+            score = composite_score(components)
+            if score is None:
+                continue
+            scores_conn.execute(
+                "INSERT INTO task_quality_rollup "
+                "(task_id, quality_score, components_json, scored_at) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(task_id) DO UPDATE SET "
+                "quality_score=excluded.quality_score, "
+                "components_json=excluded.components_json, "
+                "scored_at=excluded.scored_at",
+                (
+                    r["id"], score, json.dumps(components), _iso(now),
+                ),
+            )
+            scored.append(r["id"])
+        scores_conn.commit()
+        return scored
+    finally:
+        scores_conn.close()

--- a/services/prism-service/app/services/scoring_service.py
+++ b/services/prism-service/app/services/scoring_service.py
@@ -1,0 +1,76 @@
+"""Scoring service — Layer-A quantitative composite score for task outcomes.
+
+Pure functions only (no I/O). The daemon in LL-04 walks git + test state
+and hands pre-computed signals here; this module turns those signals
+into a single quality score that Brain.best_prompt can consume.
+
+Parent task: 37932f3f · LL-02.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+# Penalty coefficients. Kept as module constants so LL-05's CUPED layer
+# can reason about expected score distributions without reimplementing
+# the math.
+_GATE_RETRY_PENALTY = 0.10         # per retry, capped at 5 retries
+_GATE_RETRY_CAP = 5
+_TESTS_RED_PENALTY = 0.30          # tests red on merge: big hit
+_CHURN_PENALTY_PER_FILE = 0.05     # per file re-edited within 14d, capped at 10
+_CHURN_CAP = 10
+_FOLLOWUP_PENALTY_PER_TASK = 0.15  # per follow-up fix task within 14d, capped at 3
+_FOLLOWUP_CAP = 3
+_REVERT_FLOOR = 0.1                # hard negative — revert proves it didn't work
+
+
+def composite_score(components: dict[str, Any]) -> Optional[float]:
+    """Return a Layer-A quality score in [0, 1] or ``None`` if unscorable.
+
+    Expected keys in ``components``:
+      * merged_to_main (bool) — binary gate. False returns ``None``; an
+        unmerged task has no outcome yet.
+      * reverted_within_14d (bool) — hard negative. A revert is strong
+        evidence the code didn't survive contact with the codebase.
+      * gate_retry_count (int) — linear penalty per retry, capped.
+      * tests_green_on_merge (bool) — red tests on merge knock a chunk
+        off the score.
+      * files_re_edited_within_14d (int) — churn proxy. Each file
+        re-edited reduces the score linearly, capped.
+      * followup_fix_tasks_within_14d (int) — the strongest "it didn't
+        stick" signal. Each follow-up drops the score linearly, capped.
+
+    Pure: no DB access, no clock, no side effects.
+    """
+    if not components.get("merged_to_main"):
+        return None
+
+    # Revert is a hard negative that dominates any other positive signal.
+    # A reverted PR with perfect retries+tests still scores below
+    # ``_REVERT_FLOOR`` — that's the whole point.
+    if components.get("reverted_within_14d"):
+        return _REVERT_FLOOR
+
+    score = 1.0
+
+    retries = min(
+        int(components.get("gate_retry_count") or 0), _GATE_RETRY_CAP
+    )
+    score -= _GATE_RETRY_PENALTY * retries
+
+    if not components.get("tests_green_on_merge", True):
+        score -= _TESTS_RED_PENALTY
+
+    churn = min(
+        int(components.get("files_re_edited_within_14d") or 0), _CHURN_CAP
+    )
+    score -= _CHURN_PENALTY_PER_FILE * churn
+
+    followups = min(
+        int(components.get("followup_fix_tasks_within_14d") or 0),
+        _FOLLOWUP_CAP,
+    )
+    score -= _FOLLOWUP_PENALTY_PER_TASK * followups
+
+    return max(0.0, min(1.0, score))

--- a/services/prism-service/app/services/task_service.py
+++ b/services/prism-service/app/services/task_service.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Callable, Optional
 
 from app.models.task import Task, TaskHistory
+
+
+# Callable signature for LL-03's embedder injection. Returns packed
+# float32 bytes suitable for the `tasks.embedding` BLOB column, or
+# ``None`` when no embedder is available (offline, first-session).
+EmbedFn = Callable[[str], Optional[bytes]]
 
 
 _CREATE_TASKS_SQL = """
@@ -54,12 +60,41 @@ _LL_TASK_COLUMNS: list[tuple[str, str]] = [
 class TaskService:
     """Manages the tasks.db lifecycle and CRUD operations."""
 
-    def __init__(self, db_path: str) -> None:
+    def __init__(self, db_path: str, embed_fn: Optional[EmbedFn] = None) -> None:
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.executescript(_CREATE_TASKS_SQL)
         self._migrate_task_columns()
+        # Optional — when provided, task create/update embeds
+        # ``title + "\n" + description`` into ``tasks.embedding`` so
+        # LL-06's cosine-similarity retrieval has vectors to work with.
+        # Left as None in contexts where the embedder isn't loaded
+        # (e.g. hook smoke tests); create/update still succeeds, the
+        # row just lacks an embedding until re-indexed.
+        self._embed_fn: Optional[EmbedFn] = embed_fn
+
+    # ------------------------------------------------------------------
+    # LL-03 helper: write an embedding for the given task if we can
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _embedding_text(title: str, description: str) -> str:
+        return f"{title}\n{description}".strip()
+
+    def _store_embedding(self, task_id: str, title: str, description: str) -> None:
+        if self._embed_fn is None:
+            return
+        try:
+            blob = self._embed_fn(self._embedding_text(title, description))
+        except Exception:
+            blob = None
+        if blob is None:
+            return
+        self._db.execute(
+            "UPDATE tasks SET embedding=? WHERE id=?", (blob, task_id)
+        )
+        self._db.commit()
 
     def _migrate_task_columns(self) -> None:
         """Backfill LL-01 columns on tasks.db files created before the
@@ -162,6 +197,10 @@ class TaskService:
         )
         self._db.commit()
         self._record_history(task.id, "created", f"title={title!r}")
+        # LL-03: embed title+description so LL-06's similarity retrieval
+        # has something to search over. Silent on embedder-offline —
+        # the row still exists, just without a vector.
+        self._store_embedding(task.id, task.title, task.description)
         return task
 
     def get(self, task_id: str) -> Optional[Task]:
@@ -254,6 +293,10 @@ class TaskService:
         )
         self._db.commit()
         self._record_history(task.id, "updated", "; ".join(changes))
+        # LL-03: re-embed only when the title or description changed.
+        # Priority / status / tag-only updates don't move the vector.
+        if "title" in kwargs or "description" in kwargs:
+            self._store_embedding(task.id, task.title, task.description)
         return task
 
     # ------------------------------------------------------------------

--- a/services/prism-service/app/services/task_service.py
+++ b/services/prism-service/app/services/task_service.py
@@ -24,7 +24,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     completed_at TEXT DEFAULT '',
     blocked_reason TEXT DEFAULT '',
     dependencies TEXT DEFAULT '[]',
-    tags TEXT DEFAULT '[]'
+    tags TEXT DEFAULT '[]',
+    embedding BLOB,
+    merge_sha TEXT,
+    merged_at TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_history (
@@ -39,6 +42,15 @@ CREATE TABLE IF NOT EXISTS task_history (
 """
 
 
+# Columns added by LL-01 (learning-loop schema migration). Applied via
+# ALTER TABLE on existing DBs so older task rows don't need rewriting.
+_LL_TASK_COLUMNS: list[tuple[str, str]] = [
+    ("embedding", "BLOB"),
+    ("merge_sha", "TEXT"),
+    ("merged_at", "TEXT"),
+]
+
+
 class TaskService:
     """Manages the tasks.db lifecycle and CRUD operations."""
 
@@ -47,6 +59,26 @@ class TaskService:
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.executescript(_CREATE_TASKS_SQL)
+        self._migrate_task_columns()
+
+    def _migrate_task_columns(self) -> None:
+        """Backfill LL-01 columns on tasks.db files created before the
+        learning-loop schema landed. Idempotent: ALTER is only issued
+        when the column is actually missing."""
+        existing = {
+            row[1]
+            for row in self._db.execute("PRAGMA table_info(tasks)").fetchall()
+        }
+        for col, col_type in _LL_TASK_COLUMNS:
+            if col in existing:
+                continue
+            try:
+                self._db.execute(
+                    f"ALTER TABLE tasks ADD COLUMN {col} {col_type}"
+                )
+                self._db.commit()
+            except sqlite3.OperationalError:
+                pass
 
     # ------------------------------------------------------------------
     # Helpers

--- a/services/prism-service/tests/unit/test_best_prompt_similar.py
+++ b/services/prism-service/tests/unit/test_best_prompt_similar.py
@@ -1,0 +1,210 @@
+"""LL-06 tests — Brain.best_prompt(similar_to_task_id=...) cosine-similarity extension.
+
+Given a new task, rank prompt variants by how well they performed on
+similar past tasks (cosine similarity on task embeddings, weighted by
+cuped_score from task_quality_rollup).
+
+Parent task: 37932f3f · Sub-task LL-06.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _pack(vec: list[float]) -> bytes:
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def _mk(tmp_path):
+    from app.engines.brain_engine import Brain
+    from app.services.task_service import TaskService
+
+    tasks_db = str(tmp_path / "tasks.db")
+    brain = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+        tasks_db=tasks_db,
+    )
+    tasks = TaskService(tasks_db)
+    return brain, tasks
+
+
+def _seed_task(tasks, *, task_id, title, embedding: list[float]):
+    """Insert a task row directly (bypass embed_fn) with the given vector."""
+    t = tasks.create(title=title)
+    tasks._db.execute(
+        "UPDATE tasks SET id=?, embedding=? WHERE id=?",
+        (task_id, _pack(embedding), t.id),
+    )
+    tasks._db.commit()
+    return task_id
+
+
+def _seed_variant_outcome(brain, *, task_id, prompt_id, persona, step_id,
+                         quality=0.8, cuped=None):
+    """Wire up a task_variants + task_quality_rollup pair for the scorer."""
+    brain._scores.execute(
+        "INSERT INTO task_variants (task_id, step_id, prompt_id, persona) "
+        "VALUES (?, ?, ?, ?)",
+        (task_id, step_id, prompt_id, persona),
+    )
+    brain._scores.execute(
+        "INSERT OR REPLACE INTO task_quality_rollup "
+        "(task_id, quality_score, cuped_score) VALUES (?, ?, ?)",
+        (task_id, quality, cuped if cuped is not None else quality),
+    )
+    brain._scores.commit()
+
+
+# ----------------------------------------------------------------------
+
+
+def test_similarity_top_k_returns_sorted(tmp_path):
+    """Internal helper returns ids sorted by cosine desc, limited to k."""
+    from app.engines.brain_engine import _similar_task_ids
+
+    import sqlite3
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, embedding BLOB)"
+    )
+    # Seed: query vec = (1,0); near = (0.99, 0.01); far = (0, 1)
+    conn.execute("INSERT INTO tasks VALUES (?, ?)", ("q", _pack([1.0, 0.0])))
+    conn.execute("INSERT INTO tasks VALUES (?, ?)", ("near", _pack([0.99, 0.01])))
+    conn.execute("INSERT INTO tasks VALUES (?, ?)", ("far", _pack([0.0, 1.0])))
+    conn.execute("INSERT INTO tasks VALUES (?, ?)", ("mid", _pack([0.7, 0.7])))
+    conn.commit()
+    ordered = _similar_task_ids(conn, "q", k=3)
+    # Query excluded from its own neighbors; near first, mid second, far last.
+    assert [t[0] for t in ordered] == ["near", "mid", "far"]
+    # Similarities strictly decreasing
+    sims = [t[1] for t in ordered]
+    assert sims == sorted(sims, reverse=True)
+
+
+def test_best_prompt_falls_back_to_global_when_no_similar_task(tmp_path):
+    """No task embeddings → existing score_aggregates path is used."""
+    brain, tasks = _mk(tmp_path)
+    # Seed score_aggregates so the fallback returns something
+    brain._scores.execute(
+        "INSERT INTO score_aggregates (prompt_id, persona, step_id, avg_score, total_runs) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("fallback/default", "dev", "green", 0.9, 10),
+    )
+    brain._scores.commit()
+    result = brain.best_prompt(
+        persona="dev", step_id="green",
+        similar_to_task_id="no-such-task",
+    )
+    assert result == "fallback/default"
+
+
+def test_best_prompt_excludes_below_threshold_variants(tmp_path):
+    """Variants with fewer than 5 observations across similar tasks
+    don't influence ranking — they're correlational noise."""
+    brain, tasks = _mk(tmp_path)
+
+    # New task (the one we're ranking for)
+    _seed_task(tasks, task_id="new-t", title="refactor x",
+               embedding=[1.0, 0.0])
+    # 10 similar tasks, all using variant_A, all high quality
+    for i in range(10):
+        tid = f"sim-{i}"
+        _seed_task(tasks, task_id=tid, title=f"refactor {i}",
+                   embedding=[0.95, 0.1])
+        _seed_variant_outcome(brain, task_id=tid, prompt_id="variant_A",
+                              persona="dev", step_id="green", quality=0.9)
+    # 3 similar tasks using variant_B, quality 0.95 (would win on avg,
+    # but below the n=5 threshold so must be excluded)
+    for i in range(3):
+        tid = f"simB-{i}"
+        _seed_task(tasks, task_id=tid, title=f"refactor B{i}",
+                   embedding=[0.94, 0.12])
+        _seed_variant_outcome(brain, task_id=tid, prompt_id="variant_B",
+                              persona="dev", step_id="green", quality=0.95)
+
+    choice = brain.best_prompt(
+        persona="dev", step_id="green",
+        similar_to_task_id="new-t",
+    )
+    assert choice == "variant_A", (
+        f"Low-n variant_B ({0.95} avg but only 3 obs) must not beat "
+        f"variant_A (0.9 avg with 10 obs); got {choice!r}"
+    )
+
+
+def test_best_prompt_uses_similar_tasks(tmp_path):
+    """20 refactor tasks: A wins 15, B wins 5 — new refactor → A."""
+    brain, tasks = _mk(tmp_path)
+    _seed_task(tasks, task_id="new-t", title="refactor new",
+               embedding=[1.0, 0.0])
+    # 15 similar tasks use variant_A, high quality
+    for i in range(15):
+        tid = f"a-{i}"
+        _seed_task(tasks, task_id=tid, title=f"refactor a{i}",
+                   embedding=[0.97 + 0.001 * i, 0.05])
+        _seed_variant_outcome(brain, task_id=tid, prompt_id="variant_A",
+                              persona="dev", step_id="green", quality=0.88)
+    # 5 similar tasks use variant_B, lower quality
+    for i in range(5):
+        tid = f"b-{i}"
+        _seed_task(tasks, task_id=tid, title=f"refactor b{i}",
+                   embedding=[0.92, 0.1])
+        _seed_variant_outcome(brain, task_id=tid, prompt_id="variant_B",
+                              persona="dev", step_id="green", quality=0.72)
+
+    choice = brain.best_prompt(
+        persona="dev", step_id="green",
+        similar_to_task_id="new-t",
+    )
+    assert choice == "variant_A"
+
+
+def test_best_prompt_ignores_dissimilar_tasks(tmp_path):
+    """When asked about a refactor task, bug-fix tasks shouldn't count.
+
+    Seed two clusters:
+      * 10 "refactor" tasks near (1,0) where variant_A dominates
+      * 10 "bug" tasks near (0,1) where variant_B dominates
+    Query a new refactor task — variant_A should win even though
+    variant_B has a higher overall avg across the whole table.
+    """
+    brain, tasks = _mk(tmp_path)
+    _seed_task(tasks, task_id="new-refactor", title="refactor thing",
+               embedding=[1.0, 0.0])
+
+    # Refactor cluster — A with decent quality
+    for i in range(10):
+        tid = f"ref-{i}"
+        _seed_task(tasks, task_id=tid, title=f"refactor {i}",
+                   embedding=[0.98, 0.05])
+        _seed_variant_outcome(brain, task_id=tid, prompt_id="variant_A",
+                              persona="dev", step_id="green", quality=0.75)
+    # Bug cluster — B with very high quality (would dominate globally)
+    for i in range(10):
+        tid = f"bug-{i}"
+        _seed_task(tasks, task_id=tid, title=f"fix bug {i}",
+                   embedding=[0.05, 0.98])
+        _seed_variant_outcome(brain, task_id=tid, prompt_id="variant_B",
+                              persona="dev", step_id="green", quality=0.98)
+
+    choice = brain.best_prompt(
+        persona="dev", step_id="green",
+        similar_to_task_id="new-refactor",
+    )
+    assert choice == "variant_A", (
+        f"refactor-cluster winner expected even though bug cluster has "
+        f"a higher global avg; got {choice!r}"
+    )

--- a/services/prism-service/tests/unit/test_consolidation_queue.py
+++ b/services/prism-service/tests/unit/test_consolidation_queue.py
@@ -1,0 +1,295 @@
+"""LL-07 tests — JanitorService queue operations, readiness policy,
+retry/backoff, and brief contract.
+
+Parent task: 37932f3f-9cd4-40bf-9df3-e9db19fcc88d · Sub-task LL-07
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _mk_service(tmp_path: Path, now=None):
+    """Create a JanitorService against a fresh scores.db. Seeds schema
+    via Brain() so the tables LL-01 added exist."""
+    from app.engines.brain_engine import Brain
+    from app.services.janitor_service import JanitorService
+
+    scores_db = str(tmp_path / "scores.db")
+    # Brain init installs the schema; we don't need the Brain instance
+    # to live beyond bootstrap.
+    Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=scores_db,
+    )
+    clock = _Clock(now or datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc))
+    svc = JanitorService(scores_db, clock=clock)
+    return svc, clock
+
+
+class _Clock:
+    """Monotonically advancing test clock."""
+
+    def __init__(self, start: datetime) -> None:
+        self._t = start
+
+    def __call__(self) -> datetime:
+        return self._t
+
+    def advance(self, **delta) -> None:
+        self._t = self._t + timedelta(**delta)
+
+
+# ----------------------------------------------------------------------
+# enqueue
+# ----------------------------------------------------------------------
+
+
+def test_enqueue_idempotent_within_10min(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    a = svc.enqueue(task_id="T-42", trigger="session_end")
+    clock.advance(minutes=5)
+    b = svc.enqueue(task_id="T-42", trigger="session_end")
+    assert a == b, "same (task_id, trigger) within 10 min must return same id"
+
+
+def test_enqueue_allows_new_candidate_after_debounce(tmp_path):
+    """Sanity: outside the 10 min window, a new enqueue is a new row."""
+    svc, clock = _mk_service(tmp_path)
+    a = svc.enqueue(task_id="T-42", trigger="session_end")
+    clock.advance(minutes=11)
+    b = svc.enqueue(task_id="T-42", trigger="session_end")
+    assert a != b
+
+
+# ----------------------------------------------------------------------
+# mark_stale
+# ----------------------------------------------------------------------
+
+
+def test_mark_stale_flips_overlapping_candidates(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    cid = svc.enqueue(
+        task_id="T-42", trigger="task_done",
+        scope={"task_ids": ["T-42"], "memory_ids": [], "file_paths": []},
+    )
+    # A later session touches T-42 — candidate should be flipped to stale
+    staled = svc.mark_stale(
+        session_id="S-1",
+        scope={"task_ids": ["T-42"], "memory_ids": [], "file_paths": []},
+    )
+    assert cid in staled
+    row = svc._db.execute(
+        "SELECT status FROM consolidation_candidates WHERE id=?", (cid,)
+    ).fetchone()
+    assert row["status"] == "stale"
+
+
+def test_mark_stale_requeues_fresh(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    original = svc.enqueue(
+        task_id="T-42", trigger="task_done",
+        scope={"task_ids": ["T-42"]},
+    )
+    svc.mark_stale(session_id="S-1", scope={"task_ids": ["T-42"]})
+    # The stale candidate should have a fresh sibling with the same scope
+    rows = svc._db.execute(
+        "SELECT id, status FROM consolidation_candidates "
+        "WHERE task_id=? ORDER BY queued_at",
+        ("T-42",),
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["id"] == original and rows[0]["status"] == "stale"
+    assert rows[1]["status"] == "pending"
+
+
+def test_mark_stale_preserves_completed(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    cid = svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    # Simulate a completed run
+    svc._db.execute(
+        "UPDATE consolidation_candidates SET status='completed', completed_at=? "
+        "WHERE id=?",
+        (clock().isoformat(), cid),
+    )
+    svc._db.commit()
+    staled = svc.mark_stale(session_id="S-1", scope={"task_ids": ["T-42"]})
+    assert cid not in staled
+    row = svc._db.execute(
+        "SELECT status FROM consolidation_candidates WHERE id=?", (cid,)
+    ).fetchone()
+    assert row["status"] == "completed"
+
+
+# ----------------------------------------------------------------------
+# check
+# ----------------------------------------------------------------------
+
+
+def test_check_not_ready_before_1h(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    clock.advance(minutes=30)
+    res = svc.check(session_id="S-next")
+    assert res["ready"] is False
+    assert res["brief"] is None
+
+
+def test_check_skips_stale_picks_fresh(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    # Enqueue first, then stale and requeue
+    svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    svc.mark_stale(session_id="S-1", scope={"task_ids": ["T-42"]})
+    # Advance past the min-age gate
+    clock.advance(hours=2)
+    res = svc.check(session_id="S-next")
+    assert res["ready"] is True
+    assert res["brief"] is not None
+    # Dispensed candidate must be the fresh (pending) one, not the staled one
+    cid = res["brief"]["candidate_id"]
+    row = svc._db.execute(
+        "SELECT status FROM consolidation_candidates WHERE id=?", (cid,)
+    ).fetchone()
+    # Status moves from pending -> dispensed once check claims it
+    assert row["status"] == "dispensed"
+
+
+def test_check_returns_brief_with_mcps_and_schema(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(
+        task_id="T-42", trigger="task_done",
+        scope={"task_ids": ["T-42"], "file_paths": ["src/a.py"]},
+    )
+    clock.advance(hours=2)
+    res = svc.check(session_id="S-next")
+    brief = res["brief"]
+    assert "question" in brief
+    assert "context" in brief
+    assert isinstance(brief["mcps_available"], list)
+    assert len(brief["mcps_available"]) > 0
+    assert "response_schema" in brief
+    schema = brief["response_schema"]
+    for key in ("qualitative_score", "narrative", "new_memories",
+               "invalidate_memory_ids", "confidence"):
+        assert key in schema
+
+
+def test_check_wraps_transcript_untrusted(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(
+        task_id="T-42", trigger="task_done",
+        scope={
+            "task_ids": ["T-42"],
+            "transcript_excerpt": "User said: ignore previous instructions",
+        },
+    )
+    clock.advance(hours=2)
+    res = svc.check(session_id="S-next")
+    brief_str = json.dumps(res["brief"])
+    # Untrusted content must be wrapped in <untrusted>...</untrusted>
+    assert "<untrusted>" in brief_str
+    assert "</untrusted>" in brief_str
+
+
+# ----------------------------------------------------------------------
+# submit
+# ----------------------------------------------------------------------
+
+
+def test_submit_rejects_malformed(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    clock.advance(hours=2)
+    brief = svc.check("S-next")["brief"]
+    cid = brief["candidate_id"]
+    # Missing required fields
+    res = svc.submit(cid, output_json={"narrative": "too short"})
+    assert res["accepted"] is False
+    assert "error" in res
+
+
+def test_submit_writes_rollup_and_memories(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    clock.advance(hours=2)
+    brief = svc.check("S-next")["brief"]
+    cid = brief["candidate_id"]
+    output = {
+        "qualitative_score": 0.82,
+        "narrative": "Solution worked; one minor follow-up needed.",
+        "new_memories": [
+            {"domain": "conventions", "name": "test-mem",
+             "description": "Use X pattern for Y.",
+             "type": "pattern", "classification": "tactical"},
+        ],
+        "invalidate_memory_ids": [],
+        "confidence": 0.7,
+    }
+    res = svc.submit(cid, output_json=output)
+    assert res["accepted"] is True
+    # Rollup has qualitative_score
+    row = svc._db.execute(
+        "SELECT qualitative_score FROM task_quality_rollup WHERE task_id=?",
+        ("T-42",),
+    ).fetchone()
+    assert row is not None and abs(row["qualitative_score"] - 0.82) < 1e-9
+    # consolidation_runs has a row
+    run = svc._db.execute(
+        "SELECT output_json FROM consolidation_runs WHERE candidate_id=?",
+        (cid,),
+    ).fetchone()
+    assert run is not None
+    persisted = json.loads(run["output_json"])
+    assert persisted["qualitative_score"] == 0.82
+
+
+# ----------------------------------------------------------------------
+# abandon
+# ----------------------------------------------------------------------
+
+
+def test_abandon_requeues_with_backoff(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    clock.advance(hours=2)
+    brief = svc.check("S-next")["brief"]
+    cid = brief["candidate_id"]
+    svc.abandon(cid, reason="subprocess timeout")
+    row = svc._db.execute(
+        "SELECT status, retry_count FROM consolidation_candidates WHERE id=?",
+        (cid,),
+    ).fetchone()
+    assert row["retry_count"] == 1
+    assert row["status"] == "pending"
+    # Immediate re-check should NOT redispense (backoff window)
+    res = svc.check("S-next-2")
+    assert res["ready"] is False or res["brief"]["candidate_id"] != cid
+
+
+def test_abandon_hard_limit_3(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    svc.enqueue(task_id="T-42", trigger="task_done", scope={"task_ids": ["T-42"]})
+    clock.advance(hours=2)
+    for _ in range(3):
+        brief = svc.check("S-next")["brief"]
+        assert brief is not None
+        svc.abandon(brief["candidate_id"], reason="fail")
+        clock.advance(minutes=10)  # clear backoff window
+    row = svc._db.execute(
+        "SELECT status, retry_count FROM consolidation_candidates "
+        "WHERE task_id=?",
+        ("T-42",),
+    ).fetchone()
+    assert row["status"] == "abandoned"
+    assert row["retry_count"] == 3

--- a/services/prism-service/tests/unit/test_cuped.py
+++ b/services/prism-service/tests/unit/test_cuped.py
@@ -1,0 +1,138 @@
+"""LL-05 tests — CUPED residualization + 90-day operator baseline.
+
+CUPED (Deng/Xu/Kohavi/Walker 2013) uses a pre-experiment covariate to
+reduce variance in post-experiment outcome measurements. Here the
+covariate is each operator's 90-day rolling merge rate; subtracting
+the operator-specific deviation from the global baseline before
+attributing a quality score to a variant keeps operator skill from
+getting credited to the variant.
+
+Parent task: 37932f3f · Sub-task LL-05.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def test_cuped_residualization_against_known_covariate():
+    """Verify the CUPED identity directly against Deng/Xu/Kohavi 2013.
+
+    Given Y=0.9 (raw quality), X=0.80 (operator baseline), mean(X)=0.55
+    (global), theta=1.0 →  Y_cuped = Y - 1.0 * (X - mean(X))
+                                   = 0.9 - (0.80 - 0.55) = 0.65.
+    """
+    from app.services.scoring_service import cuped_residualize
+    adjusted = cuped_residualize(
+        quality_score=0.9,
+        operator_baseline=0.80,
+        global_baseline=0.55,
+        theta=1.0,
+    )
+    assert abs(adjusted - 0.65) < 1e-9
+
+
+def test_cuped_zero_samples_falls_back_to_raw_score():
+    """When the operator has 0 prior tasks, we have no covariate — CUPED
+    degrades to the identity: Y_cuped = Y."""
+    from app.services.scoring_service import cuped_residualize
+    # Operator baseline == global baseline → (X - mean(X)) == 0 → no
+    # adjustment. This is the defensive path: when we don't know an
+    # operator's history, assume they're average.
+    adjusted = cuped_residualize(
+        quality_score=0.77,
+        operator_baseline=0.55,   # == global
+        global_baseline=0.55,
+        theta=1.0,
+    )
+    assert abs(adjusted - 0.77) < 1e-9
+
+
+def test_cuped_isolates_operator_effect():
+    """Two operators with different baselines but the same raw quality
+    score on the same variant should produce residuals that are
+    comparable (close to each other) — otherwise the variant would be
+    falsely credited/penalized for operator skill."""
+    from app.services.scoring_service import cuped_residualize
+
+    global_baseline = 0.60
+    raw = 0.85
+
+    # Alice: high-skill operator (90% baseline merge rate)
+    alice_cuped = cuped_residualize(
+        quality_score=raw,
+        operator_baseline=0.90,
+        global_baseline=global_baseline,
+        theta=1.0,
+    )
+    # Bob: newer operator (30% baseline)
+    bob_cuped = cuped_residualize(
+        quality_score=raw,
+        operator_baseline=0.30,
+        global_baseline=global_baseline,
+        theta=1.0,
+    )
+    # Post-adjustment, the per-variant credit differs only by the
+    # difference between their baselines — which is the POINT of CUPED:
+    # residualize away the operator-skill component.
+    #
+    # What we assert: the *spread* of cuped scores (alice vs bob) is
+    # much smaller than the spread of raw scores would imply if we
+    # naively penalized bob for his weaker track record. Specifically,
+    # each residual moves away from the raw score by (X - mean(X)),
+    # and the check is that residuals land within 20% of each other's
+    # deviation from raw.
+    alice_delta = abs(alice_cuped - raw)
+    bob_delta = abs(bob_cuped - raw)
+    # Both deltas should be non-trivially >0 (we're adjusting).
+    assert alice_delta > 0.05
+    assert bob_delta > 0.05
+    # And the adjustments should reflect the operator's deviation from
+    # the global, not the raw score — meaning residuals should be on
+    # opposite sides of raw by comparable amounts.
+    assert (alice_cuped < raw) and (bob_cuped > raw), (
+        "high-baseline operator residual should drop, low should rise"
+    )
+
+
+def test_compute_operator_baseline_returns_merge_rate_and_sample_n(tmp_path):
+    """Per-operator 90-day rolling merge rate."""
+    from app.services.scoring_service import compute_operator_baseline
+    from app.services.task_service import TaskService
+
+    svc = TaskService(str(tmp_path / "tasks.db"))
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+
+    # Alice: 3 tasks, 2 merged
+    for i in range(3):
+        t = svc.create(title=f"a{i}", assigned_agent="alice")
+        if i < 2:
+            svc._db.execute(
+                "UPDATE tasks SET merge_sha=?, merged_at=? WHERE id=?",
+                ("abc", (now - timedelta(days=10)).isoformat(), t.id),
+            )
+    svc._db.commit()
+
+    merge_rate, n = compute_operator_baseline(
+        svc, "alice", window_days=90, now=now,
+    )
+    assert n == 3
+    assert abs(merge_rate - (2 / 3)) < 1e-9
+
+
+def test_compute_operator_baseline_zero_samples(tmp_path):
+    """Unknown operator returns (0.0, 0)."""
+    from app.services.scoring_service import compute_operator_baseline
+    from app.services.task_service import TaskService
+
+    svc = TaskService(str(tmp_path / "tasks.db"))
+    merge_rate, n = compute_operator_baseline(svc, "unknown", window_days=90)
+    assert merge_rate == 0.0
+    assert n == 0

--- a/services/prism-service/tests/unit/test_ll_schema.py
+++ b/services/prism-service/tests/unit/test_ll_schema.py
@@ -1,0 +1,173 @@
+"""LL-01 tests — learning-loop schema migrations.
+
+Verifies that:
+  * New scores.db tables are created fresh
+  * Migrations are idempotent (second run is no-op, data preserved)
+  * `tasks` gains nullable columns (embedding, merge_sha, merged_at)
+  * High-frequency join columns have indexes
+  * `memory_meta` sidecar table exists (JSONL is primary, SQL for queryable metadata)
+
+Parent task: 37932f3f-9cd4-40bf-9df3-e9db19fcc88d · Sub-task LL-01
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make ``app`` importable without installing the service as a package.
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _init_brain(db_dir: Path):
+    from app.engines.brain_engine import Brain
+    return Brain(
+        brain_db=str(db_dir / "brain.db"),
+        graph_db=str(db_dir / "graph.db"),
+        scores_db=str(db_dir / "scores.db"),
+    )
+
+
+def _init_tasks(db_dir: Path):
+    from app.services.task_service import TaskService
+    return TaskService(str(db_dir / "tasks.db"))
+
+
+def _tables(conn) -> set[str]:
+    return {
+        row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+
+def _columns(conn, table: str) -> dict[str, dict]:
+    """Return {column_name: PRAGMA-info-row-as-dict}."""
+    out: dict[str, dict] = {}
+    for row in conn.execute(f"PRAGMA table_info({table})").fetchall():
+        # row: (cid, name, type, notnull, dflt_value, pk)
+        out[row[1]] = {
+            "type": row[2], "notnull": row[3], "dflt_value": row[4], "pk": row[5],
+        }
+    return out
+
+
+def _indexes(conn, table: str) -> list[tuple[str, str]]:
+    """Return [(index_name, sql_definition)] for all indexes on a table."""
+    return [
+        (row[0], row[1] or "")
+        for row in conn.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type='index' AND tbl_name=?",
+            (table,),
+        ).fetchall()
+    ]
+
+
+_NEW_SCORES_TABLES = (
+    "task_sessions",
+    "task_variants",
+    "task_quality_rollup",
+    "operator_baselines",
+    "consolidation_candidates",
+    "consolidation_runs",
+    "memory_meta",
+)
+
+
+def test_tables_created_on_fresh_db(tmp_path):
+    """Every LL-01 table is present after the first Brain init."""
+    brain = _init_brain(tmp_path)
+    try:
+        tables = _tables(brain._scores)
+        for t in _NEW_SCORES_TABLES:
+            assert t in tables, f"{t} missing from fresh scores.db"
+    finally:
+        brain._scores.close()
+        brain._brain.close()
+        brain._graph.close()
+
+
+def test_migration_idempotent(tmp_path):
+    """Re-invoking schema init is a no-op and never raises."""
+    brain = _init_brain(tmp_path)
+    try:
+        brain._init_scores_schema()
+        brain._init_scores_schema()
+        tables = _tables(brain._scores)
+        for t in _NEW_SCORES_TABLES:
+            assert t in tables
+    finally:
+        brain._scores.close()
+        brain._brain.close()
+        brain._graph.close()
+
+
+def test_tables_unchanged_on_existing_db(tmp_path):
+    """Reopening a Brain pointing at existing DBs preserves rows."""
+    brain1 = _init_brain(tmp_path)
+    try:
+        brain1._scores.execute(
+            "INSERT INTO task_quality_rollup(task_id, quality_score) "
+            "VALUES (?, ?)",
+            ("t-probe", 0.77),
+        )
+        brain1._scores.commit()
+    finally:
+        brain1._scores.close()
+        brain1._brain.close()
+        brain1._graph.close()
+
+    brain2 = _init_brain(tmp_path)
+    try:
+        row = brain2._scores.execute(
+            "SELECT quality_score FROM task_quality_rollup WHERE task_id=?",
+            ("t-probe",),
+        ).fetchone()
+        assert row is not None
+        assert abs(row[0] - 0.77) < 1e-9
+    finally:
+        brain2._scores.close()
+        brain2._brain.close()
+        brain2._graph.close()
+
+
+def test_new_columns_nullable_for_backward_compat(tmp_path):
+    """New `tasks` columns must be nullable so legacy rows keep working."""
+    tasks = _init_tasks(tmp_path)
+    try:
+        cols = _columns(tasks._db, "tasks")
+        for col in ("embedding", "merge_sha", "merged_at"):
+            assert col in cols, f"{col} missing from tasks"
+            # notnull flag == 0 means the column allows NULL
+            assert cols[col]["notnull"] == 0, (
+                f"tasks.{col} must be nullable for backward compatibility"
+            )
+    finally:
+        tasks._db.close()
+
+
+def test_indexes_present_on_task_id_and_session_id(tmp_path):
+    """High-frequency join columns have indexes (else scans explode)."""
+    brain = _init_brain(tmp_path)
+    try:
+        ts_idx_sql = " ".join(sql for _, sql in _indexes(brain._scores, "task_sessions"))
+        cc_idx_sql = " ".join(sql for _, sql in _indexes(brain._scores, "consolidation_candidates"))
+        tv_idx_sql = " ".join(sql for _, sql in _indexes(brain._scores, "task_variants"))
+
+        assert "session_id" in ts_idx_sql.lower(), (
+            f"task_sessions needs session_id index; got {ts_idx_sql!r}"
+        )
+        assert "session_id" in cc_idx_sql.lower(), (
+            f"consolidation_candidates needs session_id index; got {cc_idx_sql!r}"
+        )
+        assert "task_id" in tv_idx_sql.lower(), (
+            f"task_variants needs task_id index; got {tv_idx_sql!r}"
+        )
+    finally:
+        brain._scores.close()
+        brain._brain.close()
+        brain._graph.close()

--- a/services/prism-service/tests/unit/test_mcp_augmentation.py
+++ b/services/prism-service/tests/unit/test_mcp_augmentation.py
@@ -1,0 +1,118 @@
+"""LL-09 tests — MCP-response augmentation middleware.
+
+When a reflection candidate is pending, every PRISM MCP tool response
+gets prefixed with a nudge header pointing at the prism-reflect sub-
+agent. Rate-limited per session (5 min). Disable via env.
+
+Parent task: 37932f3f · Sub-task LL-09.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    from app import config as cfg
+    from app import project_context as pc
+    monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    pc._contexts.clear()
+    monkeypatch.delenv("PRISM_MCP_AUGMENT_NUDGES", raising=False)
+    yield "test-ll-09"
+    pc._contexts.clear()
+
+
+def _call(tool_name, arguments=None, project_id="test-ll-09"):
+    from app.mcp.tools import handle_tool
+    return asyncio.run(
+        handle_tool(tool_name, arguments or {}, project_id=project_id)
+    )
+
+
+def _text(result):
+    assert len(result) == 1
+    return result[0].text
+
+
+def _seed_pending(project_id, task_id="T-pending"):
+    """Stamp a pending candidate so augmentation has something to fire on."""
+    _call("janitor_enqueue", {
+        "task_id": task_id,
+        "trigger": "task_done",
+        "scope": {"task_ids": [task_id]},
+    }, project_id=project_id)
+
+
+# ----------------------------------------------------------------------
+
+
+def test_mcp_response_augmented_when_pending(project):
+    _seed_pending(project)
+    out = _text(_call("task_list", project_id=project))
+    # Prefix should be present
+    assert "PRISM_REFLECTION_PENDING" in out, (
+        "pending candidate exists — response should be prefixed with nudge"
+    )
+    # Original response body (JSON array) still present after the
+    # delimiter.
+    assert "---" in out
+
+
+def test_mcp_response_not_augmented_when_none(project):
+    # No candidates seeded
+    out = _text(_call("task_list", project_id=project))
+    assert "PRISM_REFLECTION_PENDING" not in out
+
+
+def test_augmentation_rate_limited_5min_per_session(project):
+    _seed_pending(project)
+    first = _text(_call("task_list", project_id=project))
+    assert "PRISM_REFLECTION_PENDING" in first
+    # Second call within 5 min — should NOT re-nudge
+    second = _text(_call("task_list", project_id=project))
+    assert "PRISM_REFLECTION_PENDING" not in second, (
+        "second call within the 5-min rate-limit window should not re-nudge"
+    )
+
+
+def test_augmentation_disabled_via_env(project, monkeypatch):
+    monkeypatch.setenv("PRISM_MCP_AUGMENT_NUDGES", "false")
+    _seed_pending(project)
+    out = _text(_call("task_list", project_id=project))
+    assert "PRISM_REFLECTION_PENDING" not in out
+
+
+def test_augmentation_adds_under_10ms_overhead(project):
+    # Baseline: no pending candidates
+    n = 10
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _call("task_list", project_id=project)
+    baseline = (time.perf_counter() - t0) / n
+
+    # With pending candidate — augmentation kicks in
+    _seed_pending(project)
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _call("task_list", project_id=project)
+    with_aug = (time.perf_counter() - t0) / n
+
+    overhead = with_aug - baseline
+    # 10ms is forgiving on the rate-limited fast path.
+    assert overhead < 0.010, (
+        f"augmentation added {overhead * 1000:.2f}ms/call > 10ms budget"
+    )

--- a/services/prism-service/tests/unit/test_mcp_janitor.py
+++ b/services/prism-service/tests/unit/test_mcp_janitor.py
@@ -1,0 +1,237 @@
+"""LL-08 tests — MCP endpoints wire janitor_service + memory_invalidate,
+memory_store stamps memory_meta with session_id.
+
+Parent task: 37932f3f · Sub-task LL-08.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _isolated_project(tmp_path, pid="test-ll-08"):
+    """Stand up a fresh project dir and swap config to point at it."""
+    from app import config as cfg
+    original = cfg.PROJECTS_DIR
+    cfg.PROJECTS_DIR = tmp_path / "projects"
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # Reset the cached context registry so each test is isolated.
+    from app import project_context as pc
+    pc._contexts.clear()
+    yield pid
+    cfg.PROJECTS_DIR = original
+    pc._contexts.clear()
+
+
+@pytest.fixture
+def project(tmp_path):
+    yield from _isolated_project(tmp_path)
+
+
+def _call(tool_name, arguments=None, project_id="test-ll-08"):
+    from app.mcp.tools import handle_tool
+    return asyncio.run(
+        handle_tool(tool_name, arguments or {}, project_id=project_id)
+    )
+
+
+def _text(result):
+    """Extract the single TextContent payload from a handle_tool result."""
+    assert len(result) == 1
+    return result[0].text
+
+
+# ----------------------------------------------------------------------
+# Tool definitions exist
+# ----------------------------------------------------------------------
+
+
+def test_janitor_tools_registered():
+    from app.mcp.tools import TOOLS
+    names = {t.name for t in TOOLS}
+    for n in (
+        "janitor_enqueue", "janitor_mark_stale", "janitor_check",
+        "janitor_submit", "janitor_abandon", "janitor_status",
+        "memory_invalidate",
+    ):
+        assert n in names, f"{n} not in TOOLS"
+
+
+def test_memory_store_schema_accepts_session_id():
+    from app.mcp.tools import TOOLS
+    [tool] = [t for t in TOOLS if t.name == "memory_store"]
+    assert "session_id" in tool.inputSchema["properties"], (
+        "memory_store should expose optional session_id argument"
+    )
+
+
+# ----------------------------------------------------------------------
+# Dispatch round-trip tests
+# ----------------------------------------------------------------------
+
+
+def test_janitor_enqueue_then_check_round_trip(project):
+    """Enqueue a candidate, wait past the 1h gate, check returns it."""
+    from app.project_context import get_project
+    from datetime import datetime, timedelta, timezone
+
+    # Enqueue via MCP
+    enq = json.loads(_text(_call("janitor_enqueue", {
+        "task_id": "T-mcp",
+        "trigger": "task_done",
+        "scope": {"task_ids": ["T-mcp"]},
+    })))
+    assert "candidate_id" in enq
+    cid = enq["candidate_id"]
+
+    # Advance the janitor's clock past the 1h gate
+    ctx = get_project(project)
+    svc = ctx.janitor_svc
+    fixed_now = datetime.now(timezone.utc) + timedelta(hours=2)
+    svc._clock = lambda: fixed_now
+
+    # check via MCP
+    chk = json.loads(_text(_call("janitor_check", {"session_id": "S-1"})))
+    assert chk["ready"] is True
+    assert chk["brief"]["candidate_id"] == cid
+
+
+def test_janitor_submit_round_trip(project):
+    """Submit valid output → rollup gets qualitative_score."""
+    from app.project_context import get_project
+    _call("janitor_enqueue", {
+        "task_id": "T-42",
+        "trigger": "task_done",
+        "scope": {"task_ids": ["T-42"]},
+    })
+    ctx = get_project(project)
+    ctx.janitor_svc._clock = lambda: datetime.now(timezone.utc) + timedelta(hours=2)
+
+    chk = json.loads(_text(_call("janitor_check", {"session_id": "S-1"})))
+    cid = chk["brief"]["candidate_id"]
+
+    result = json.loads(_text(_call("janitor_submit", {
+        "candidate_id": cid,
+        "output_json": {
+            "qualitative_score": 0.7,
+            "narrative": "Reviewed the code; solid work.",
+            "new_memories": [],
+            "invalidate_memory_ids": [],
+            "confidence": 0.8,
+        },
+    })))
+    assert result["accepted"] is True
+
+    # Rollup now carries qualitative_score
+    conn = sqlite3.connect(str(ctx._data_dir / "scores.db"))
+    row = conn.execute(
+        "SELECT qualitative_score FROM task_quality_rollup WHERE task_id=?",
+        ("T-42",),
+    ).fetchone()
+    conn.close()
+    assert abs(row[0] - 0.7) < 1e-9
+
+
+def test_janitor_abandon_round_trip(project):
+    from app.project_context import get_project
+
+    _call("janitor_enqueue", {
+        "task_id": "T-99",
+        "trigger": "task_done",
+        "scope": {"task_ids": ["T-99"]},
+    })
+    ctx = get_project(project)
+    ctx.janitor_svc._clock = lambda: datetime.now(timezone.utc) + timedelta(hours=2)
+    chk = json.loads(_text(_call("janitor_check", {"session_id": "S-1"})))
+    cid = chk["brief"]["candidate_id"]
+
+    res = json.loads(_text(_call("janitor_abandon", {
+        "candidate_id": cid, "reason": "subprocess timeout",
+    })))
+    assert res["accepted"] is True
+    assert res["retry_count"] == 1
+
+
+def test_janitor_status_returns_queue_depth(project):
+    _call("janitor_enqueue", {"task_id": "T-A", "trigger": "task_done"})
+    _call("janitor_enqueue", {"task_id": "T-B", "trigger": "task_done"})
+    status = json.loads(_text(_call("janitor_status")))
+    assert status["pending"] >= 2
+
+
+# ----------------------------------------------------------------------
+# memory_store stamps session_id + memory_invalidate flips status
+# ----------------------------------------------------------------------
+
+
+def test_memory_store_stamps_session_id(project):
+    from app.project_context import get_project
+
+    res = json.loads(_text(_call("memory_store", {
+        "domain": "conventions",
+        "name": "test-sid",
+        "description": "Test session_id stamping.",
+        "type": "pattern",
+        "classification": "tactical",
+        "session_id": "S-STAMP-1",
+    })))
+    mem_id = res.get("id") or res.get("entry_id") or res.get("memory_id")
+    assert mem_id, f"memory_store response missing id: {res}"
+
+    ctx = get_project(project)
+    conn = sqlite3.connect(str(ctx._data_dir / "scores.db"))
+    row = conn.execute(
+        "SELECT session_id, status FROM memory_meta WHERE memory_id=?",
+        (mem_id,),
+    ).fetchone()
+    conn.close()
+    assert row is not None, (
+        "memory_store with session_id must create a memory_meta row"
+    )
+    assert row[0] == "S-STAMP-1"
+    assert row[1] == "active"
+
+
+def test_memory_invalidate_flips_status_preserves_row(project):
+    from app.project_context import get_project
+
+    # Create a memory (with session_id so memory_meta row exists)
+    stored = json.loads(_text(_call("memory_store", {
+        "domain": "conventions",
+        "name": "test-inv",
+        "description": "Stale convention.",
+        "type": "pattern",
+        "classification": "tactical",
+        "session_id": "S-INV-1",
+    })))
+    mem_id = stored.get("id") or stored.get("entry_id") or stored.get("memory_id")
+
+    # Invalidate via MCP
+    res = json.loads(_text(_call("memory_invalidate", {
+        "memory_id": mem_id,
+        "reason": "code now contradicts this",
+    })))
+    assert res["accepted"] is True
+
+    ctx = get_project(project)
+    conn = sqlite3.connect(str(ctx._data_dir / "scores.db"))
+    row = conn.execute(
+        "SELECT status FROM memory_meta WHERE memory_id=?",
+        (mem_id,),
+    ).fetchone()
+    conn.close()
+    # Status flipped to invalidated; row preserved (not deleted)
+    assert row is not None
+    assert row[0] == "invalidated"

--- a/services/prism-service/tests/unit/test_quality_loop.py
+++ b/services/prism-service/tests/unit/test_quality_loop.py
@@ -1,0 +1,347 @@
+"""LL-04 tests — start_quality_timer daemon + git walker + composite scorer wiring.
+
+Parent task: 37932f3f · Sub-task LL-04.
+
+These tests stand up a real tmp git repo via subprocess so the revert
+detector, churn detector, and follow-up detector exercise the same git
+plumbing the daemon will use in production.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+# ----------------------------------------------------------------------
+# git fixture — tiny helper that makes timestamped commits
+# ----------------------------------------------------------------------
+
+
+class _GitRepo:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        path.mkdir(parents=True, exist_ok=True)
+        self._run("init", "-q")
+        self._run("config", "user.email", "t@t")
+        self._run("config", "user.name", "t")
+        self._run("config", "commit.gpgsign", "false")
+        # Initial empty commit so HEAD exists.
+        self._run("commit", "--allow-empty", "-m", "root",
+                  env_time=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    def _run(self, *args, env_time: datetime | None = None) -> str:
+        env = os.environ.copy()
+        if env_time is not None:
+            iso = env_time.isoformat()
+            env["GIT_AUTHOR_DATE"] = iso
+            env["GIT_COMMITTER_DATE"] = iso
+        out = subprocess.run(
+            ["git", *args], cwd=str(self.path), env=env,
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+
+    def commit(
+        self, files: dict[str, str], msg: str, when: datetime,
+    ) -> str:
+        for rel, content in files.items():
+            p = self.path / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+            self._run("add", rel)
+        self._run("commit", "-m", msg, env_time=when)
+        return self._run("rev-parse", "HEAD")
+
+    def revert(self, sha: str, when: datetime) -> str:
+        self._run("revert", "--no-edit", sha, env_time=when)
+        return self._run("rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path) -> _GitRepo:
+    return _GitRepo(tmp_path / "repo")
+
+
+# ----------------------------------------------------------------------
+# Revert detection
+# ----------------------------------------------------------------------
+
+
+def test_revert_detection(repo):
+    """Revert committed within 14d of merge flips the flag."""
+    from app.services.scoring_service import detect_revert
+
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merge_sha = repo.commit(
+        {"src/a.py": "x = 1\n"}, "feat: add x", merged_at
+    )
+    repo.revert(merge_sha, merged_at + timedelta(days=5))
+
+    now = merged_at + timedelta(days=10)
+    assert detect_revert(repo.path, merge_sha, merged_at, now) is True
+
+
+def test_revert_outside_window_ignored(repo):
+    """A revert at t=15d is past the 14-day window — flag stays False."""
+    from app.services.scoring_service import detect_revert
+
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merge_sha = repo.commit(
+        {"src/a.py": "x = 1\n"}, "feat: add x", merged_at
+    )
+    repo.revert(merge_sha, merged_at + timedelta(days=15))
+
+    now = merged_at + timedelta(days=20)
+    assert detect_revert(repo.path, merge_sha, merged_at, now) is False
+
+
+# ----------------------------------------------------------------------
+# Churn detection
+# ----------------------------------------------------------------------
+
+
+def test_churn_detection(repo):
+    """Files touched by the merge get re-edited within 14d → churn>0."""
+    from app.services.scoring_service import detect_churn
+
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merge_sha = repo.commit(
+        {"src/a.py": "x = 1\n", "src/b.py": "y = 1\n"},
+        "feat: add ab", merged_at,
+    )
+    # Re-edit a.py at day 7 (within 14d), b.py never re-touched
+    repo.commit(
+        {"src/a.py": "x = 2\n"}, "chore: tweak a",
+        merged_at + timedelta(days=7),
+    )
+    now = merged_at + timedelta(days=10)
+    churned = detect_churn(repo.path, merge_sha, merged_at, now)
+    assert churned == 1
+
+
+def test_churn_outside_window_ignored(repo):
+    """Re-edit at day 15 — outside window — doesn't count."""
+    from app.services.scoring_service import detect_churn
+
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merge_sha = repo.commit(
+        {"src/a.py": "x = 1\n"}, "feat: add a", merged_at
+    )
+    repo.commit(
+        {"src/a.py": "x = 2\n"}, "chore: much later",
+        merged_at + timedelta(days=15),
+    )
+    now = merged_at + timedelta(days=20)
+    assert detect_churn(repo.path, merge_sha, merged_at, now) == 0
+
+
+# ----------------------------------------------------------------------
+# Follow-up task detection
+# ----------------------------------------------------------------------
+
+
+def test_followup_task_detection(tmp_path):
+    """A task created within 14d of the merge that names one of the
+    merged files counts as a follow-up fix."""
+    from app.services.scoring_service import detect_followup_fixes
+    from app.services.task_service import TaskService
+
+    svc = TaskService(str(tmp_path / "tasks.db"))
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merged_files = ["src/a.py"]
+
+    # Create a follow-up task AFTER the merge, mentioning the file.
+    fu = svc.create(
+        title="Fix regression in src/a.py",
+        description="The change broke the nightly run; investigate.",
+    )
+    # Patch created_at to a post-merge time.
+    svc._db.execute(
+        "UPDATE tasks SET created_at=? WHERE id=?",
+        ((merged_at + timedelta(days=3)).isoformat(), fu.id),
+    )
+    svc._db.commit()
+
+    now = merged_at + timedelta(days=10)
+    count = detect_followup_fixes(svc, merged_files, merged_at, now,
+                                  exclude_task_id=None)
+    assert count == 1
+
+
+def test_followup_requires_file_overlap(tmp_path):
+    """A task that doesn't mention any merged file is NOT a follow-up."""
+    from app.services.scoring_service import detect_followup_fixes
+    from app.services.task_service import TaskService
+
+    svc = TaskService(str(tmp_path / "tasks.db"))
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merged_files = ["src/a.py"]
+
+    fu = svc.create(
+        title="Add dashboard analytics",
+        description="New widget in ui/dashboard.py — unrelated.",
+    )
+    svc._db.execute(
+        "UPDATE tasks SET created_at=? WHERE id=?",
+        ((merged_at + timedelta(days=3)).isoformat(), fu.id),
+    )
+    svc._db.commit()
+
+    now = merged_at + timedelta(days=10)
+    assert detect_followup_fixes(svc, merged_files, merged_at, now,
+                                 exclude_task_id=None) == 0
+
+
+# ----------------------------------------------------------------------
+# End-to-end scoring + timer
+# ----------------------------------------------------------------------
+
+
+def _mk_brain_scores(tmp_path):
+    """Init Brain so scores.db has the LL-01 schema."""
+    from app.engines.brain_engine import Brain
+
+    Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+
+
+def test_end_to_end_scoring(tmp_path, repo):
+    """Seed a merged task, run the scorer once, verify rollup populated."""
+    from app.services.scoring_service import score_merged_tasks
+    from app.services.task_service import TaskService
+
+    _mk_brain_scores(tmp_path)
+    tasks_svc = TaskService(str(tmp_path / "tasks.db"))
+
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merge_sha = repo.commit(
+        {"src/main.py": "print(1)\n"}, "feat: hello", merged_at
+    )
+    t = tasks_svc.create(title="Add greeter",
+                        description="Adds print(1) in src/main.py.")
+    tasks_svc._db.execute(
+        "UPDATE tasks SET merge_sha=?, merged_at=? WHERE id=?",
+        (merge_sha, merged_at.isoformat(), t.id),
+    )
+    tasks_svc._db.commit()
+
+    now = merged_at + timedelta(days=10)
+    scored = score_merged_tasks(
+        tasks_svc=tasks_svc,
+        scores_db=str(tmp_path / "scores.db"),
+        repo_path=str(repo.path),
+        now=now,
+    )
+    assert t.id in scored
+
+    import sqlite3
+    conn = sqlite3.connect(str(tmp_path / "scores.db"))
+    row = conn.execute(
+        "SELECT quality_score, components_json FROM task_quality_rollup "
+        "WHERE task_id=?",
+        (t.id,),
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    # No retries, green tests implied, no churn, no followups → ~1.0
+    assert row[0] is not None and row[0] >= 0.9
+
+
+def test_timer_idempotent(tmp_path, repo):
+    """Second pass skips tasks already in rollup."""
+    from app.services.scoring_service import score_merged_tasks
+    from app.services.task_service import TaskService
+
+    _mk_brain_scores(tmp_path)
+    tasks_svc = TaskService(str(tmp_path / "tasks.db"))
+
+    merged_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    merge_sha = repo.commit(
+        {"src/a.py": "x = 1\n"}, "feat: a", merged_at
+    )
+    t = tasks_svc.create(title="Add a", description="src/a.py")
+    tasks_svc._db.execute(
+        "UPDATE tasks SET merge_sha=?, merged_at=? WHERE id=?",
+        (merge_sha, merged_at.isoformat(), t.id),
+    )
+    tasks_svc._db.commit()
+
+    now = merged_at + timedelta(days=10)
+    first = score_merged_tasks(
+        tasks_svc=tasks_svc,
+        scores_db=str(tmp_path / "scores.db"),
+        repo_path=str(repo.path),
+        now=now,
+    )
+    second = score_merged_tasks(
+        tasks_svc=tasks_svc,
+        scores_db=str(tmp_path / "scores.db"),
+        repo_path=str(repo.path),
+        now=now,
+    )
+    assert t.id in first
+    assert t.id not in second, (
+        "already-scored task must not be re-scored on the second pass"
+    )
+
+
+def test_timer_skips_unmerged_tasks(tmp_path, repo):
+    """Tasks without a merge_sha aren't scored."""
+    from app.services.scoring_service import score_merged_tasks
+    from app.services.task_service import TaskService
+
+    _mk_brain_scores(tmp_path)
+    tasks_svc = TaskService(str(tmp_path / "tasks.db"))
+    t = tasks_svc.create(title="Draft", description="unmerged")
+
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    scored = score_merged_tasks(
+        tasks_svc=tasks_svc,
+        scores_db=str(tmp_path / "scores.db"),
+        repo_path=str(repo.path),
+        now=now,
+    )
+    assert t.id not in scored
+
+
+def test_timer_handles_missing_git_repo(tmp_path):
+    """A configured repo path that doesn't exist doesn't crash the timer."""
+    from app.services.scoring_service import score_merged_tasks
+    from app.services.task_service import TaskService
+
+    _mk_brain_scores(tmp_path)
+    tasks_svc = TaskService(str(tmp_path / "tasks.db"))
+    t = tasks_svc.create(title="Add x", description="src/x.py")
+    tasks_svc._db.execute(
+        "UPDATE tasks SET merge_sha=?, merged_at=? WHERE id=?",
+        ("deadbeef", "2026-04-01T00:00:00+00:00", t.id),
+    )
+    tasks_svc._db.commit()
+
+    # Point at a path that is *not* a git repo
+    not_a_repo = str(tmp_path / "nope")
+    (tmp_path / "nope").mkdir()
+
+    # Must not raise
+    scored = score_merged_tasks(
+        tasks_svc=tasks_svc,
+        scores_db=str(tmp_path / "scores.db"),
+        repo_path=not_a_repo,
+        now=datetime(2026, 4, 15, tzinfo=timezone.utc),
+    )
+    # Task wasn't scored (no git data to score from), but no crash
+    assert t.id not in scored

--- a/services/prism-service/tests/unit/test_quality_scorer.py
+++ b/services/prism-service/tests/unit/test_quality_scorer.py
@@ -1,0 +1,92 @@
+"""LL-02 tests — composite Layer-A quality scorer (pure function).
+
+Parent task: 37932f3f-9cd4-40bf-9df3-e9db19fcc88d · Sub-task LL-02
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _score(**components):
+    """Call composite_score with defaults for unspecified fields.
+
+    Defaults lean "neutral positive" — merged, tests green, no retries,
+    no churn, no followups, no revert. Individual tests override what
+    they care about.
+    """
+    from app.services.scoring_service import composite_score
+
+    base = {
+        "merged_to_main": True,
+        "gate_retry_count": 0,
+        "tests_green_on_merge": True,
+        "reverted_within_14d": False,
+        "files_re_edited_within_14d": 0,
+        "followup_fix_tasks_within_14d": 0,
+    }
+    base.update(components)
+    return composite_score(base)
+
+
+def test_composite_all_positive_returns_max():
+    """Merged + tests_green + 0 retries + 0 churn + 0 followups → 1.0."""
+    assert _score() == 1.0
+
+
+def test_reverted_is_hard_negative():
+    """A revert dominates all other positives — proves the code didn't survive."""
+    # Even with zero retries, green tests, zero churn, the revert flag
+    # must collapse the score to a low value that a "barely shipped" run
+    # can't beat.
+    reverted = _score(reverted_within_14d=True)
+    assert reverted is not None
+    assert reverted <= 0.2, f"reverted score {reverted} should be ≤0.2"
+
+
+def test_unmerged_returns_none():
+    """Unmerged tasks are unscored — score is only meaningful after merge."""
+    assert _score(merged_to_main=False) is None
+
+
+def test_gate_retry_linearly_penalizes():
+    """Increasing gate retries must strictly decrease the score."""
+    scores = [_score(gate_retry_count=n) for n in (0, 1, 2, 3)]
+    for a, b in zip(scores, scores[1:]):
+        assert a > b, (
+            f"gate_retry penalty must be monotonically decreasing; got {scores}"
+        )
+
+
+def test_churn_uses_exact_14d_window():
+    """The pure function trusts the count coming from the 14d-window
+    detector (LL-04 owns the window math). Here we verify the scorer
+    reacts linearly to whatever count it's given: 0 churn → max, more
+    churn → lower score, and the delta between consecutive counts is
+    consistent (linear)."""
+    s0 = _score(files_re_edited_within_14d=0)
+    s1 = _score(files_re_edited_within_14d=1)
+    s2 = _score(files_re_edited_within_14d=2)
+    assert s0 > s1 > s2
+    # Linear penalty check — differences within 1e-9 tolerance.
+    assert abs((s0 - s1) - (s1 - s2)) < 1e-9
+
+
+def test_followup_requires_file_overlap():
+    """The pure function trusts the count from the follow-up detector
+    (LL-04 requires ≥1 file overlap before counting). Here: zero
+    follow-ups → no penalty; any follow-up drops the score."""
+    s_none = _score(followup_fix_tasks_within_14d=0)
+    s_one = _score(followup_fix_tasks_within_14d=1)
+    assert s_none == 1.0, (
+        "zero follow-ups (no file overlap detected) must not penalize"
+    )
+    assert s_one < s_none, (
+        "any follow-up with file overlap must drop the score"
+    )

--- a/services/prism-service/tests/unit/test_task_embedding.py
+++ b/services/prism-service/tests/unit/test_task_embedding.py
@@ -1,0 +1,101 @@
+"""LL-03 tests — task embedding on create/update.
+
+Parent task: 37932f3f-9cd4-40bf-9df3-e9db19fcc88d · Sub-task LL-03
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _fake_embed(text: str) -> bytes:
+    """Deterministic fake embedder: packs a 4-float vector derived from
+    the text. Different text → different bytes. Same text → same bytes."""
+    h = hash(text) & 0xFFFFFFFF
+    return struct.pack("<4f", float(h & 0xFF),
+                       float((h >> 8) & 0xFF),
+                       float((h >> 16) & 0xFF),
+                       float((h >> 24) & 0xFF))
+
+
+def _mk_service(tmp_path: Path, embed_fn=_fake_embed):
+    from app.services.task_service import TaskService
+    return TaskService(str(tmp_path / "tasks.db"), embed_fn=embed_fn)
+
+
+# ----------------------------------------------------------------------
+
+
+def test_embedding_populated_on_create(tmp_path):
+    """Creating a task stores an embedding BLOB."""
+    svc = _mk_service(tmp_path)
+    t = svc.create(title="Refactor auth middleware",
+                   description="Move JWT parse into a dedicated helper.")
+    row = svc._db.execute(
+        "SELECT embedding FROM tasks WHERE id=?", (t.id,)
+    ).fetchone()
+    assert row is not None
+    assert row["embedding"] is not None
+    assert len(row["embedding"]) > 0
+
+
+def test_embedding_updated_on_title_change(tmp_path):
+    """Changing the title re-embeds (new bytes stored)."""
+    svc = _mk_service(tmp_path)
+    t = svc.create(title="Task A", description="Do a thing.")
+    old = svc._db.execute(
+        "SELECT embedding FROM tasks WHERE id=?", (t.id,)
+    ).fetchone()["embedding"]
+    svc.update(t.id, title="Task A — renamed")
+    new = svc._db.execute(
+        "SELECT embedding FROM tasks WHERE id=?", (t.id,)
+    ).fetchone()["embedding"]
+    assert old != new, "title change must trigger re-embedding"
+
+
+def test_embedding_unchanged_when_title_unchanged(tmp_path):
+    """Updating unrelated fields (priority, tags) leaves the embedding alone."""
+    svc = _mk_service(tmp_path)
+    t = svc.create(title="Task A", description="Do a thing.")
+    old = svc._db.execute(
+        "SELECT embedding FROM tasks WHERE id=?", (t.id,)
+    ).fetchone()["embedding"]
+    svc.update(t.id, priority=7)
+    new = svc._db.execute(
+        "SELECT embedding FROM tasks WHERE id=?", (t.id,)
+    ).fetchone()["embedding"]
+    assert old == new, "non-title/description update must not re-embed"
+
+
+def test_embedding_dim_matches_miniLM_384(tmp_path):
+    """Real MiniLM embedding is 384-dim float32 (1536 bytes packed).
+
+    Skipped when the embedder couldn't load (offline, first-session, etc).
+    The point of this test is to catch someone swapping to a
+    different-dim model without updating dependent code.
+    """
+    from app.engines import brain_engine as be
+    # Force-load the embedder the same way Brain does.
+    try:
+        be._try_enable_vector(__import__("sqlite3").connect(":memory:"))
+    except Exception:
+        pass
+    if be._MODEL is None:
+        pytest.skip("MiniLM embedder unavailable in this environment")
+
+    # Use the public helper the service layer will call
+    blob = be.encode_task_text("Sample title\nSample description.")
+    assert blob is not None
+    # 384 floats * 4 bytes/float = 1536 bytes
+    assert len(blob) == 384 * 4, (
+        f"expected 1536 bytes (384 floats × 4), got {len(blob)}"
+    )


### PR DESCRIPTION
Every PRISM MCP tool response now gets prefixed with `PRISM_REFLECTION_PENDING` when a candidate is pending AND hasn't been nudged in >5min. Second redundant channel alongside LL-10's SessionStart additionalContext so Claude sees the nudge via any brain_search/memory_recall/etc it happens to call.\n\n- Exclusion list: janitor_*, memory_invalidate, prism_install, prism_guide (pipeline's own tools skip to avoid feedback loops)\n- Exception-safe: advisory, never blocks the caller\n- `PRISM_MCP_AUGMENT_NUDGES=false` disables globally\n\nTests 5/5: augmented_when_pending, not_augmented_when_none, rate_limited_5min, disabled_via_env, adds_under_10ms_overhead. Full suite: 60 pass, 1 skip.\n\nParent `37932f3f` · LL-09. Stacked on #27.