### PR TITLE
feat(graph): AC3 — surface confidence + confidence_score in call_chain

### DIFF
--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3147,7 +3147,9 @@ class Brain:
                 "s.name AS src_name, t.name AS tgt_name, "
                 "t.kind AS tgt_kind, t.id AS tgt_id, "
                 "s.kind AS src_kind, "
-                "r.relation AS relation, r.target_id AS tgt_id_raw "
+                "r.relation AS relation, r.target_id AS tgt_id_raw, "
+                "r.confidence AS confidence, "
+                "r.confidence_score AS confidence_score "
                 "FROM relationships r "
                 "JOIN entities s ON s.id = r.source_id "
                 "JOIN entities t ON t.id = r.target_id "
@@ -3172,11 +3174,22 @@ class Brain:
                 # direction. The 'direction' field marks how this edge
                 # was discovered — useful when the caller passed
                 # direction='both' and wants to partition results.
+                # confidence_score may be NULL for edges from the
+                # legacy tree-sitter pass (graphify started populating
+                # it in v0.4.x). Coerce to a float so the API stays
+                # uniform; treat missing as 1.0 (extracted-with-no-doubt
+                # is the conservative interpretation for legacy edges).
+                conf_raw = r["confidence_score"]
+                conf_score = (
+                    float(conf_raw) if conf_raw is not None else 1.0
+                )
                 edges.append({
                     "from": r["src_name"], "to": r["tgt_name"],
                     "kind": r["tgt_kind"] if direction == "callees"
                     else r["src_kind"],
                     "relation": r["relation"],
+                    "confidence": r["confidence"] or "EXTRACTED",
+                    "confidence_score": conf_score,
                     "hop": hop,
                     "direction": direction,
                 })

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3037,20 +3037,31 @@ class Brain:
         depth: int = 2,
         limit: int = 50,
         relation: str | list[str] | tuple[str, ...] | None = "calls",
+        direction: str = "callees",
     ) -> list[dict]:
         """Bounded BFS on the relationships graph starting at ``entity``.
 
-        Returns a flat list of edges [{from, to, kind, relation, hop}]
-        so the caller can reconstruct either tree or flat views. Hop 0
-        is the entity itself; hop 1 is direct callees; etc.
+        Returns a flat list of edges [{from, to, kind, relation, hop,
+        direction}] so the caller can reconstruct either tree or flat
+        views. Hop 1 is direct neighbours; hop 2 is neighbours-of-
+        neighbours; etc.
 
         ``relation`` filters edges by their relation kind. Default is
         ``"calls"`` so structural edges (``contains``/``method``/``uses``
-        /``imports_from``) don't eat the depth+limit budget — those tend
-        to dominate in number while adding nothing to a call-flow trace.
-        Pass ``None`` (or the string ``"*"``) to include every relation
-        kind (legacy pre-v4.7 behavior); pass a list/tuple of strings to
-        accept several kinds.
+        /``imports_from``) don't eat the depth+limit budget. Pass
+        ``None`` or ``"*"`` for every kind; list/tuple for several kinds.
+
+        ``direction`` controls traversal:
+          * ``"callees"`` (default) — walk forward on source_id IN frontier;
+            answers "what does ``entity`` transitively call?"
+          * ``"callers"`` — walk backward on target_id IN frontier; the
+            blast-radius primitive — answers "who would break if I change
+            ``entity``?"
+          * ``"both"`` — union of the two; useful for impact analysis
+            that needs both upstream and downstream edges in one query.
+
+        Each edge carries its ``direction`` so callers of "both" can
+        partition the result.
         """
         # Normalize the relation filter into a list of allowed kinds
         # (or None meaning "no filter").
@@ -3064,6 +3075,18 @@ class Brain:
             if not allowed:
                 allowed = None
 
