### PR TITLE
fix: Stop hook auto-tags in-progress tasks with HEAD (closes #49)

### DIFF
--- a/services/prism-service/app/assets/stop_record_hook.py
+++ b/services/prism-service/app/assets/stop_record_hook.py
@@ -172,7 +172,98 @@ def main() -> int:
             "file_paths": [],
         },
     })
+    # Issue #49: feed the autonomous-learning loop. /learning and
+    # /consolidation read from task_quality_rollup and
+    # consolidation_candidates, both of which require:
+    #   1. tasks.merge_sha to be set (drives the quality-timer scoring)
+    #   2. janitor_enqueue to be called (drives consolidation candidates)
+    # Without a hook doing this, both pages stay empty forever after a
+    # fresh install. We do it here on Stop: tag every in-progress task
+    # that doesn't yet have a merge_sha with the current git HEAD, then
+    # enqueue it for consolidation. Idempotent — once tagged, skipped.
+    _tag_active_tasks_with_head(base, project, root)
     return 0
+
+
+def _git_head(root: Path) -> Optional[str]:
+    """Return the project's current HEAD commit SHA, or None on failure."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5, check=True,
+        ).stdout.strip()
+        return out or None
+    except Exception:
+        return None
+
+
+def _tag_active_tasks_with_head(
+    base: str, project: str, root: Path,
+) -> None:
+    """Issue #49: tag in-progress tasks with HEAD + enqueue for consolidation.
+
+    Reads task_list, finds tasks where status='in_progress' and
+    merge_sha is empty/missing, and for each calls task_update with
+    merge_sha=HEAD then janitor_enqueue. Skips silently when no git
+    repo, no MCP, or no candidate tasks. Best-effort, advisory.
+    """
+    head = _git_head(root)
+    if not head:
+        return
+    # Use a longer timeout than the 4s default — task_list can be
+    # slow on large projects, and we have no UI latency budget here.
+    try:
+        url = f"{base}/?project={project}"
+        payload = json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "task_list", "arguments": {}},
+        }).encode()
+        req = urllib.request.Request(
+            url, data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30.0) as resp:
+            raw = resp.read().decode()
+    except Exception:
+        return
+    # Parse SSE wrapper or plain JSON
+    payload_text = raw
+    if "text/event-stream" in raw[:200] or raw.startswith("event:"):
+        for line in raw.splitlines():
+            if line.startswith("data: "):
+                payload_text = line[6:]
+                break
+    try:
+        body = json.loads(payload_text)
+        content = (body.get("result") or {}).get("content") or []
+        text = content[0].get("text", "") if content else ""
+        tasks = json.loads(text) if text else []
+    except Exception:
+        return
+    if not isinstance(tasks, list):
+        return
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        if t.get("status") != "in_progress":
+            continue
+        # Already tagged — skip (idempotency).
+        if t.get("merge_sha"):
+            continue
+        tid = t.get("id")
+        if not tid:
+            continue
+        _mcp_call(base, project, "task_update", {
+            "id": tid, "merge_sha": head,
+        })
+        _mcp_call(base, project, "janitor_enqueue", {
+            "task_id": tid,
+        })
 
 
 if __name__ == "__main__":

--- a/services/prism-service/tests/unit/test_install_manifest.py
+++ b/services/prism-service/tests/unit/test_install_manifest.py
@@ -124,9 +124,13 @@ def test_stop_hook_calls_mark_stale_no_subprocess():
     files = _files_by_path(_manifest())
     content = files[".claude/hooks/prism-stop.py"]["content"]
     assert "janitor_mark_stale" in content
-    # No subprocess or claude -p invocation in the hook
-    assert "subprocess.run" not in content
+    # No `claude -p` shellout — janitor reflection runs server-side via
+    # MCP, never by spawning an LLM subprocess from the hook. (Issue #49
+    # added a `git rev-parse HEAD` subprocess, which IS legitimate;
+    # specifically guard against the old claude-shellout pattern.)
     assert '"claude"' not in content and "'claude'" not in content
+    assert "claude -p" not in content
+    assert "claude --" not in content
 
 
 def test_stop_hook_latency_under_500ms(tmp_path):

--- a/services/prism-service/tests/unit/test_stop_hook_merge_tagging.py
+++ b/services/prism-service/tests/unit/test_stop_hook_merge_tagging.py
@@ -1,0 +1,176 @@
+"""Issue #49 tests — Stop hook auto-tags in-progress tasks with HEAD.
+
+resolve-io/.prism#49: /learning and /consolidation never populated
+because the install bundle had no caller-side wiring to set
+tasks.merge_sha or call janitor_enqueue. Both pages stayed empty
+forever after a fresh install.
+
+Stop hook now: rev-parse HEAD, find in_progress tasks with no
+merge_sha, tag each with HEAD + enqueue for consolidation. Idempotent
+(tagged tasks are skipped on subsequent stops).
+
+Tests use a unittest.mock-friendly approach: load the hook module
+fresh, patch its _mcp_call and _git_head, drive _tag_active_tasks
+directly with controlled task_list responses.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+_HOOK_SRC = _SERVICE_ROOT / "app" / "assets" / "stop_record_hook.py"
+
+
+def _load_hook():
+    """Import the hook script as a module so we can call its helpers."""
+    spec = importlib.util.spec_from_file_location(
+        "stop_record_hook_under_test", _HOOK_SRC,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["stop_record_hook_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _mock_task_list_response(tasks: list[dict]) -> bytes:
+    """Build a fake MCP task_list response wrapped as SSE."""
+    body = {
+        "jsonrpc": "2.0", "id": 1,
+        "result": {
+            "content": [{
+                "type": "text",
+                "text": json.dumps(tasks),
+            }],
+        },
+    }
+    return f"event: message\ndata: {json.dumps(body)}\n".encode()
+
+
+def test_tags_in_progress_task_without_merge_sha(tmp_path):
+    """Issue #49 happy path: in_progress task with no merge_sha gets
+    task_update(merge_sha=HEAD) AND janitor_enqueue."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "t1", "status": "in_progress", "merge_sha": None},
+    ]
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    calls = [c.args for c in mock_call.call_args_list]
+    tools = [args[2] for args in calls]
+    assert "task_update" in tools
+    assert "janitor_enqueue" in tools
+    update_args = next(c.args[3] for c in mock_call.call_args_list
+                       if c.args[2] == "task_update")
+    assert update_args == {"id": "t1", "merge_sha": "abc123"}
+    enqueue_args = next(c.args[3] for c in mock_call.call_args_list
+                        if c.args[2] == "janitor_enqueue")
+    assert enqueue_args == {"task_id": "t1"}
+
+
+def test_skips_task_already_tagged(tmp_path):
+    """Issue #49 idempotency: task with merge_sha already set is
+    skipped on subsequent Stops."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "t1", "status": "in_progress", "merge_sha": "old_sha"},
+    ]
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    assert mock_call.call_count == 0, (
+        "no MCP writes expected when task is already tagged"
+    )
+
+
+def test_skips_non_in_progress_tasks(tmp_path):
+    """Issue #49: only in_progress tasks get auto-tagged. pending,
+    completed, deleted are ignored."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "t1", "status": "pending", "merge_sha": None},
+        {"id": "t2", "status": "completed", "merge_sha": None},
+        {"id": "t3", "status": "in_progress", "merge_sha": None},
+    ]
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    update_args = [c.args[3] for c in mock_call.call_args_list
+                   if c.args[2] == "task_update"]
+    assert len(update_args) == 1
+    assert update_args[0] == {"id": "t3", "merge_sha": "abc123"}
+
+
+def test_no_git_head_skips_silently(tmp_path):
+    """Issue #49 robustness: no git repo → exit cleanly, no MCP writes."""
+    mod = _load_hook()
+    with patch.object(mod, "_git_head", return_value=None), \
+         patch.object(mod, "_mcp_call") as mock_call:
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    assert mock_call.call_count == 0
+
+
+def test_unreachable_mcp_skips_silently(tmp_path):
+    """Issue #49 robustness: MCP server down → exit cleanly, no error
+    propagation."""
+    mod = _load_hook()
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen", side_effect=OSError("boom")):
+        # Should not raise.
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    assert mock_call.call_count == 0
+
+
+def test_multiple_in_progress_tasks_all_tagged(tmp_path):
+    """Issue #49: each in_progress task is independently tagged. No
+    'pick the active one' heuristic — if you have N in_progress tasks
+    you're tracking N concurrent workstreams and want them all scored."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "a", "status": "in_progress", "merge_sha": None},
+        {"id": "b", "status": "in_progress", "merge_sha": None},
+        {"id": "c", "status": "in_progress", "merge_sha": "old"},
+    ]
+    with patch.object(mod, "_git_head", return_value="HEADSHA"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    update_calls = [c.args[3] for c in mock_call.call_args_list
+                    if c.args[2] == "task_update"]
+    enqueue_calls = [c.args[3] for c in mock_call.call_args_list
+                     if c.args[2] == "janitor_enqueue"]
+    assert {u["id"] for u in update_calls} == {"a", "b"}
+    assert {e["task_id"] for e in enqueue_calls} == {"a", "b"}


### PR DESCRIPTION
Closes #49.

## Problem

After upgrading to v4.6.0, /learning and /consolidation render empty. Schema and timers have been live since 2026-04-23, but no rows ever appeared in task_quality_rollup, task_variants, consolidation_candidates, or consolidation_runs.

Root cause: the loop's input is entirely caller-driven and **nothing in the shipped install actually drives it**. The bundled hooks record session/skill telemetry but never tag a merge or queue a reflection.

## Fix

Stop hook now does what the issue's reporter offered to PR:
1. `git rev-parse HEAD` for the current commit
2. `task_list` to find in_progress tasks
3. For each in_progress task with no `merge_sha`: call `task_update(merge_sha=HEAD)` then `janitor_enqueue(task_id=...)`

Idempotent — once tagged, a task is skipped on subsequent stops. Multiple in_progress tasks all get tagged independently (concurrent workstreams are real; no 'pick the active one' heuristic needed).

Robust to missing git repo, unreachable MCP, or no in_progress tasks (all skip cleanly).

## Test plan

- [x] 6 new cases in test_stop_hook_merge_tagging.py: happy path, idempotency, status filter, missing git, unreachable MCP, multi-task
- [x] Existing janitor-no-subprocess test refined to specifically block `claude -p` shellout (the original intent) instead of all subprocess (we now legitimately use it for `git rev-parse`)
- [x] Full unit suite: 115/115 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)