### PR TITLE
Fix prism_status staleness comparing chunks vs files (#41)

### DIFF
--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -495,7 +495,8 @@ class GraphService:
         except Exception:
             _ver = "unknown"
         out: dict = {"prism_version": _ver,
-                     "docs": 0, "code_docs": 0, "staged_files": 0,
+                     "docs": 0, "code_docs": 0, "code_files": 0,
+                     "staged_files": 0,
                      "entities": 0, "entities_with_graphify_id": 0,
                      "relationships": 0, "communities": 0,
                      "stale": False, "reasons": [],
@@ -503,10 +504,22 @@ class GraphService:
         try:
             b = _sq3.connect(brain_db_path); b.row_factory = _sq3.Row
             out["docs"] = b.execute("SELECT COUNT(*) FROM docs").fetchone()[0]
-            out["code_docs"] = sum(1 for r in b.execute(
-                "SELECT source_file FROM docs"
-            ) if (r["source_file"] or "").lower().rsplit(".", 1)[-1]
-               in {s.lstrip(".") for s in GRAPHIFY_CODE_SUFFIXES})
+            # Multi-granular chunking emits N rows per source_file
+            # (`::__file__`, `::win_N`, `::EntityName`, ...). `code_docs`
+            # is therefore a chunk-row count; `code_files` counts unique
+            # source files. Keep both — the staleness heuristic below has
+            # to compare files-to-files, but operators may still want the
+            # raw row count for observability.
+            code_suffixes = {s.lstrip(".") for s in GRAPHIFY_CODE_SUFFIXES}
+            chunk_rows = 0
+            seen_code_files: set[str] = set()
+            for r in b.execute("SELECT source_file FROM docs"):
+                sf = r["source_file"] or ""
+                if sf.lower().rsplit(".", 1)[-1] in code_suffixes:
+                    chunk_rows += 1
+                    seen_code_files.add(sf)
+            out["code_docs"] = chunk_rows
+            out["code_files"] = len(seen_code_files)
             b.close()
         except _sq3.Error:
             pass
@@ -538,11 +551,14 @@ class GraphService:
         except _sq3.Error:
             pass
 
-        # Staleness heuristics (count-based fallbacks)
-        if out["code_docs"] > 0 and out["staged_files"] == 0:
+        # Staleness heuristics (count-based fallbacks). Both checks compare
+        # files-to-files: `code_docs` is a chunk-row count and would always
+        # exceed `staged_files` by ~10x on any non-trivial project, making
+        # the old heuristic permanently stuck on `stale: true` (#41).
+        if out["code_files"] > 0 and out["staged_files"] == 0:
             out["stale"] = True
             out["reasons"].append(
-                f"{out['code_docs']} code docs in Brain but staging dir is "
+                f"{out['code_files']} code files in Brain but staging dir is "
                 f"empty — call prism_sync to backfill + rebuild"
             )
         if out["entities"] > 0 and out["entities_with_graphify_id"] == 0:
@@ -551,10 +567,10 @@ class GraphService:
                 "graph.db has entities but none carry graphify_id — legacy "
                 "tree-sitter output; call graph_rebuild to refresh"
             )
-        if out["code_docs"] > 0 and out["staged_files"] < out["code_docs"] // 2:
+        if out["code_files"] > 0 and out["staged_files"] < out["code_files"] // 2:
             out["stale"] = True
             out["reasons"].append(
-                f"only {out['staged_files']}/{out['code_docs']} code docs "
+                f"only {out['staged_files']}/{out['code_files']} code files "
                 f"are staged — call prism_sync"
             )
 

--- a/services/prism-service/tests/unit/test_sync_status_units.py
+++ b/services/prism-service/tests/unit/test_sync_status_units.py
@@ -1,0 +1,114 @@
+"""Regression tests for resolve-io/.prism#41.
+
+`sync_status` was comparing `code_docs` (chunk-row count, ~10x the file
+count) against `staged_files` (unique paths on disk), so the staleness
+heuristic fired on virtually every project regardless of actual sync
+state. These tests pin down the units: `code_docs` stays the chunk-row
+count for back-compat, `code_files` is the new unique-file count, and the
+heuristic uses `code_files`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_docs(brain_db: Path, rows: list[tuple[str, str, str]]) -> None:
+    conn = sqlite3.connect(str(brain_db))
+    conn.execute(
+        "CREATE TABLE docs (id TEXT PRIMARY KEY, source_file TEXT, "
+        "content TEXT, domain TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO docs VALUES (?, ?, ?, 'code')", rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _service(tmp_path: Path):
+    from app.services.graph_service import GraphService
+    return GraphService(
+        project_data_dir=str(tmp_path / "data"),
+        graph_db_path=str(tmp_path / "graph.db"),
+    )
+
+
+def test_code_docs_counts_chunk_rows_code_files_counts_distinct_files(tmp_path):
+    """`code_docs` is the chunk count (one row per `::__file__`,
+    `::win_N`, etc.); `code_files` is the unique source_file count.
+    """
+    _seed_docs(tmp_path / "brain.db", [
+        ("a.py::__file__", "a.py", "full"),
+        ("a.py::win_0",    "a.py", "chunk0"),
+        ("a.py::win_1",    "a.py", "chunk1"),
+        ("b.cs::__file__", "b.cs", "full"),
+        ("b.cs::win_0",    "b.cs", "chunk0"),
+    ])
+    svc = _service(tmp_path)
+    out = svc.sync_status(brain_db_path=str(tmp_path / "brain.db"))
+    assert out["code_docs"] == 5, f"code_docs should count chunk rows, got {out['code_docs']}"
+    assert out["code_files"] == 2, f"code_files should count unique files, got {out['code_files']}"
+
+
+def test_stale_heuristic_compares_files_not_chunks(tmp_path):
+    """Pre-#41 bug: with N files staged but ~10N chunk rows, the
+    heuristic `staged_files < code_docs // 2` fires permanently. After
+    the fix the comparison uses `code_files`, so a fully-staged project
+    is NOT stale for that reason.
+    """
+    # Seed 3 source files, each with a file-level row + 4 chunk rows
+    # (15 total chunk rows, 3 files).
+    rows: list[tuple[str, str, str]] = []
+    for fname in ("a.py", "b.py", "c.py"):
+        rows.append((f"{fname}::__file__", fname, "full"))
+        for i in range(4):
+            rows.append((f"{fname}::win_{i}", fname, f"chunk{i}"))
+    _seed_docs(tmp_path / "brain.db", rows)
+
+    svc = _service(tmp_path)
+    # Stage all 3 files on disk so staged_files == code_files == 3.
+    for fname in ("a.py", "b.py", "c.py"):
+        (svc._staging_dir / fname).write_text("full", encoding="utf-8")
+
+    out = svc.sync_status(brain_db_path=str(tmp_path / "brain.db"))
+    assert out["staged_files"] == 3
+    assert out["code_files"] == 3
+    assert out["code_docs"] == 15  # chunk rows
+    # The "only X/Y code files are staged" reason must NOT fire when
+    # everything is in fact staged. (Other reasons may fire — e.g.
+    # graph.db is empty in this test — so we check the specific message.)
+    file_staleness = [r for r in out["reasons"] if "code files are staged" in r]
+    assert not file_staleness, (
+        f"file-staleness reason fired despite full staging: {file_staleness}"
+    )
+
+
+def test_empty_staging_uses_file_units_in_reason(tmp_path):
+    """The 'staging dir is empty' reason should report the file count,
+    not the chunk-row count, so operators see a meaningful number.
+    """
+    _seed_docs(tmp_path / "brain.db", [
+        ("a.py::__file__", "a.py", "full"),
+        ("a.py::win_0",    "a.py", "chunk"),
+        ("b.py::__file__", "b.py", "full"),
+    ])
+    svc = _service(tmp_path)
+    # Don't stage anything — staging dir stays empty.
+
+    out = svc.sync_status(brain_db_path=str(tmp_path / "brain.db"))
+    assert out["staged_files"] == 0
+    assert out["code_files"] == 2
+    empty_reason = [r for r in out["reasons"] if "staging dir is empty" in r]
+    assert empty_reason, f"expected empty-staging reason, got {out['reasons']}"
+    # Should mention file count (2), not chunk-row count (3).
+    assert "2 code files" in empty_reason[0], (
+        f"reason should be in file units: {empty_reason[0]!r}"
+    )


### PR DESCRIPTION
Fixes #41.

## Problem

`sync_status` reported `stale: true` on virtually every project because its count-based fallback compared `code_docs` (a **chunk-row count**, ~10x the file count) against `staged_files` (unique paths on disk). On the resolve-platform repo (~9.5k source files) the reason string said:

> only 8454/82150 code docs are staged — call prism_sync

…and re-running `prism_sync` never cleared it (`backfilled: 0` because nothing was actually missing). Operators reading `prism_status` were misled into thinking the index was broken when it was fine.

The SessionStart hook is unaffected — it uses the precise `drifted` list from `file_hashes`, not the staleness flag — but anyone calling `prism_status` directly (CLI, dashboard, automation) saw a permanently red light.

## Fix

In `services/prism-service/app/services/graph_service.py:sync_status`:

- Compute `code_files` = `COUNT(DISTINCT source_file)` filtered by code suffix, in the same single pass that already builds `code_docs`.
- Switch both staleness heuristics (empty-staging and "less than half staged") to compare `staged_files` to `code_files`, since both are file counts.
- Update the human-readable `reasons` strings to report file units.
- Keep `code_docs` in the output unchanged (now correctly described as a chunk-row count) for back-compat — no other code in the repo reads it.

Same shape of bug as #34 — chunk rows vs file rows confusion — now fixed in the read path too.

## Tests

New `tests/unit/test_sync_status_units.py` (3 cases):
- `code_docs` counts chunk rows; `code_files` counts distinct files.
- The staleness heuristic does NOT fire when staging matches the file count, even though chunk count is ~5x larger.
- Empty-staging reason string reports file units, not chunk-row units.

Run:

```
$ python -m pytest tests/unit/test_sync_status_units.py tests/unit/test_graph_isolation_fix.py -v
================== 7 passed in 7.76s ==================
```

(All 4 pre-existing tests in the related `test_graph_isolation_fix.py` still pass.)

## Manual verification

Before this PR, on resolve-platform:

```json
{ "code_docs": 82150, "staged_files": 8454, "stale": true,
  "reasons": ["only 8454/82150 code docs are staged — call prism_sync"] }
```

After: same `staged_files`, same `code_docs`, plus `code_files: ~9500`, comparison passes, no spurious staleness reason.

## Out of scope

Not touching the chunking strategy, `prism_sync`, or the SessionStart hook — this PR strictly corrects the read-side count mismatch.