### PR TITLE
feat(graph): AC6 — exclude rationale nodes from graph_query/find_references by default

### DIFF
--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -2916,27 +2916,42 @@ class Brain:
         entity: str,
         relation: Optional[str] = None,
         limit: int = 10,
+        include_rationale: bool = False,
     ) -> list[dict]:
-        """Traverse entity relationships and return related entities."""
+        """Traverse entity relationships and return related entities.
+
+        ``include_rationale`` defaults to False so rationale nodes
+        (graphify-extracted ``# WHY:`` / ``# HACK:`` / ``# NOTE:``
+        comments stored as ``kind='rationale'``) don't pollute graph
+        traversal results — they account for ~43% of nodes in a typical
+        graph and answer different questions than code-flow traversal.
+        Pass ``True`` to surface them when intent metadata is the goal.
+        """
         ent_row = self._graph.execute(
             "SELECT id FROM entities WHERE name = ? LIMIT 1", (entity,)
         ).fetchone()
         if not ent_row:
             return []
         eid = ent_row["id"]
+        rat_clause = "" if include_rationale else (
+            " AND COALESCE(e.kind,'') != 'rationale'"
+        )
         try:
             if relation:
                 rows = self._graph.execute(
-                    "SELECT e.name, e.kind, e.file, r.relation FROM relationships r "
+                    "SELECT e.name, e.kind, e.file, r.relation "
+                    "FROM relationships r "
                     "JOIN entities e ON e.id = r.target_id "
-                    "WHERE r.source_id = ? AND r.relation = ? LIMIT ?",
+                    f"WHERE r.source_id = ? AND r.relation = ?{rat_clause} "
+                    "LIMIT ?",
                     (eid, relation, limit),
                 ).fetchall()
             else:
                 rows = self._graph.execute(
-                    "SELECT e.name, e.kind, e.file, r.relation FROM relationships r "
+                    "SELECT e.name, e.kind, e.file, r.relation "
+                    "FROM relationships r "
                     "JOIN entities e ON e.id = r.target_id "
-                    "WHERE r.source_id = ? LIMIT ?",
+                    f"WHERE r.source_id = ?{rat_clause} LIMIT ?",
                     (eid, limit),
                 ).fetchall()
             return [
@@ -3005,6 +3020,7 @@ class Brain:
 
     def find_references(
         self, name: str, limit: int = 20,
+        include_rationale: bool = False,
     ) -> list[dict]:
         """Return call sites referencing ``name`` via the graph.
 
@@ -3012,6 +3028,11 @@ class Brain:
         relationships. For each caller, returns its name/kind/file and
         the relation type. No chunk body — use find_symbol() on the
         returned caller names for content.
+
+        ``include_rationale`` defaults to False so ``rationale_for``
+        edges (rationale-comment → entity-it-explains) don't show up
+        as fake "callers". Pass True when looking for intent metadata
+        attached to ``name``.
         """
         try:
             tgt = self._graph.execute(
@@ -3019,12 +3040,15 @@ class Brain:
             ).fetchone()
             if not tgt:
                 return []
+            rat_clause = "" if include_rationale else (
+                " AND COALESCE(e.kind,'') != 'rationale'"
+            )
             rows = self._graph.execute(
                 "SELECT e.name AS caller_name, e.kind AS caller_kind, "
                 "e.file AS caller_file, r.relation AS relation "
                 "FROM relationships r "
                 "JOIN entities e ON e.id = r.source_id "
-                "WHERE r.target_id = ? LIMIT ?",
+                f"WHERE r.target_id = ?{rat_clause} LIMIT ?",
                 (tgt["id"], int(limit)),
             ).fetchall()
         except Exception:

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -160,13 +160,23 @@ TOOLS: list[Tool] = [
             "Each result is {caller_name, caller_kind, caller_file, "
             "relation}. Use find_symbol() on a caller_name to fetch its "
             "chunk content. Replaces 'grep for foo(' with a semantic "
-            "query that respects function boundaries."
+            "query that respects function boundaries. By default skips "
+            "rationale-comment edges; set include_rationale=true to "
+            "include them when surfacing intent metadata."
         ),
         inputSchema={
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
                 "limit": {"type": "integer", "default": 20},
+                "include_rationale": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Include rationale-comment edges "
+                        "(rationale_for relation). Default false."
+                    ),
+                },
             },
             "required": ["name"],
         },
