### PR TITLE
Pin graphifyy to >=0.4.29,<0.5 for PRISM v4.6.0

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -11,5 +11,6 @@ PRISM_VERSION = "4.6.0"
 PRISM_VERSION_NOTES = (
     "autonomous learning loop (PostToolUse edit-learn + Stop idle-rebuild "
     "hooks), cwd-robust hook commands via ${CLAUDE_PROJECT_DIR}, default "
-    "ports moved to MCP=7777 / UI=7778 (breaking — update .mcp.json)"
+    "ports moved to MCP=7777 / UI=7778 (breaking — update .mcp.json), "
+    "graphifyy pinned to 0.4.29 (>=0.4.29,<0.5)"
 )

--- a/services/prism-service/requirements.txt
+++ b/services/prism-service/requirements.txt
@@ -18,7 +18,10 @@ sentence-transformers>=2.7
 
 # Code knowledge graph (tree-sitter AST + Leiden clustering + edge confidence).
 # We use graphify's `update` subcommand which is LLM-free and local-only.
-graphifyy>=0.1
+# PRISM v4.6.0 is tested against graphifyy 0.4.29 — pin to the 0.4.x
+# series so patch fixes flow through but a 0.5 jump can't silently
+# change graph.json schema and break _import_graph_json.
+graphifyy>=0.4.29,<0.5
 
 # AST chunking for Python / TypeScript / JavaScript / C# / Go etc.
 # Without these the chunker falls back to regex which loses structural info.


### PR DESCRIPTION
## Summary

- Tighten `graphifyy` requirement from unbounded `>=0.1` to `>=0.4.29,<0.5`.
- PRISM v4.6.0 (merged in #45) is tested against `graphifyy 0.4.29`. Without the pin, a `graphifyy 0.5` release could silently change `graph.json` schema and break `_import_graph_json` for resolve users.
- Patch upgrades within the 0.4.x series still flow through automatically.
- Updated `PRISM_VERSION_NOTES` to call out the pin so it's discoverable from `prism_status`.

Companion to #45 — should have been part of that PR but landed on the branch after the merge.

## Test plan

- [x] `python -m pytest services/prism-service/tests/unit` → 109 passed
- [ ] After merge: clean `pip install -r requirements.txt` resolves to `graphifyy==0.4.29`

🤖 Generated with [Claude Code](https://claude.com/claude-code)