+        # Normalize direction; tolerate plurals and casing.
+        dir_norm = (direction or "callees").lower().strip()
+        if dir_norm in ("callee", "down", "forward", "out"):
+            dir_norm = "callees"
+        elif dir_norm in ("caller", "up", "reverse", "back", "in",
+                          "blast", "blast_radius"):
+            dir_norm = "callers"
+        elif dir_norm in ("bidirectional", "all", "either"):
+            dir_norm = "both"
+        if dir_norm not in ("callees", "callers", "both"):
+            dir_norm = "callees"
+
         try:
             start = self._graph.execute(
                 "SELECT id, name FROM entities WHERE name = ? LIMIT 1",
@@ -3071,45 +3094,97 @@ class Brain:
             ).fetchone()
             if not start:
                 return []
-            visited = {start["id"]}
-            frontier = [start["id"]]
             edges: list[dict] = []
-            for hop in range(1, max(1, int(depth)) + 1):
-                if not frontier or len(edges) >= limit:
-                    break
-                placeholders = ",".join("?" * len(frontier))
-                sql = (
-                    f"SELECT r.source_id AS src_id, "
-                    f"s.name AS src_name, t.name AS tgt_name, "
-                    f"t.kind AS tgt_kind, t.id AS tgt_id, "
-                    f"r.relation AS relation "
-                    f"FROM relationships r "
-                    f"JOIN entities s ON s.id = r.source_id "
-                    f"JOIN entities t ON t.id = r.target_id "
-                    f"WHERE r.source_id IN ({placeholders})"
+            seen_edges: set[tuple[int, int, str]] = set()
+            directions = (
+                ["callees", "callers"] if dir_norm == "both" else [dir_norm]
+            )
+            for one_dir in directions:
+                self._walk_chain(
+                    start_id=start["id"], depth=depth, limit=limit,
+                    allowed=allowed, direction=one_dir,
+                    edges=edges, seen_edges=seen_edges,
                 )
-                params: list = [*frontier]
-                if allowed is not None:
-                    rel_placeholders = ",".join("?" * len(allowed))
-                    sql += f" AND r.relation IN ({rel_placeholders})"
-                    params.extend(allowed)
-                sql += " LIMIT ?"
-                params.append(int(limit) - len(edges))
-                rows = self._graph.execute(sql, params).fetchall()
-                next_frontier: list[int] = []
-                for r in rows:
-                    edges.append({
-                        "from": r["src_name"], "to": r["tgt_name"],
-                        "kind": r["tgt_kind"], "relation": r["relation"],
-                        "hop": hop,
-                    })
-                    if r["tgt_id"] not in visited:
-                        visited.add(r["tgt_id"])
-                        next_frontier.append(r["tgt_id"])
-                frontier = next_frontier
             return edges
         except Exception:
             return []
+
+    def _walk_chain(
+        self,
+        *,
+        start_id: int,
+        depth: int,
+        limit: int,
+        allowed: list[str] | None,
+        direction: str,
+        edges: list[dict],
+        seen_edges: set[tuple[int, int, str]],
+    ) -> None:
+        """One-direction BFS used by call_chain.
+
+        For ``direction='callees'`` the frontier is on source_id and we
+        advance via target_id (forward call flow). For ``'callers'`` it
+        flips: frontier on target_id, advance via source_id (reverse).
+        Edges are appended to the shared ``edges`` list; ``seen_edges``
+        de-dupes when called twice (direction='both' case).
+        """
+        # Pivot column the frontier matches against, and the column to
+        # advance to next hop.
+        if direction == "callers":
+            frontier_col = "r.target_id"
+            advance_col = "src_id"
+        else:
+            frontier_col = "r.source_id"
+            advance_col = "tgt_id"
+        visited = {start_id}
+        frontier = [start_id]
+        for hop in range(1, max(1, int(depth)) + 1):
+            if not frontier or len(edges) >= limit:
+                break
+            placeholders = ",".join("?" * len(frontier))
+            sql = (
+                "SELECT r.source_id AS src_id, "
+                "s.name AS src_name, t.name AS tgt_name, "
+                "t.kind AS tgt_kind, t.id AS tgt_id, "
+                "s.kind AS src_kind, "
+                "r.relation AS relation, r.target_id AS tgt_id_raw "
+                "FROM relationships r "
+                "JOIN entities s ON s.id = r.source_id "
+                "JOIN entities t ON t.id = r.target_id "
+                f"WHERE {frontier_col} IN ({placeholders})"
+            )
+            params: list = [*frontier]
+            if allowed is not None:
+                rel_placeholders = ",".join("?" * len(allowed))
+                sql += f" AND r.relation IN ({rel_placeholders})"
+                params.extend(allowed)
+            sql += " LIMIT ?"
+            params.append(int(limit) - len(edges))
+            rows = self._graph.execute(sql, params).fetchall()
+            next_frontier: list[int] = []
+            for r in rows:
+                key = (r["src_id"], r["tgt_id_raw"], r["relation"])
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
+                # 'from' / 'to' always reflect the underlying call edge
+                # direction (caller → callee), regardless of traversal
+                # direction. The 'direction' field marks how this edge
+                # was discovered — useful when the caller passed
+                # direction='both' and wants to partition results.
+                edges.append({
+                    "from": r["src_name"], "to": r["tgt_name"],
+                    "kind": r["tgt_kind"] if direction == "callees"
+                    else r["src_kind"],
+                    "relation": r["relation"],
+                    "hop": hop,
+                    "direction": direction,
+                })
+                advance_id = r[advance_col]
+                if advance_id not in visited:
+                    visited.add(advance_id)
+                    next_frontier.append(advance_id)
+            frontier = next_frontier
 
     # ------------------------------------------------------------------
     # Ingest

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -795,6 +795,21 @@ class Brain:
             CREATE INDEX IF NOT EXISTS idx_rel_src ON relationships(source_id);
             CREATE INDEX IF NOT EXISTS idx_rel_tgt ON relationships(target_id);
         """)
+        # Apply the graphify-side schema extensions (confidence,
+        # confidence_score, weight, source_location, communities,
+        # graphify_id, etc.) so call_chain / graph_query can rely on
+        # those columns existing without depending on _import_graph_json
+        # having run first. Idempotent — each ALTER guards on
+        # PRAGMA table_info.
+        try:
+            from app.services.graph_service import _graph_schema_migrations
+            _graph_schema_migrations(self._graph)
+        except Exception:
+            # Tests with stripped imports / circular-import edge cases
+            # fall through silently — the SELECT will then raise and
+            # the call_chain except-clause returns []. Production has
+            # the import path available.
+            pass
 
     def _init_scores_schema(self) -> None:
         self._scores.executescript("""

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3036,13 +3036,34 @@ class Brain:
         entity: str,
         depth: int = 2,
         limit: int = 50,
+        relation: str | list[str] | tuple[str, ...] | None = "calls",
     ) -> list[dict]:
         """Bounded BFS on the relationships graph starting at ``entity``.
 
         Returns a flat list of edges [{from, to, kind, relation, hop}]
         so the caller can reconstruct either tree or flat views. Hop 0
         is the entity itself; hop 1 is direct callees; etc.
+
+        ``relation`` filters edges by their relation kind. Default is
+        ``"calls"`` so structural edges (``contains``/``method``/``uses``
+        /``imports_from``) don't eat the depth+limit budget — those tend
+        to dominate in number while adding nothing to a call-flow trace.
+        Pass ``None`` (or the string ``"*"``) to include every relation
+        kind (legacy pre-v4.7 behavior); pass a list/tuple of strings to
+        accept several kinds.
         """