@@ -391,13 +401,29 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="brain_graph",
-        description="Query the knowledge graph for entity relationships",
+        description=(
+            "Query the knowledge graph for entity relationships. By "
+            "default excludes rationale nodes (kind='rationale') so "
+            "graph traversal returns code-flow targets, not "
+            "graphify-extracted comment metadata."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "entity": {"type": "string", "description": "Entity name to query"},
-                "relation": {"type": "string", "description": "Filter by relation type"},
-                "limit": {"type": "integer", "description": "Max results", "default": 10},
+                "entity": {"type": "string",
+                           "description": "Entity name to query"},
+                "relation": {"type": "string",
+                             "description": "Filter by relation type"},
+                "limit": {"type": "integer",
+                          "description": "Max results", "default": 10},
+                "include_rationale": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Include rationale nodes (kind='rationale') "
+                        "in results. Default false."
+                    ),
+                },
             },
             "required": ["entity"],
         },
@@ -2169,6 +2195,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
             results = brain_svc.find_references(
                 name=arguments["name"],
                 limit=arguments.get("limit", 20),
+                include_rationale=arguments.get("include_rationale", False),
             )
             return [TextContent(type="text", text=_json(results))]
 
@@ -2288,6 +2315,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 entity=arguments["entity"],
                 relation=arguments.get("relation"),
                 limit=arguments.get("limit", 10),
+                include_rationale=arguments.get("include_rationale", False),
             )
             return [TextContent(type="text", text=_json(results))]
 

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -174,11 +174,20 @@ class BrainService:
         entity: str,
         relation: Optional[str] = None,
         limit: int = 10,
+        include_rationale: bool = False,
     ) -> list[dict]:
-        """Query the knowledge graph."""
+        """Query the knowledge graph.
+
+        Rationale nodes (kind='rationale', graphify-extracted intent
+        comments) are excluded by default. Pass include_rationale=True
+        to include them.
+        """
         if not self._available or self._brain is None:
             return []
