### PR TITLE
fix: nav resolves active project against real options (closes #43)

### DIFF
--- a/services/prism-service/app/ui/components/nav.py
+++ b/services/prism-service/app/ui/components/nav.py
@@ -21,6 +21,36 @@ body, .q-page, .nicegui-content {
 """
 
 
+def resolve_active_project(
+    qs_proj: str | None,
+    stored: str | None,
+    projects: list[str],
+) -> str:
+    """Pick the active project from a cascade of signals.
+
+    Issue resolve-io/.prism#43: nav.py used to seed `app.storage.user['project']`
+    to the literal `'default'` sentinel even when real projects existed,
+    then pass that sentinel as `value=` to a `ui.select(options=projects)`
+    where `'default'` was NOT in `options`. NiceGUI raised ValueError and
+    every dashboard page 500'd. Resolve everything against the live
+    `projects` list so the chosen value is guaranteed to be in options.
+
+    Order:
+      1. URL ?project= if it points at a real project
+      2. Stored user value if it points at a real project
+      3. First available project
+      4. ``'default'`` sentinel only if `projects` is empty
+         (matches the `or ['default']` fallback for the options list).
+    """
+    if qs_proj and qs_proj in projects:
+        return qs_proj
+    if stored and stored in projects:
+        return stored
+    if projects:
+        return projects[0]
+    return 'default'
+
+
 def create_nav():
     """Shared navigation header with project selector and page links."""
     from app.project_context import get_all_projects
@@ -34,13 +64,12 @@ def create_nav():
         _qs_proj = _ctx.client.request.query_params.get('project')
     except Exception:
         _qs_proj = None
-    if _qs_proj:
-        app.storage.user['project'] = _qs_proj
-    elif 'project' not in app.storage.user:
-        app.storage.user['project'] = 'default'
 
-    current = app.storage.user['project']
     projects = get_all_projects() or ['default']
+    stored = app.storage.user.get('project')
+    current = resolve_active_project(_qs_proj, stored, projects)
+    # Persist the resolved value so subsequent renders skip the cascade.
+    app.storage.user['project'] = current
 
     with ui.header().classes('items-center justify-between bg-indigo-700 px-6 shadow-md'):
         with ui.row().classes('items-center gap-3'):

--- a/services/prism-service/tests/unit/test_nav_resolve_active_project.py
+++ b/services/prism-service/tests/unit/test_nav_resolve_active_project.py
@@ -1,0 +1,105 @@
+"""Issue #43 tests — resolve_active_project never returns a value
+that's outside the projects list.
+
+resolve-io/.prism#43: nav.py used to seed app.storage.user['project']
+to the literal 'default' sentinel even when real projects existed,
+then pass that sentinel as value= to ui.select(options=projects)
+where 'default' was not in options. NiceGUI raised ValueError and
+every dashboard page 500'd.
+
+The fix extracts a pure helper resolve_active_project(qs_proj, stored,
+projects) that always returns a value guaranteed to be in projects
+(or the 'default' sentinel only when projects is empty, in which case
+the caller's `or ['default']` fallback covers it).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+from app.ui.components.nav import resolve_active_project
+
+
+PROJECTS = ['resolve-platform', 'talentsync', 'prism']
+
+
+def test_url_project_wins_when_valid():
+    """URL ?project= overrides stored value when it points at a real project."""
+    assert resolve_active_project(
+        'talentsync', 'prism', PROJECTS,
+    ) == 'talentsync'
+
+
+def test_url_project_ignored_when_not_in_options():
+    """The bug from #43 — never return a value outside projects.
+    Falls back to stored, then to first project."""
+    assert resolve_active_project(
+        'does-not-exist', 'prism', PROJECTS,
+    ) == 'prism'
+
+
+def test_stored_value_used_when_valid():
+    """No URL hint, stored value is real → keep it."""
+    assert resolve_active_project(None, 'prism', PROJECTS) == 'prism'
+
+
+def test_stored_default_sentinel_replaced_by_real_project():
+    """The exact #43 scenario: stored = 'default', real projects exist.
+    Old code: returned 'default', NiceGUI 500. New code: first project."""
+    assert resolve_active_project(
+        None, 'default', PROJECTS,
+    ) == 'resolve-platform'
+
+
+def test_first_project_when_no_stored_value():
+    """First visit, no cookies, projects exist → first project."""
+    assert resolve_active_project(None, None, PROJECTS) == 'resolve-platform'
+
+
+def test_first_project_when_stored_value_is_stale():
+    """Project was deleted but cookie still references it → fall back."""
+    assert resolve_active_project(
+        None, 'deleted-project', PROJECTS,
+    ) == 'resolve-platform'
+
+
+def test_default_sentinel_only_when_projects_empty():
+    """Truly empty install (first run, nothing onboarded) → return
+    'default' so the caller's `or ['default']` options fallback aligns."""
+    assert resolve_active_project(None, None, []) == 'default'
+    assert resolve_active_project('foo', 'bar', []) == 'default'
+
+
+def test_empty_string_qs_proj_does_not_match():
+    """Empty string from URL parsing isn't a real project."""
+    assert resolve_active_project('', 'prism', PROJECTS) == 'prism'
+
+
+def test_returned_value_always_in_options_or_default():
+    """Property test: for any combination of inputs, the result is
+    either in projects OR the literal 'default' sentinel (which is
+    fine because the caller falls back to `['default']` options when
+    projects is empty)."""
+    test_cases = [
+        ('valid', 'valid-stored', PROJECTS),
+        ('invalid', 'invalid', PROJECTS),
+        (None, None, PROJECTS),
+        ('', '', PROJECTS),
+        ('resolve-platform', 'talentsync', PROJECTS),
+        (None, None, []),
+        ('foo', 'bar', []),
+    ]
+    for qs, stored, projects in test_cases:
+        result = resolve_active_project(qs, stored, projects)
+        assert result in projects or result == 'default', (
+            f"resolve_active_project({qs!r}, {stored!r}, {projects!r}) "
+            f"returned {result!r} which is neither in projects nor 'default'"
+        )


### PR DESCRIPTION
Closes #43.

## Problem

The PRISM dashboard at `:7778` (post-port-move) returned 500 on every page (`/`, `/brain`, `/graph`, …) for any user whose `app.storage.user['project']` wasn't already set to a valid project — first visit, cleared cookies, fresh container, deleted project.

`app/ui/components/nav.py:39-55` seeded the active project to the literal `'default'` sentinel, then passed it as `value=` to `ui.select(options=projects, ...)` where `options = get_all_projects()`. The literal `'default'` was not in `options`, so NiceGUI raised:

```
ValueError: Invalid value: default
```

Container logs showed it twice — once for the page render, once when NiceGUI's own `create_500_error_page` re-raised while rendering the error page, so the user got an unhelpful 500 instead of a fallback.

## Fix

Extracted a pure helper `resolve_active_project(qs_proj, stored, projects)` that always returns a value guaranteed to be in `projects` (or the `'default'` sentinel only when `projects` is empty, matching the caller's `or ['default']` options fallback).

Cascade:
1. URL `?project=` if it points at a real project
2. Stored user value if it points at a real project
3. First available project
4. `'default'` sentinel only if no projects exist

## Test plan

- [x] 9 new cases in `tests/unit/test_nav_resolve_active_project.py`:
  - URL hint wins when valid; ignored when invalid
  - Stale stored value (deleted project) recovers gracefully
  - Empty-string URL doesn't match any project
  - Empty projects list returns the `'default'` sentinel
  - Property-style sweep: result is always in `projects` OR the sentinel
- [x] Full unit suite: 118/118 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)