### PR TITLE
Fix dashboard 500 — nav defaulted active project to invalid sentinel (#43)

### DIFF
--- a/services/prism-service/app/ui/components/nav.py
+++ b/services/prism-service/app/ui/components/nav.py
@@ -21,6 +21,32 @@ body, .q-page, .nicegui-content {
 """
 
 
+def resolve_active_project(stored: str | None,
+                           qs_proj: str | None,
+                           projects: list[str]) -> str:
+    """Pick the active project for the nav selector.
+
+    Priority: query-string ?project= (if valid) > stored value (if still
+    valid) > first real project > 'default' sentinel. The sentinel is
+    only used in the truly-empty case where no projects are onboarded —
+    in that case the selector will still complain, which is the right
+    signal for "you have no projects yet."
+
+    Pure function so the resolution logic is unit-testable without
+    standing up NiceGUI. See #43: the previous code seeded the literal
+    string 'default' into storage on first visit, then passed it as the
+    select's `value=` while `options=` was the real project list, which
+    raised `ValueError: Invalid value: default` on every page.
+    """
+    if qs_proj and qs_proj in projects:
+        return qs_proj
+    if stored and stored in projects:
+        return stored
+    if projects:
+        return projects[0]
+    return 'default'
+
+
 def create_nav():
     """Shared navigation header with project selector and page links."""
     from app.project_context import get_all_projects
@@ -34,13 +60,18 @@ def create_nav():
         _qs_proj = _ctx.client.request.query_params.get('project')
     except Exception:
         _qs_proj = None
-    if _qs_proj:
-        app.storage.user['project'] = _qs_proj
-    elif 'project' not in app.storage.user:
-        app.storage.user['project'] = 'default'
 
-    current = app.storage.user['project']
-    projects = get_all_projects() or ['default']
+    projects = get_all_projects()
+    current = resolve_active_project(
+        stored=app.storage.user.get('project'),
+        qs_proj=_qs_proj,
+        projects=projects,
+    )
+    app.storage.user['project'] = current
+    if not projects:
+        # Empty-state fallback so the selector has at least one option.
+        # ui.select would otherwise show an empty dropdown.
+        projects = ['default']
 
     with ui.header().classes('items-center justify-between bg-indigo-700 px-6 shadow-md'):
         with ui.row().classes('items-center gap-3'):

--- a/services/prism-service/tests/unit/test_nav_active_project.py
+++ b/services/prism-service/tests/unit/test_nav_active_project.py
@@ -1,0 +1,90 @@
+"""Regression tests for resolve-io/.prism#43.
+
+`create_nav` was seeding the literal string `'default'` into
+`app.storage.user['project']` on first visit and then passing it to
+`ui.select(options=get_all_projects(), value=current)`, which raised
+`ValueError: Invalid value: default` because the literal sentinel was
+not in the real project list. Every dashboard page 500'd as a result.
+
+These tests pin the resolution rules of `resolve_active_project`, the
+pure helper extracted from `create_nav`, so the bug can't return.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _resolver():
+    from app.ui.components.nav import resolve_active_project
+    return resolve_active_project
+
+
+def test_first_visit_picks_first_real_project_not_literal_default():
+    """The exact #43 repro: no stored value, no qs hint, one real
+    project. Must return the project — NOT the literal 'default'.
+    """
+    r = _resolver()
+    assert r(stored=None, qs_proj=None, projects=["resolve-platform"]) == "resolve-platform"
+
+
+def test_stored_value_wins_when_still_valid():
+    r = _resolver()
+    assert r(
+        stored="proj-b",
+        qs_proj=None,
+        projects=["proj-a", "proj-b", "proj-c"],
+    ) == "proj-b"
+
+
+def test_query_string_overrides_stored_when_valid():
+    r = _resolver()
+    assert r(
+        stored="proj-a",
+        qs_proj="proj-c",
+        projects=["proj-a", "proj-b", "proj-c"],
+    ) == "proj-c"
+
+
+def test_invalid_query_string_falls_through_to_stored():
+    """A garbage ?project= shouldn't override a valid stored value or
+    crash the selector."""
+    r = _resolver()
+    assert r(
+        stored="proj-a",
+        qs_proj="does-not-exist",
+        projects=["proj-a", "proj-b"],
+    ) == "proj-a"
+
+
+def test_stored_project_was_deleted_self_heals_to_first_real_project():
+    """Latent bug companion to #43: if the stored project is no longer
+    in the project list (e.g. it got deleted), nav should self-heal
+    rather than re-raise on every page."""
+    r = _resolver()
+    assert r(
+        stored="proj-deleted",
+        qs_proj=None,
+        projects=["proj-a", "proj-b"],
+    ) == "proj-a"
+
+
+def test_no_projects_at_all_returns_default_sentinel():
+    """The truly-empty-state case is the ONLY situation where the
+    'default' literal is acceptable. The empty-state UI is responsible
+    for guiding the user to onboard a project from there."""
+    r = _resolver()
+    assert r(stored=None, qs_proj=None, projects=[]) == "default"
+
+
+def test_empty_string_stored_treated_as_unset():
+    """An empty string in storage is functionally unset — must not be
+    matched against a project list that doesn't contain it."""
+    r = _resolver()
+    assert r(stored="", qs_proj=None, projects=["proj-a"]) == "proj-a"


### PR DESCRIPTION
Fixes #43.

## Problem

The web dashboard 500'd on every page (`/`, `/brain`, `/graph`, …) for any visitor whose `app.storage.user['project']` wasn't already a valid project — first visit, cleared cookies, fresh container, etc.

Underlying error (visible in container logs):

```
File "/usr/local/lib/python3.12/site-packages/nicegui/elements/choice_element.py", line 20
    raise ValueError(f'Invalid value: {value}')
ValueError: Invalid value: default
```

App-side frame: `app/ui/components/nav.py:49`. The shared nav is included on every page, so a single bug here blacked out the entire dashboard.

The error showed up twice in logs because NiceGUI's `create_500_error_page` re-raised while trying to render the error page itself, masking the real cause behind a generic 500.

## Root cause

`create_nav` was seeding the literal string `'default'` into storage and then handing it to `ui.select` as `value=` while `options=` was the real project list:

```python
elif 'project' not in app.storage.user:
    app.storage.user['project'] = 'default'   # literal sentinel

current = app.storage.user['project']         # 'default'
projects = get_all_projects() or ['default']  # ['resolve-platform']
ui.select(options=projects, value=current)    # 'default' ∉ projects → raise
```

The same shape of bug also fired if a user's stored project was deleted — the stored value would no longer be in `options`.

## Fix

Extract a pure helper `resolve_active_project(stored, qs_proj, projects)` that picks the first valid candidate:

1. Query-string `?project=` if it matches a real project.
2. Stored value if it still matches.
3. First real project as a sane fallback.
4. `'default'` literal only when no projects exist at all.

`create_nav` now calls the helper and writes the resolved value back to storage, so the latent deleted-project bug self-heals on next render.

## Tests

`tests/unit/test_nav_active_project.py` (7 cases):

- First visit (no stored, no qs, one project) returns the project, NOT the literal `'default'` — direct repro of #43.
- Stored value wins when valid.
- Query-string overrides stored when valid.
- Garbage `?project=` falls through to stored.
- Deleted stored project self-heals to first real project.
- Empty project list returns the `'default'` sentinel (the only legitimate use of it).
- Empty-string stored treated as unset.

Run:

```
$ python -m pytest tests/unit/test_nav_active_project.py -v
================== 7 passed in 0.60s ==================
```

The pure-helper pattern follows `test_ui_learning.py`'s style — testing the data-access logic without standing up a NiceGUI runtime.

## Out of scope

- The doubled-traceback (NiceGUI's own `create_500_error_page` raises while rendering) is a NiceGUI quirk, not something this repo can fix. Once `nav.py` stops raising, the symptom disappears either way.
- Doc says dashboard is at `:9000`; actual port is `:8080`. Worth fixing in docs separately.