-        return self._brain.graph_query(entity, relation=relation, limit=limit)
+        return self._brain.graph_query(
+            entity, relation=relation, limit=limit,
+            include_rationale=include_rationale,
+        )
 
     def find_symbol(
         self,
@@ -199,11 +208,19 @@ class BrainService:
 
     def find_references(
         self, name: str, limit: int = 20,
+        include_rationale: bool = False,
     ) -> list[dict]:
-        """Return callers of ``name`` from the graph (caller_name/kind/file)."""
+        """Return callers of ``name`` from the graph (caller_name/kind/file).
+
+        Rationale-comment "callers" (rationale_for edges) are excluded
+        by default; pass include_rationale=True to surface them.
+        """
         if not self._available or self._brain is None:
             return []
-        return self._brain.find_references(name=name, limit=limit)
+        return self._brain.find_references(
+            name=name, limit=limit,
+            include_rationale=include_rationale,
+        )
 
     def call_chain(
         self, entity: str, depth: int = 2, limit: int = 50,

--- a/services/prism-service/tests/unit/test_brain_rationale_filter.py
+++ b/services/prism-service/tests/unit/test_brain_rationale_filter.py
@@ -1,0 +1,168 @@
+"""AC6 tests — rationale node filter on graph_query / find_references.
+
+Task: 7471514b-5ba6-494e-94a8-d695df4cb1e6 (Close graph-quality gap vs
+GitNexus). AC6: rationale nodes (kind='rationale', graphify-extracted
+# WHY: / # HACK: / # NOTE: comments) should NOT pollute graph
+traversal results by default — they account for ~43% of nodes in a
+typical PRISM graph and answer different questions than code-flow
+traversal. Surface them only when callers ask via include_rationale=True.
+
+Seeds graph.db directly so tests don't depend on graphify being
+installed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_graph(graph_db: str) -> None:
+    """Seed a tiny graph: 'Target' is referenced by one real caller
+    ('RealCaller', kind='function') AND one rationale node
+    ('RationaleNote', kind='rationale'). Also gives 'Target' an
+    outbound edge to a real callee plus an outbound rationale_for
+    edge to verify graph_query filtering on the target side."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("Target", "function", "src/target.py", 10),
+        )
+        target_id = cur.lastrowid
+
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("RealCaller", "function", "src/caller.py", 5),
+        )
+        real_caller_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("RationaleNote", "rationale", "src/target.py", 9),
+        )
+        rationale_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("RealCallee", "function", "src/callee.py", 1),
+        )
+        real_callee_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("WhyTargetExists", "rationale", "src/callee.py", 1),
+        )
+        rationale_callee_id = cur.lastrowid
+
+        # Inbound edges to Target — one real call, one rationale_for
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (real_caller_id, target_id, "calls"),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (rationale_id, target_id, "rationale_for"),
+        )
+        # Outbound edges from Target — one real call, one rationale_for
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (target_id, real_callee_id, "calls"),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (target_id, rationale_callee_id, "rationale_for"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed_graph(str(tmp_path / "graph.db"))
+    return b
+
+
+# ---------------------------------------------------------------------------
+# find_references
+# ---------------------------------------------------------------------------
+
+
+def test_find_references_excludes_rationale_by_default(brain):
+    """AC6 default: only real callers come back; rationale_for edges
+    are filtered."""
+    refs = brain.find_references("Target")
+    callers = {r["caller_name"] for r in refs}
+    assert callers == {"RealCaller"}, (
+        f"default should exclude rationale callers; got {callers!r}"
+    )
+
+
+def test_find_references_includes_rationale_when_opted_in(brain):
+    """AC6 opt-in: include_rationale=True surfaces both real callers
+    and rationale_for edges."""
+    refs = brain.find_references("Target", include_rationale=True)
+    callers = {r["caller_name"] for r in refs}
+    assert callers == {"RealCaller", "RationaleNote"}
+
+
+# ---------------------------------------------------------------------------
+# graph_query
+# ---------------------------------------------------------------------------
+
+
+def test_graph_query_excludes_rationale_targets_by_default(brain):
+    """AC6 default: outbound traversal skips rationale-kind targets."""
+    rows = brain.graph_query("Target")
+    names = {r["name"] for r in rows}
+    assert names == {"RealCallee"}
+
+
+def test_graph_query_includes_rationale_when_opted_in(brain):
+    """AC6 opt-in: include_rationale=True returns rationale targets too."""
+    rows = brain.graph_query("Target", include_rationale=True)
+    names = {r["name"] for r in rows}
+    assert names == {"RealCallee", "WhyTargetExists"}
+
+
+def test_graph_query_with_relation_filter_still_filters_rationale(brain):
+    """AC6 + existing relation filter: combining both works — asking
+    for rationale_for relation returns nothing by default (the targets
+    of rationale_for are themselves kind='rationale')."""
+    rows = brain.graph_query("Target", relation="rationale_for")
+    assert rows == [], (
+        "rationale_for edges point at rationale-kind nodes; should be "
+        "filtered when include_rationale=False"
+    )
+    rows_with = brain.graph_query(
+        "Target", relation="rationale_for", include_rationale=True,
+    )
+    names = {r["name"] for r in rows_with}
+    assert names == {"WhyTargetExists"}
+
+
+def test_graph_query_unknown_entity_returns_empty(brain):
+    """AC6 regression guard: missing start entity still returns []."""
+    assert brain.graph_query("DoesNotExist") == []


### PR DESCRIPTION
## Summary

Closes **AC6** of PRISM task `7471514b-5ba6-494e-94a8-d695df4cb1e6` (Close graph-quality gap vs GitNexus).

Graphify extracts `# WHY:` / `# HACK:` / `# NOTE:` comments as their own entities with `file_type='rationale'`. In PRISM's own graph these are **1855 of 4278 nodes (~43%)**. They get stored as `kind='rationale'` in `graph.db` entities and are linked to the code they explain via the `rationale_for` relation.

The graph-viz UI already filters them (`graph_page.py:189, 481`), but Brain APIs returned them as if they were real callers/callees:

- `find_references('Foo')` would surface a "RationaleNote" caller that's actually a comment block, not a call site
- `graph_query('Foo')` would walk into `rationale_for` edges and return rationale entities as related-target rows

## Fix

Both methods now accept `include_rationale: bool = False`. SQL adds `AND COALESCE(e.kind,'') != 'rationale'` when False. Default behavior is the code-flow view; intent metadata is opt-in.

| Tool | New param | Default |
|---|---|---|
| `brain_find_references` | `include_rationale` | `false` |
| `brain_graph` | `include_rationale` | `false` |

`brain_call_chain` is intentionally untouched on this branch — [PR #47](https://github.com/resolve-io/.prism/pull/47) (AC1) owns the call_chain signature changes; rationale filtering on call_chain can layer on top once AC1 lands.

## Test plan

- [x] 6 new cases in `tests/unit/test_brain_rationale_filter.py` — default exclusion (find_references + graph_query), opt-in inclusion, relation-filter interaction, missing-entity guard
- [x] Full unit suite: 115/115 pass (109 baseline + 6 new)
- [x] Existing C# `find_references` regression test (`test_ac1_find_references_returns_cross_file_caller`) continues to pass — confirms real callers (kind='function') aren't accidentally excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)