### PR TITLE
fix: use python3 in hook commands (closes #36)

### DIFF
--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -1571,7 +1571,7 @@ def _install_manifest(project_id: str) -> dict:
         "SessionStart": [
             {
                 "type": "command",
-                "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-sync.py",
+                "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-sync.py",
                 "timeout": 30000,
             },
         ],
@@ -1581,7 +1581,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-feedback-signal.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-feedback-signal.py",
                         "description": (
                             "Implicit retrieval feedback: correlate "
                             "brain_search results with Read/Edit and emit "
@@ -1595,7 +1595,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-skill-usage.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-skill-usage.py",
                         "description": (
                             "Record skill invocations to scores.db via "
                             "record_skill_usage — populates /skills."
@@ -1608,7 +1608,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-edit-learn.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-edit-learn.py",
                         "description": (
                             "Auto-ingest edited source files into Brain via "
                             "prism_refresh (skip_graph) so brain_search "
@@ -1624,7 +1624,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-stop.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-stop.py",
                         "description": (
                             "Record session-level metrics (duration, "
                             "tokens, files, skills) via "
@@ -1633,7 +1633,7 @@ def _install_manifest(project_id: str) -> dict:
                     },
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-idle-rebuild.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-idle-rebuild.py",
                         "description": (
                             "Flush in-session edits into the code graph via "
                             "graph_rebuild iff the edit-learn hook left a "
@@ -1649,7 +1649,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-subagent.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-subagent.py",
                         "description": (
                             "Record sub-agent outcome (recommendation, "
                             "evidence count, timing) via "

--- a/services/prism-service/tests/unit/test_install_manifest.py
+++ b/services/prism-service/tests/unit/test_install_manifest.py
@@ -87,6 +87,22 @@ def test_install_settings_wires_all_shipped_hooks():
         "hook commands must use ${CLAUDE_PROJECT_DIR} so they resolve "
         "regardless of the subprocess cwd"
     )
+    # Issue #36: hook commands must invoke `python3`, not bare `python`.
+    # Modern Linux distros (Ubuntu 20.04+, Debian 11+, Fedora, Arch) ship
+    # only `/usr/bin/python3`; bare `python` exits with `command not found`
+    # and Claude Code reports `SessionStart:startup hook error`. Guard
+    # against any future drift back to the broken default.
+    assert "python " not in rendered, (
+        "hook commands must invoke `python3`, not bare `python` "
+        "(see resolve-io/.prism#36)"
+    )
+    # Sanity: every hook entry uses the python3 prefix.
+    import re as _re
+    py3_count = len(_re.findall(r'"python3 ', rendered))
+    assert py3_count >= 7, (
+        f"expected >=7 hook commands prefixed with `python3 `, found "
+        f"{py3_count}"
+    )
 
 
 def test_plugin_hook_registration_is_noop():


### PR DESCRIPTION
Closes #36.

## Problem

The install manifest emitted hook commands as `python ${CLAUDE_PROJECT_DIR}/.claude/hooks/<name>.py`. On modern Linux distros (Ubuntu 20.04+, Debian 11+, Fedora, Arch) `/usr/bin/python` no longer exists — only `/usr/bin/python3` ships. Every PRISM hook silently died on those systems with:

```
SessionStart:startup hook error
Failed with non-blocking status code: /bin/sh: 1: python: not found
```

That broke **the entire autonomous learning loop** for resolve users:
- Edits never reach Brain (PostToolUse `prism-edit-learn` dead)
- Graph never rebuilds at session end (Stop `prism-idle-rebuild` dead)
- Drift never gets caught at session start (SessionStart `prism-sync` dead)
- Session metrics never recorded (Stop `prism-stop` dead)
- Implicit retrieval feedback never collected (PostToolUse `prism-feedback-signal` dead)

Hook scripts themselves were already shebanged `#!/usr/bin/env python3` — only the installer's wrapper command was wrong.

## Fix

Switch to `python3` in all 7 hook commands in `_install_manifest`:
- SessionStart × 1 (`prism-sync.py`)
- PostToolUse × 3 (`prism-feedback-signal.py`, `prism-skill-usage.py`, `prism-edit-learn.py`)
- Stop × 2 (`prism-stop.py`, `prism-idle-rebuild.py`)
- SubagentStop × 1 (`prism-subagent.py`)

Cross-platform compat:
| OS | `python3` works? |
|---|---|
| Linux (Ubuntu 20.04+, Debian 11+, Fedora, Arch) | ✅ |
| macOS | ✅ (Apple ships `/usr/bin/python3`) |
| Windows (python.org installer) | ✅ (`python3.exe` shipped since 3.4) |

## Test plan

- [x] `test_install_settings_wires_all_shipped_hooks` extended to assert (a) `python ` with trailing space does NOT appear in any hook command, (b) ≥7 commands use the `python3 ` prefix
- [x] Full unit suite: 109/109 pass
- [x] Pre-commit docs validation + portability checks pass

## Note for resolve users post-merge

You'll need to re-run `prism_install` so the corrected manifest rewrites your `.claude/settings.json`. After that, the hooks fire correctly on next Claude Code restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)