### PR TITLE
fix: pin NICEGUI_STORAGE_PATH to writable /data volume (closes #48)

### DIFF
--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -8,6 +8,14 @@ services:
       - ./data:/data
     environment:
       - PRISM_DATA_DIR=/data
+      # NiceGUI persists per-client storage under cwd/.nicegui by default.
+      # If cwd ever lands on a read-only mount (common when callers bind
+      # /project read-only and set working_dir there for `git diff`-style
+      # access), every storage-using page silently 500s with an
+      # OSError that doesn't surface to the browser. Pin storage to
+      # the writable /data volume so the failure mode can't recur.
+      # Closes resolve-io/.prism#48.
+      - NICEGUI_STORAGE_PATH=/data/.nicegui
       # MiniLM is the +11pt LongMemEval default (vs potion baseline).
       # Override per project if needed: potion | minilm | bge-small | jina-code
       - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}


### PR DESCRIPTION
Closes #48.

NiceGUI 3.x stores per-client state under `cwd/.nicegui` by default. If cwd lands on a read-only mount (the compose pattern danpuzon-resolve described: bind `/project` read-only + `working_dir: /project` so Brain._purge_deleted's relative `Path(sf).exists()` checks work), every storage-using page silently 500s with an unsurfaced OSError. Browser sees an empty NiceGUI shell — easy to mistake for 'no data yet.'

Pin to `/data/.nicegui` (always writable) so the failure mode can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)