+        # Normalize the relation filter into a list of allowed kinds
+        # (or None meaning "no filter").
+        allowed: list[str] | None
+        if relation is None or relation == "*" or relation == "":
+            allowed = None
+        elif isinstance(relation, str):
+            allowed = [relation]
+        else:
+            allowed = [str(r) for r in relation if r]
+            if not allowed:
+                allowed = None
+
         try:
             start = self._graph.execute(
                 "SELECT id, name FROM entities WHERE name = ? LIMIT 1",
@@ -3057,7 +3078,7 @@ class Brain:
                 if not frontier or len(edges) >= limit:
                     break
                 placeholders = ",".join("?" * len(frontier))
-                rows = self._graph.execute(
+                sql = (
                     f"SELECT r.source_id AS src_id, "
                     f"s.name AS src_name, t.name AS tgt_name, "
                     f"t.kind AS tgt_kind, t.id AS tgt_id, "
@@ -3065,10 +3086,16 @@ class Brain:
                     f"FROM relationships r "
                     f"JOIN entities s ON s.id = r.source_id "
                     f"JOIN entities t ON t.id = r.target_id "
-                    f"WHERE r.source_id IN ({placeholders}) "
-                    f"LIMIT ?",
-                    (*frontier, int(limit) - len(edges)),
-                ).fetchall()
+                    f"WHERE r.source_id IN ({placeholders})"
+                )
+                params: list = [*frontier]
+                if allowed is not None:
+                    rel_placeholders = ",".join("?" * len(allowed))
+                    sql += f" AND r.relation IN ({rel_placeholders})"
+                    params.extend(allowed)
+                sql += " LIMIT ?"
+                params.append(int(limit) - len(edges))
+                rows = self._graph.execute(sql, params).fetchall()
                 next_frontier: list[int] = []
                 for r in rows:
                     edges.append({

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -177,8 +177,10 @@ TOOLS: list[Tool] = [
             "Bounded BFS over the call graph starting at ``entity``. "
             "Returns a flat edge list [{from, to, kind, relation, hop}] "
             "so you can reconstruct 'what does this entity transitively "
-            "call'. Use to understand flow without Reading multiple "
-            "files."
+            "call'. By default only follows ``calls`` edges so "
+            "structural relations (contains/method/uses/imports_from) "
+            "don't fill the depth+limit budget; pass ``relation=\"*\"`` "
+            "to include every kind."
         ),
         inputSchema={
             "type": "object",
@@ -187,6 +189,16 @@ TOOLS: list[Tool] = [
                 "depth": {"type": "integer", "default": 2,
                           "description": "max hops (default 2)"},
                 "limit": {"type": "integer", "default": 50},
+                "relation": {
+                    "type": "string",
+                    "default": "calls",
+                    "description": (
+                        "Edge-kind filter: 'calls' (default) follows "
+                        "only call edges; '*' (or empty) includes "
+                        "every relation kind; any other value (e.g. "
+                        "'uses', 'inherits') filters to that one kind."
+                    ),
+                },
             },
             "required": ["entity"],
         },
@@ -2177,6 +2189,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 entity=arguments["entity"],
                 depth=arguments.get("depth", 2),
                 limit=arguments.get("limit", 50),
+                relation=arguments.get("relation", "calls"),
             )
             return [TextContent(type="text", text=_json(results))]
 

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -175,12 +175,12 @@ TOOLS: list[Tool] = [
         name="brain_call_chain",
         description=(
             "Bounded BFS over the call graph starting at ``entity``. "
-            "Returns a flat edge list [{from, to, kind, relation, hop}] "
-            "so you can reconstruct 'what does this entity transitively "
-            "call'. By default only follows ``calls`` edges so "
-            "structural relations (contains/method/uses/imports_from) "
-            "don't fill the depth+limit budget; pass ``relation=\"*\"`` "
-            "to include every kind."
+            "Returns a flat edge list [{from, to, kind, relation, hop, "
+            "direction}] so you can reconstruct call flow OR blast "
+            "radius. By default follows only ``calls`` edges and walks "
+            "forward (callees). Set direction='callers' to answer "
+            "'who would break if I change this?' or direction='both' "
+            "for full impact analysis."
         ),
         inputSchema={
             "type": "object",
@@ -197,6 +197,17 @@ TOOLS: list[Tool] = [
                         "only call edges; '*' (or empty) includes "
                         "every relation kind; any other value (e.g. "
                         "'uses', 'inherits') filters to that one kind."
+                    ),
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["callees", "callers", "both"],
+                    "default": "callees",
+                    "description": (
+                        "BFS direction. 'callees' (default) = forward "
+                        "call flow; 'callers' = blast radius (who "
+                        "calls this); 'both' = union, with each edge "
+                        "tagged by how it was discovered."
                     ),
                 },
             },
@@ -2190,6 +2201,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 depth=arguments.get("depth", 2),
                 limit=arguments.get("limit", 50),
                 relation=arguments.get("relation", "calls"),
+                direction=arguments.get("direction", "callees"),
             )
             return [TextContent(type="text", text=_json(results))]
 

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -211,18 +211,19 @@ class BrainService:
         depth: int = 2,
         limit: int = 50,
         relation: str | list[str] | tuple[str, ...] | None = "calls",
+        direction: str = "callees",
     ) -> list[dict]:
         """Bounded BFS over the call graph from ``entity``.
 
-        ``relation`` defaults to ``"calls"`` so structural edges
-        (contains/method/uses/imports_from) don't crowd out real call
-        edges within the depth+limit budget. Pass ``None`` or ``"*"``
-        for legacy unfiltered behavior.
+        ``direction`` is the blast-radius primitive — ``"callees"``
+        (default) walks forward, ``"callers"`` walks backward (who would
+        break if I change ``entity``?), ``"both"`` unions the two.
         """
         if not self._available or self._brain is None:
             return []
         return self._brain.call_chain(
             entity=entity, depth=depth, limit=limit, relation=relation,
+            direction=direction,
         )
 
     def record_session_outcome(

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -206,13 +206,23 @@ class BrainService:
         return self._brain.find_references(name=name, limit=limit)
 
     def call_chain(
-        self, entity: str, depth: int = 2, limit: int = 50,
+        self,
+        entity: str,
+        depth: int = 2,
+        limit: int = 50,
+        relation: str | list[str] | tuple[str, ...] | None = "calls",
     ) -> list[dict]:
-        """Bounded BFS over the call graph from ``entity``."""
+        """Bounded BFS over the call graph from ``entity``.
+
+        ``relation`` defaults to ``"calls"`` so structural edges
+        (contains/method/uses/imports_from) don't crowd out real call
+        edges within the depth+limit budget. Pass ``None`` or ``"*"``
+        for legacy unfiltered behavior.
+        """
         if not self._available or self._brain is None:
             return []
         return self._brain.call_chain(
-            entity=entity, depth=depth, limit=limit,
+            entity=entity, depth=depth, limit=limit, relation=relation,
         )
 
     def record_session_outcome(

--- a/services/prism-service/tests/unit/test_brain_call_chain_confidence.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_confidence.py
@@ -1,0 +1,110 @@
+"""AC3 tests — surface confidence + confidence_score in call_chain.
+
+Task: 7471514b. AC3: brain_call_chain returns the per-edge confidence
+tier (EXTRACTED/INFERRED/AMBIGUOUS) and confidence_score (0.0-1.0).
+Already stored on relationships, just needs to flow through the SELECT
+and result mapping.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed(graph_db: str) -> None:
+    """A → B (EXTRACTED, 1.0), A → C (INFERRED, 0.6),
+       A → D (no confidence columns populated — legacy edge)."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        # Apply graphify schema migrations so the confidence columns
+        # exist on the relationships table (production code calls these
+        # during _import_graph_json; tests bypass that path).
+        from app.services.graph_service import _graph_schema_migrations
+        _graph_schema_migrations(conn)
+        ids = {}
+        for n in ("A", "B", "C", "D"):
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (n, "function", f"src/{n.lower()}.py", 1),
+            )
+            ids[n] = cur.lastrowid
+        # Two edges with confidence populated, one legacy edge with NULLs.
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation, confidence, "
+            " confidence_score) VALUES (?, ?, 'calls', 'EXTRACTED', 1.0)",
+            (ids["A"], ids["B"]),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation, confidence, "
+            " confidence_score) VALUES (?, ?, 'calls', 'INFERRED', 0.6)",
+            (ids["A"], ids["C"]),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) "
+            "VALUES (?, ?, 'calls')",
+            (ids["A"], ids["D"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_extracted_edge_carries_full_confidence(brain):
+    edges = brain.call_chain("A", limit=100)
+    a_to_b = next(e for e in edges if e["to"] == "B")
+    assert a_to_b["confidence"] == "EXTRACTED"
+    assert a_to_b["confidence_score"] == 1.0
+
+
+def test_inferred_edge_carries_lower_score(brain):
+    edges = brain.call_chain("A", limit=100)
+    a_to_c = next(e for e in edges if e["to"] == "C")
+    assert a_to_c["confidence"] == "INFERRED"
+    assert a_to_c["confidence_score"] == pytest.approx(0.6)
+
+
+def test_legacy_edge_with_null_confidence_defaults_to_extracted_1(brain):
+    """AC3: legacy tree-sitter edges (pre-graphify) have NULL
+    confidence columns. Default to EXTRACTED / 1.0 so the result
+    schema is uniform — matches what _import_graph_json writes for
+    new edges with no explicit confidence."""
+    edges = brain.call_chain("A", limit=100)
+    a_to_d = next(e for e in edges if e["to"] == "D")
+    assert a_to_d["confidence"] == "EXTRACTED"
+    assert a_to_d["confidence_score"] == 1.0
+
+
+def test_callers_direction_also_carries_confidence(brain):
+    """AC2 + AC3 interaction: confidence flows through in both
+    directions (no shared SQL means we have to verify)."""
+    edges = brain.call_chain("B", direction="callers")
+    e = edges[0]
+    assert e["confidence"] == "EXTRACTED"
+    assert e["confidence_score"] == 1.0
+    assert e["from"] == "A"

--- a/services/prism-service/tests/unit/test_brain_call_chain_direction.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_direction.py
@@ -1,0 +1,168 @@
+"""AC2 tests — brain_call_chain `direction` blast-radius primitive.
+
+Task: 7471514b. AC2: brain_call_chain accepts direction in
+{'callees','callers','both'}. 'callers' answers "who would break if I
+change this?" — the actual blast-radius primitive. 'both' returns the
+union with each edge tagged so callers can partition.
+
+Stacks on top of AC1 (relation filter). Tests build a tiny chain
+A → B → C with branching so we can verify hop counts and edge tags.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed(graph_db: str) -> dict:
+    """Seed graph: A→B→C (linear chain) plus X→B (extra caller of B).
+
+    From B's perspective:
+      callees: B → C
+      callers: A → B  AND  X → B
+      both: union of the above
+    """
+    conn = sqlite3.connect(graph_db)
+    try:
+        ids: dict[str, int] = {}
+        for n in ("A", "B", "C", "X"):
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (n, "function", f"src/{n.lower()}.py", 1),
+            )
+            ids[n] = cur.lastrowid
+        for src, tgt in (("A", "B"), ("B", "C"), ("X", "B")):
+            conn.execute(
+                "INSERT INTO relationships "
+                "(source_id, target_id, relation) VALUES (?, ?, ?)",
+                (ids[src], ids[tgt], "calls"),
+            )
+        conn.commit()
+        return ids
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_callees_default_unchanged(brain):
+    """AC2 default: direction='callees' is the existing behavior —
+    walk forward from B to find C."""
+    edges = brain.call_chain("B")  # default direction='callees'
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("B", "C")}
+    assert all(e["direction"] == "callees" for e in edges)
+
+
+def test_callers_finds_blast_radius(brain):
+    """AC2 blast radius: direction='callers' from B returns A AND X
+    (both call B)."""
+    edges = brain.call_chain("B", direction="callers")
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("A", "B"), ("X", "B")}
+    assert all(e["direction"] == "callers" for e in edges)
+
+
+def test_both_unions_callers_and_callees(brain):
+    """AC2 union: direction='both' returns the call-flow forward AND
+    the blast radius, with each edge tagged."""
+    edges = brain.call_chain("B", direction="both")
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("A", "B"), ("X", "B"), ("B", "C")}
+    by_dir = {e["direction"] for e in edges}
+    assert by_dir == {"callees", "callers"}
+    # Each edge appears exactly once even though 'both' runs two BFS
+    # passes — de-dup by (src, tgt, relation) prevents duplicates.
+    keys = [(e["from"], e["to"], e["relation"]) for e in edges]
+    assert len(keys) == len(set(keys))
+
+
+def test_callers_walks_multiple_hops(brain):
+    """AC2 + depth: from C, callers=2 should reach B (hop 1) and
+    A + X (hop 2)."""
+    edges = brain.call_chain("C", direction="callers", depth=2)
+    by_hop: dict[int, set] = {}
+    for e in edges:
+        by_hop.setdefault(e["hop"], set()).add((e["from"], e["to"]))
+    assert by_hop[1] == {("B", "C")}
+    assert by_hop[2] == {("A", "B"), ("X", "B")}
+
+
+def test_unknown_direction_falls_back_to_callees(brain):
+    """AC2 robustness: garbage direction string defaults to callees,
+    not crashes."""
+    edges = brain.call_chain("B", direction="sideways")
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("B", "C")}
+
+
+def test_direction_aliases(brain):
+    """AC2 ergonomics: common alternate spellings normalize."""
+    for alias in ("caller", "up", "blast_radius"):
+        edges = brain.call_chain("B", direction=alias)
+        pairs = {(e["from"], e["to"]) for e in edges}
+        assert pairs == {("A", "B"), ("X", "B")}, (
+            f"alias {alias!r} should map to 'callers'"
+        )
+    for alias in ("callee", "down", "forward"):
+        edges = brain.call_chain("B", direction=alias)
+        pairs = {(e["from"], e["to"]) for e in edges}
+        assert pairs == {("B", "C")}
+
+
+def test_relation_filter_still_works_with_direction(brain):
+    """AC1 + AC2 interaction: the relation filter applies in both
+    directions. Add a non-call edge from Z to B; filtering for 'calls'
+    excludes it whether walking forward or backward."""
+    import sqlite3 as _sq
+    conn = _sq.connect(brain._graph_db_path) if hasattr(
+        brain, "_graph_db_path") else None
+    # Use the brain's own graph cursor instead.
+    brain._graph.execute(
+        "INSERT INTO entities (name, kind, file, line) VALUES (?,?,?,?)",
+        ("Z", "function", "src/z.py", 1),
+    )
+    z_id = brain._graph.execute(
+        "SELECT id FROM entities WHERE name='Z'"
+    ).fetchone()["id"]
+    b_id = brain._graph.execute(
+        "SELECT id FROM entities WHERE name='B'"
+    ).fetchone()["id"]
+    brain._graph.execute(
+        "INSERT INTO relationships (source_id, target_id, relation) "
+        "VALUES (?, ?, ?)",
+        (z_id, b_id, "uses"),
+    )
+    brain._graph.commit()
+
+    # callers default 'calls' — Z is NOT a caller (uses, not calls)
+    callers = brain.call_chain("B", direction="callers")
+    names = {e["from"] for e in callers}
+    assert "Z" not in names
+    # callers with relation='*' — Z shows up
+    callers_all = brain.call_chain(
+        "B", direction="callers", relation="*",
+    )
+    names_all = {e["from"] for e in callers_all}
+    assert "Z" in names_all

--- a/services/prism-service/tests/unit/test_brain_call_chain_relation_filter.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_relation_filter.py
@@ -1,0 +1,138 @@
+"""AC1 tests — brain_call_chain.relation filter.
+
+Task: 7471514b-5ba6-494e-94a8-d695df4cb1e6 (Close graph-quality gap vs
+GitNexus). AC1: brain_call_chain accepts a `relation` filter; default
+"calls" stops contains/method/uses/imports_from from eating the
+depth+limit budget.
+
+These tests construct a minimal in-memory graph by writing rows
+directly into a Brain instance's graph.db so the assertions don't
+depend on the C# fixture or graphify being installed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_graph(graph_db: str) -> None:
+    """Seed graph.db with a single source 'Hub' that has one outbound
+    edge of each relation kind to a distinct target. Lets us assert
+    that the relation filter selects exactly the right edges."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("Hub", "function", "src/hub.py", 1),
+        )
+        hub_id = cur.lastrowid
+        targets = [
+            ("Callee", "calls"),
+            ("Container", "contains"),
+            ("Used", "uses"),
+            ("MethodOf", "method"),
+            ("ImportedFrom", "imports_from"),
+            ("Parent", "inherits"),
+        ]
+        for tgt_name, rel in targets:
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (tgt_name, "function", f"src/{tgt_name.lower()}.py", 1),
+            )
+            tgt_id = cur.lastrowid
+            conn.execute(
+                "INSERT INTO relationships "
+                "(source_id, target_id, relation) "
+                "VALUES (?, ?, ?)",
+                (hub_id, tgt_id, rel),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    """Brain with a seeded graph but no docs/embeddings — we only
+    exercise the call_chain SQL path here."""
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed_graph(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_default_returns_only_calls_edges(brain):
+    """AC1 default: relation defaults to 'calls'; structural edges
+    (contains/uses/method/imports_from/inherits) are excluded."""
+    edges = brain.call_chain("Hub")
+    assert edges, "expected at least the 'calls' edge to come back"
+    relations = {e["relation"] for e in edges}
+    assert relations == {"calls"}, (
+        f"default relation filter should keep only 'calls'; got "
+        f"{relations!r}"
+    )
+    assert {e["to"] for e in edges} == {"Callee"}
+
+
+def test_wildcard_includes_every_relation_kind(brain):
+    """AC1 escape hatch: relation='*' restores legacy unfiltered
+    behavior so every outbound edge appears."""
+    edges = brain.call_chain("Hub", relation="*", limit=100)
+    relations = {e["relation"] for e in edges}
+    assert relations == {
+        "calls", "contains", "uses", "method", "imports_from", "inherits",
+    }, f"expected every relation kind; got {relations!r}"
+
+
+def test_none_includes_every_relation_kind(brain):
+    """AC1: passing relation=None is equivalent to '*'."""
+    edges = brain.call_chain("Hub", relation=None, limit=100)
+    relations = {e["relation"] for e in edges}
+    assert "calls" in relations and "contains" in relations
+
+
+def test_explicit_kind_filters_to_just_that_kind(brain):
+    """AC1: a non-default relation string filters to exactly that kind."""
+    edges = brain.call_chain("Hub", relation="uses")
+    assert len(edges) == 1
+    assert edges[0]["relation"] == "uses"
+    assert edges[0]["to"] == "Used"
+
+
+def test_list_filter_accepts_multiple_kinds(brain):
+    """AC1: list/tuple input lets callers union several relation kinds
+    (e.g. 'calls' + 'inherits' for OO impact analysis)."""
+    edges = brain.call_chain(
+        "Hub", relation=["calls", "inherits"], limit=100,
+    )
+    relations = {e["relation"] for e in edges}
+    assert relations == {"calls", "inherits"}
+
+
+def test_unknown_relation_returns_empty(brain):
+    """AC1: filtering to a relation that doesn't exist returns []."""
+    edges = brain.call_chain("Hub", relation="does_not_exist")
+    assert edges == []
+
+
+def test_unknown_entity_returns_empty(brain):
+    """AC1 regression guard: missing start entity still returns []
+    regardless of the relation filter."""
+    edges = brain.call_chain("DoesNotExist")
+    assert edges == []


### PR DESCRIPTION
Closes AC3 of task 7471514b. Stacks on AC2 (#54) which stacks on AC1 (#47).

confidence ('EXTRACTED'/'INFERRED'/'AMBIGUOUS') and confidence_score (0.0-1.0) were stored on every relationship by graphify but never returned. Now every call_chain edge carries both so callers can rank or filter by certainty.

Bonus fix: Brain.__init__ now runs the graphify schema migrations so the confidence columns always exist (previously only added when graphify imports ran).

127/127 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)