### PR TITLE
fix: cross-platform hook commands (Windows uses py -3, POSIX keeps python3)

### DIFF
--- a/services/prism-service/app/assets/stop_record_hook.py
+++ b/services/prism-service/app/assets/stop_record_hook.py
@@ -172,7 +172,98 @@ def main() -> int:
             "file_paths": [],
         },
     })
+    # Issue #49: feed the autonomous-learning loop. /learning and
+    # /consolidation read from task_quality_rollup and
+    # consolidation_candidates, both of which require:
+    #   1. tasks.merge_sha to be set (drives the quality-timer scoring)
+    #   2. janitor_enqueue to be called (drives consolidation candidates)
+    # Without a hook doing this, both pages stay empty forever after a
+    # fresh install. We do it here on Stop: tag every in-progress task
+    # that doesn't yet have a merge_sha with the current git HEAD, then
+    # enqueue it for consolidation. Idempotent — once tagged, skipped.
+    _tag_active_tasks_with_head(base, project, root)
     return 0
+
+
+def _git_head(root: Path) -> Optional[str]:
+    """Return the project's current HEAD commit SHA, or None on failure."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5, check=True,
+        ).stdout.strip()
+        return out or None
+    except Exception:
+        return None
+
+
+def _tag_active_tasks_with_head(
+    base: str, project: str, root: Path,
+) -> None:
+    """Issue #49: tag in-progress tasks with HEAD + enqueue for consolidation.
+
+    Reads task_list, finds tasks where status='in_progress' and
+    merge_sha is empty/missing, and for each calls task_update with
+    merge_sha=HEAD then janitor_enqueue. Skips silently when no git
+    repo, no MCP, or no candidate tasks. Best-effort, advisory.
+    """
+    head = _git_head(root)
+    if not head:
+        return
+    # Use a longer timeout than the 4s default — task_list can be
+    # slow on large projects, and we have no UI latency budget here.
+    try:
+        url = f"{base}/?project={project}"
+        payload = json.dumps({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "task_list", "arguments": {}},
+        }).encode()
+        req = urllib.request.Request(
+            url, data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=30.0) as resp:
+            raw = resp.read().decode()
+    except Exception:
+        return
+    # Parse SSE wrapper or plain JSON
+    payload_text = raw
+    if "text/event-stream" in raw[:200] or raw.startswith("event:"):
+        for line in raw.splitlines():
+            if line.startswith("data: "):
+                payload_text = line[6:]
+                break
+    try:
+        body = json.loads(payload_text)
+        content = (body.get("result") or {}).get("content") or []
+        text = content[0].get("text", "") if content else ""
+        tasks = json.loads(text) if text else []
+    except Exception:
+        return
+    if not isinstance(tasks, list):
+        return
+    for t in tasks:
+        if not isinstance(t, dict):
+            continue
+        if t.get("status") != "in_progress":
+            continue
+        # Already tagged — skip (idempotency).
+        if t.get("merge_sha"):
+            continue
+        tid = t.get("id")
+        if not tid:
+            continue
+        _mcp_call(base, project, "task_update", {
+            "id": tid, "merge_sha": head,
+        })
+        _mcp_call(base, project, "janitor_enqueue", {
+            "task_id": tid,
+        })
 
 
 if __name__ == "__main__":

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -2916,27 +2916,42 @@ class Brain:
         entity: str,
         relation: Optional[str] = None,
         limit: int = 10,
+        include_rationale: bool = False,
     ) -> list[dict]:
-        """Traverse entity relationships and return related entities."""
+        """Traverse entity relationships and return related entities.
+
+        ``include_rationale`` defaults to False so rationale nodes
+        (graphify-extracted ``# WHY:`` / ``# HACK:`` / ``# NOTE:``
+        comments stored as ``kind='rationale'``) don't pollute graph
+        traversal results — they account for ~43% of nodes in a typical
+        graph and answer different questions than code-flow traversal.
+        Pass ``True`` to surface them when intent metadata is the goal.
+        """
         ent_row = self._graph.execute(
             "SELECT id FROM entities WHERE name = ? LIMIT 1", (entity,)
         ).fetchone()
         if not ent_row:
             return []
         eid = ent_row["id"]
+        rat_clause = "" if include_rationale else (
+            " AND COALESCE(e.kind,'') != 'rationale'"
+        )
         try:
             if relation:
                 rows = self._graph.execute(
-                    "SELECT e.name, e.kind, e.file, r.relation FROM relationships r "
+                    "SELECT e.name, e.kind, e.file, r.relation "
+                    "FROM relationships r "
                     "JOIN entities e ON e.id = r.target_id "
-                    "WHERE r.source_id = ? AND r.relation = ? LIMIT ?",
+                    f"WHERE r.source_id = ? AND r.relation = ?{rat_clause} "
+                    "LIMIT ?",
                     (eid, relation, limit),
                 ).fetchall()
             else:
                 rows = self._graph.execute(
-                    "SELECT e.name, e.kind, e.file, r.relation FROM relationships r "
+                    "SELECT e.name, e.kind, e.file, r.relation "
+                    "FROM relationships r "
                     "JOIN entities e ON e.id = r.target_id "
-                    "WHERE r.source_id = ? LIMIT ?",
+                    f"WHERE r.source_id = ?{rat_clause} LIMIT ?",
                     (eid, limit),
                 ).fetchall()
             return [
@@ -3005,6 +3020,7 @@ class Brain:
 
     def find_references(
         self, name: str, limit: int = 20,
+        include_rationale: bool = False,
     ) -> list[dict]:
         """Return call sites referencing ``name`` via the graph.
 
@@ -3012,6 +3028,11 @@ class Brain:
         relationships. For each caller, returns its name/kind/file and
         the relation type. No chunk body — use find_symbol() on the
         returned caller names for content.
+
+        ``include_rationale`` defaults to False so ``rationale_for``
+        edges (rationale-comment → entity-it-explains) don't show up
+        as fake "callers". Pass True when looking for intent metadata
+        attached to ``name``.
         """
         try:
             tgt = self._graph.execute(
@@ -3019,12 +3040,15 @@ class Brain:
             ).fetchone()
             if not tgt:
                 return []
+            rat_clause = "" if include_rationale else (
+                " AND COALESCE(e.kind,'') != 'rationale'"
+            )
             rows = self._graph.execute(
                 "SELECT e.name AS caller_name, e.kind AS caller_kind, "
                 "e.file AS caller_file, r.relation AS relation "
                 "FROM relationships r "
                 "JOIN entities e ON e.id = r.source_id "
-                "WHERE r.target_id = ? LIMIT ?",
+                f"WHERE r.target_id = ?{rat_clause} LIMIT ?",
                 (tgt["id"], int(limit)),
             ).fetchall()
         except Exception:

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3147,7 +3147,9 @@ class Brain:
                 "s.name AS src_name, t.name AS tgt_name, "
                 "t.kind AS tgt_kind, t.id AS tgt_id, "
                 "s.kind AS src_kind, "
-                "r.relation AS relation, r.target_id AS tgt_id_raw "
+                "r.relation AS relation, r.target_id AS tgt_id_raw, "
+                "r.confidence AS confidence, "
+                "r.confidence_score AS confidence_score "
                 "FROM relationships r "
                 "JOIN entities s ON s.id = r.source_id "
                 "JOIN entities t ON t.id = r.target_id "
@@ -3172,11 +3174,22 @@ class Brain:
                 # direction. The 'direction' field marks how this edge
                 # was discovered — useful when the caller passed
                 # direction='both' and wants to partition results.
+                # confidence_score may be NULL for edges from the
+                # legacy tree-sitter pass (graphify started populating
+                # it in v0.4.x). Coerce to a float so the API stays
+                # uniform; treat missing as 1.0 (extracted-with-no-doubt
+                # is the conservative interpretation for legacy edges).
+                conf_raw = r["confidence_score"]
+                conf_score = (
+                    float(conf_raw) if conf_raw is not None else 1.0
+                )
                 edges.append({
                     "from": r["src_name"], "to": r["tgt_name"],
                     "kind": r["tgt_kind"] if direction == "callees"
                     else r["src_kind"],
                     "relation": r["relation"],
+                    "confidence": r["confidence"] or "EXTRACTED",
+                    "confidence_score": conf_score,
                     "hop": hop,
                     "direction": direction,
                 })

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3037,20 +3037,31 @@ class Brain:
         depth: int = 2,
         limit: int = 50,
         relation: str | list[str] | tuple[str, ...] | None = "calls",
+        direction: str = "callees",
     ) -> list[dict]:
         """Bounded BFS on the relationships graph starting at ``entity``.
 
-        Returns a flat list of edges [{from, to, kind, relation, hop}]
-        so the caller can reconstruct either tree or flat views. Hop 0
-        is the entity itself; hop 1 is direct callees; etc.
+        Returns a flat list of edges [{from, to, kind, relation, hop,
+        direction}] so the caller can reconstruct either tree or flat
+        views. Hop 1 is direct neighbours; hop 2 is neighbours-of-
+        neighbours; etc.
 
         ``relation`` filters edges by their relation kind. Default is
         ``"calls"`` so structural edges (``contains``/``method``/``uses``
-        /``imports_from``) don't eat the depth+limit budget — those tend
-        to dominate in number while adding nothing to a call-flow trace.
-        Pass ``None`` (or the string ``"*"``) to include every relation
-        kind (legacy pre-v4.7 behavior); pass a list/tuple of strings to
-        accept several kinds.
+        /``imports_from``) don't eat the depth+limit budget. Pass
+        ``None`` or ``"*"`` for every kind; list/tuple for several kinds.
+
+        ``direction`` controls traversal:
+          * ``"callees"`` (default) — walk forward on source_id IN frontier;
+            answers "what does ``entity`` transitively call?"
+          * ``"callers"`` — walk backward on target_id IN frontier; the
+            blast-radius primitive — answers "who would break if I change
+            ``entity``?"
+          * ``"both"`` — union of the two; useful for impact analysis
+            that needs both upstream and downstream edges in one query.
+
+        Each edge carries its ``direction`` so callers of "both" can
+        partition the result.
         """
         # Normalize the relation filter into a list of allowed kinds
         # (or None meaning "no filter").
@@ -3064,6 +3075,18 @@ class Brain:
             if not allowed:
                 allowed = None
 
+        # Normalize direction; tolerate plurals and casing.
+        dir_norm = (direction or "callees").lower().strip()
+        if dir_norm in ("callee", "down", "forward", "out"):
+            dir_norm = "callees"
+        elif dir_norm in ("caller", "up", "reverse", "back", "in",
+                          "blast", "blast_radius"):
+            dir_norm = "callers"
+        elif dir_norm in ("bidirectional", "all", "either"):
+            dir_norm = "both"
+        if dir_norm not in ("callees", "callers", "both"):
+            dir_norm = "callees"
+
         try:
             start = self._graph.execute(
                 "SELECT id, name FROM entities WHERE name = ? LIMIT 1",
@@ -3071,45 +3094,97 @@ class Brain:
             ).fetchone()
             if not start:
                 return []
-            visited = {start["id"]}
-            frontier = [start["id"]]
             edges: list[dict] = []
-            for hop in range(1, max(1, int(depth)) + 1):
-                if not frontier or len(edges) >= limit:
-                    break
-                placeholders = ",".join("?" * len(frontier))
-                sql = (
-                    f"SELECT r.source_id AS src_id, "
-                    f"s.name AS src_name, t.name AS tgt_name, "
-                    f"t.kind AS tgt_kind, t.id AS tgt_id, "
-                    f"r.relation AS relation "
-                    f"FROM relationships r "
-                    f"JOIN entities s ON s.id = r.source_id "
-                    f"JOIN entities t ON t.id = r.target_id "
-                    f"WHERE r.source_id IN ({placeholders})"
+            seen_edges: set[tuple[int, int, str]] = set()
+            directions = (
+                ["callees", "callers"] if dir_norm == "both" else [dir_norm]
+            )
+            for one_dir in directions:
+                self._walk_chain(
+                    start_id=start["id"], depth=depth, limit=limit,
+                    allowed=allowed, direction=one_dir,
+                    edges=edges, seen_edges=seen_edges,
                 )
-                params: list = [*frontier]
-                if allowed is not None:
-                    rel_placeholders = ",".join("?" * len(allowed))
-                    sql += f" AND r.relation IN ({rel_placeholders})"
-                    params.extend(allowed)
-                sql += " LIMIT ?"
-                params.append(int(limit) - len(edges))
-                rows = self._graph.execute(sql, params).fetchall()
-                next_frontier: list[int] = []
-                for r in rows:
-                    edges.append({
-                        "from": r["src_name"], "to": r["tgt_name"],
-                        "kind": r["tgt_kind"], "relation": r["relation"],
-                        "hop": hop,
-                    })
-                    if r["tgt_id"] not in visited:
-                        visited.add(r["tgt_id"])
-                        next_frontier.append(r["tgt_id"])
-                frontier = next_frontier
             return edges
         except Exception:
             return []
+
+    def _walk_chain(
+        self,
+        *,
+        start_id: int,
+        depth: int,
+        limit: int,
+        allowed: list[str] | None,
+        direction: str,
+        edges: list[dict],
+        seen_edges: set[tuple[int, int, str]],
+    ) -> None:
+        """One-direction BFS used by call_chain.
+
+        For ``direction='callees'`` the frontier is on source_id and we
+        advance via target_id (forward call flow). For ``'callers'`` it
+        flips: frontier on target_id, advance via source_id (reverse).
+        Edges are appended to the shared ``edges`` list; ``seen_edges``
+        de-dupes when called twice (direction='both' case).
+        """
+        # Pivot column the frontier matches against, and the column to
+        # advance to next hop.
+        if direction == "callers":
+            frontier_col = "r.target_id"
+            advance_col = "src_id"
+        else:
+            frontier_col = "r.source_id"
+            advance_col = "tgt_id"
+        visited = {start_id}
+        frontier = [start_id]
+        for hop in range(1, max(1, int(depth)) + 1):
+            if not frontier or len(edges) >= limit:
+                break
+            placeholders = ",".join("?" * len(frontier))
+            sql = (
+                "SELECT r.source_id AS src_id, "
+                "s.name AS src_name, t.name AS tgt_name, "
+                "t.kind AS tgt_kind, t.id AS tgt_id, "
+                "s.kind AS src_kind, "
+                "r.relation AS relation, r.target_id AS tgt_id_raw "
+                "FROM relationships r "
+                "JOIN entities s ON s.id = r.source_id "
+                "JOIN entities t ON t.id = r.target_id "
+                f"WHERE {frontier_col} IN ({placeholders})"
+            )
+            params: list = [*frontier]
+            if allowed is not None:
+                rel_placeholders = ",".join("?" * len(allowed))
+                sql += f" AND r.relation IN ({rel_placeholders})"
+                params.extend(allowed)
+            sql += " LIMIT ?"
+            params.append(int(limit) - len(edges))
+            rows = self._graph.execute(sql, params).fetchall()
+            next_frontier: list[int] = []
+            for r in rows:
+                key = (r["src_id"], r["tgt_id_raw"], r["relation"])
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
+                # 'from' / 'to' always reflect the underlying call edge
+                # direction (caller → callee), regardless of traversal
+                # direction. The 'direction' field marks how this edge
+                # was discovered — useful when the caller passed
+                # direction='both' and wants to partition results.
+                edges.append({
+                    "from": r["src_name"], "to": r["tgt_name"],
+                    "kind": r["tgt_kind"] if direction == "callees"
+                    else r["src_kind"],
+                    "relation": r["relation"],
+                    "hop": hop,
+                    "direction": direction,
+                })
+                advance_id = r[advance_col]
+                if advance_id not in visited:
+                    visited.add(advance_id)
+                    next_frontier.append(advance_id)
+            frontier = next_frontier
 
     # ------------------------------------------------------------------
     # Ingest

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3183,7 +3183,9 @@ class Brain:
                 "s.kind AS src_kind, "
                 "r.relation AS relation, r.target_id AS tgt_id_raw, "
                 "r.confidence AS confidence, "
-                "r.confidence_score AS confidence_score "
+                "r.confidence_score AS confidence_score, "
+                "r.call_site_file AS call_site_file, "
+                "r.source_location AS call_site_location "
                 "FROM relationships r "
                 "JOIN entities s ON s.id = r.source_id "
                 "JOIN entities t ON t.id = r.target_id "
@@ -3224,6 +3226,10 @@ class Brain:
                     "relation": r["relation"],
                     "confidence": r["confidence"] or "EXTRACTED",
                     "confidence_score": conf_score,
+                    # AC5: per-edge call-site location. Empty string
+                    # for legacy edges that predate the column.
+                    "call_site_file": r["call_site_file"] or "",
+                    "call_site_location": r["call_site_location"] or "",
                     "hop": hop,
                     "direction": direction,
                 })

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -795,6 +795,21 @@ class Brain:
             CREATE INDEX IF NOT EXISTS idx_rel_src ON relationships(source_id);
             CREATE INDEX IF NOT EXISTS idx_rel_tgt ON relationships(target_id);
         """)
+        # Apply the graphify-side schema extensions (confidence,
+        # confidence_score, weight, source_location, communities,
+        # graphify_id, etc.) so call_chain / graph_query can rely on
+        # those columns existing without depending on _import_graph_json
+        # having run first. Idempotent — each ALTER guards on
+        # PRAGMA table_info.
+        try:
+            from app.services.graph_service import _graph_schema_migrations
+            _graph_schema_migrations(self._graph)
+        except Exception:
+            # Tests with stripped imports / circular-import edge cases
+            # fall through silently — the SELECT will then raise and
+            # the call_chain except-clause returns []. Production has
+            # the import path available.
+            pass
 
     def _init_scores_schema(self) -> None:
         self._scores.executescript("""

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3107,6 +3107,25 @@ class Brain:
                 "SELECT id, name FROM entities WHERE name = ? LIMIT 1",
                 (entity,),
             ).fetchone()
+            # AC4: fuzzy fallback via norm_label so 'Brain.search()',
+            # 'Brain.search', and 'brain_search' all resolve to the same
+            # entity. norm_label is graphify-emitted (or derived during
+            # _import_graph_json), and the column may be absent on
+            # pre-AC4 graphs — wrap in try/except.
+            if not start:
+                try:
+                    from app.services.graph_service import (
+                        _derive_norm_label as _norm,
+                    )
+                    needle = _norm(entity)
+                    if needle:
+                        start = self._graph.execute(
+                            "SELECT id, name FROM entities "
+                            "WHERE norm_label = ? LIMIT 1",
+                            (needle,),
+                        ).fetchone()
+                except Exception:
+                    start = None
             if not start:
                 return []
             edges: list[dict] = []

--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -3036,13 +3036,34 @@ class Brain:
         entity: str,
         depth: int = 2,
         limit: int = 50,
+        relation: str | list[str] | tuple[str, ...] | None = "calls",
     ) -> list[dict]:
         """Bounded BFS on the relationships graph starting at ``entity``.
 
         Returns a flat list of edges [{from, to, kind, relation, hop}]
         so the caller can reconstruct either tree or flat views. Hop 0
         is the entity itself; hop 1 is direct callees; etc.
+
+        ``relation`` filters edges by their relation kind. Default is
+        ``"calls"`` so structural edges (``contains``/``method``/``uses``
+        /``imports_from``) don't eat the depth+limit budget — those tend
+        to dominate in number while adding nothing to a call-flow trace.
+        Pass ``None`` (or the string ``"*"``) to include every relation
+        kind (legacy pre-v4.7 behavior); pass a list/tuple of strings to
+        accept several kinds.
         """
+        # Normalize the relation filter into a list of allowed kinds
+        # (or None meaning "no filter").
+        allowed: list[str] | None
+        if relation is None or relation == "*" or relation == "":
+            allowed = None
+        elif isinstance(relation, str):
+            allowed = [relation]
+        else:
+            allowed = [str(r) for r in relation if r]
+            if not allowed:
+                allowed = None
+
         try:
             start = self._graph.execute(
                 "SELECT id, name FROM entities WHERE name = ? LIMIT 1",
@@ -3057,7 +3078,7 @@ class Brain:
                 if not frontier or len(edges) >= limit:
                     break
                 placeholders = ",".join("?" * len(frontier))
-                rows = self._graph.execute(
+                sql = (
                     f"SELECT r.source_id AS src_id, "
                     f"s.name AS src_name, t.name AS tgt_name, "
                     f"t.kind AS tgt_kind, t.id AS tgt_id, "
@@ -3065,10 +3086,16 @@ class Brain:
                     f"FROM relationships r "
                     f"JOIN entities s ON s.id = r.source_id "
                     f"JOIN entities t ON t.id = r.target_id "
-                    f"WHERE r.source_id IN ({placeholders}) "
-                    f"LIMIT ?",
-                    (*frontier, int(limit) - len(edges)),
-                ).fetchall()
+                    f"WHERE r.source_id IN ({placeholders})"
+                )
+                params: list = [*frontier]
+                if allowed is not None:
+                    rel_placeholders = ",".join("?" * len(allowed))
+                    sql += f" AND r.relation IN ({rel_placeholders})"
+                    params.extend(allowed)
+                sql += " LIMIT ?"
+                params.append(int(limit) - len(edges))
+                rows = self._graph.execute(sql, params).fetchall()
                 next_frontier: list[int] = []
                 for r in rows:
                     edges.append({

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -587,9 +587,27 @@ TOOLS: list[Tool] = [
             "(.claude/settings.json hooks block + hook scripts), step-by-step "
             "instructions, and verification steps. The MCP is self-describing "
             "— no external docs needed. Call this inside project_onboard's "
-            "flow or any time you want to re-install the client-side hooks."
+            "flow or any time you want to re-install the client-side hooks. "
+            "Pass `host_platform` (sys.platform of the host running Claude "
+            "Code) so hook commands use the right Python launcher: "
+            "`python3` on Linux/macOS, `py -3` on Windows. Default is "
+            "POSIX/`python3`."
         ),
-        inputSchema={"type": "object", "properties": {}},
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "host_platform": {
+                    "type": "string",
+                    "description": (
+                        "Host OS where the hooks will run. Accepts "
+                        "`sys.platform` values (`linux`, `darwin`, `win32`) "
+                        "or aliases (`windows`, `macos`, `posix`). Determines "
+                        "whether hook commands use `python3` (POSIX) or "
+                        "`py -3` (Windows, via the PEP 397 launcher)."
+                    ),
+                },
+            },
+        },
     ),
     Tool(
         name="prism_guide",
@@ -962,6 +980,17 @@ TOOLS: list[Tool] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "Known project conventions to seed immediately",
+                },
+                "host_platform": {
+                    "type": "string",
+                    "description": (
+                        "Host OS where Claude Code (and therefore the "
+                        "PRISM hooks) will run. Accepts sys.platform "
+                        "values (`linux`, `darwin`, `win32`) or aliases "
+                        "(`windows`, `macos`, `posix`). Forwarded to "
+                        "prism_install so hook commands use `python3` on "
+                        "POSIX and `py -3` on Windows."
+                    ),
                 },
             },
             "required": ["project_name"],
@@ -1607,11 +1636,38 @@ _REFLECT_AGENT_MD = _load_asset("prism_reflect_agent.md")
 _REFLECT_COMMAND_MD = _load_asset("prism_reflect_command.md")
 
 
-def _install_manifest(project_id: str) -> dict:
+def _hook_python_cmd(host_platform: str | None) -> str:
+    """Pick the Python invocation that hook commands should use on the host.
+
+    PEP 394 makes `python3` canonical on POSIX (modern Linux distros and
+    Debian dropped bare `python`; only `/usr/bin/python3` ships).
+    PEP 397 makes `py.exe` canonical on Windows: it is installed by every
+    python.org installer, lives in PATH by default, and routes shebangs.
+    `python3.exe` does NOT ship by default on Windows, so the previous
+    `python3 ...` command broke every Windows host. `py -3 ...` works on
+    every supported Windows install and reads the shebang in our hooks
+    (`#!/usr/bin/env python3`) to pick the right interpreter.
+
+    Caller passes the host's platform (Claude Code knows its own OS).
+    Anything starting with `win` / `nt` is treated as Windows; everything
+    else (including None) falls back to POSIX `python3`.
+    """
+    token = (host_platform or "").strip().lower()
+    if token.startswith(("win", "nt")):
+        return "py -3"
+    return "python3"
+
+
+def _install_manifest(project_id: str, host_platform: str | None = None) -> dict:
     """Return the install manifest the agent should apply on first onboard.
     The PRISM service is the single source of truth — if the hook logic
-    changes in a future release, a re-onboard serves the new version."""
+    changes in a future release, a re-onboard serves the new version.
+
+    `host_platform` is the OS where Claude Code (and therefore the hooks)
+    will run. Pass `sys.platform` from the caller, or `"windows"` /
+    `"linux"` / `"darwin"`. Defaults to POSIX (`python3`)."""
     hook_script = _HOOK_SCRIPT.replace("__PRISM_VERSION__", PRISM_VERSION)
+    py = _hook_python_cmd(host_platform)
     # Claude Code reads hooks from .claude/settings.json under a top-level
     # "hooks" key. A bare .claude/hooks.json is ignored (only plugin-shipped
     # hooks/hooks.json is loaded, via a different code path). Wrap the event
@@ -1620,7 +1676,7 @@ def _install_manifest(project_id: str) -> dict:
         "SessionStart": [
             {
                 "type": "command",
-                "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-sync.py",
+                "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-sync.py",
                 "timeout": 30000,
             },
         ],
@@ -1630,7 +1686,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-feedback-signal.py",
+                        "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-feedback-signal.py",
                         "description": (
                             "Implicit retrieval feedback: correlate "
                             "brain_search results with Read/Edit and emit "
@@ -1644,7 +1700,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-skill-usage.py",
+                        "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-skill-usage.py",
                         "description": (
                             "Record skill invocations to scores.db via "
                             "record_skill_usage — populates /skills."
@@ -1657,7 +1713,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-edit-learn.py",
+                        "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-edit-learn.py",
                         "description": (
                             "Auto-ingest edited source files into Brain via "
                             "prism_refresh (skip_graph) so brain_search "
@@ -1673,7 +1729,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-stop.py",
+                        "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-stop.py",
                         "description": (
                             "Record session-level metrics (duration, "
                             "tokens, files, skills) via "
@@ -1682,7 +1738,7 @@ def _install_manifest(project_id: str) -> dict:
                     },
                     {
                         "type": "command",
-                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-idle-rebuild.py",
+                        "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-idle-rebuild.py",
                         "description": (
                             "Flush in-session edits into the code graph via "
                             "graph_rebuild iff the edit-learn hook left a "
@@ -1698,7 +1754,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-subagent.py",
+                        "command": f"{py} ${{CLAUDE_PROJECT_DIR}}/.claude/hooks/prism-subagent.py",
                         "description": (
                             "Record sub-agent outcome (recommendation, "
                             "evidence count, timing) via "
@@ -2079,7 +2135,8 @@ def _dispatch_tool(name: str, arguments: dict, *, project_id: str = "default") -
 
             # Return direct imperative instructions as plain text.
             # This is NOT a report — Claude must execute these steps.
-            manifest = _install_manifest(project_id)
+            host_platform = arguments.get("host_platform")
+            manifest = _install_manifest(project_id, host_platform)
             files_list = "\n".join(
                 f"  - {f['path']} (action: {f['action']})"
                 for f in manifest["install_files"]
@@ -2472,7 +2529,10 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
         if name == "prism_install":
             # Returns the client-side install manifest so the agent can
             # Write the hook files into the user's project directly.
-            return [TextContent(type="text", text=_json(_install_manifest(project_id)))]
+            host_platform = (arguments or {}).get("host_platform")
+            return [TextContent(type="text", text=_json(
+                _install_manifest(project_id, host_platform)
+            ))]
 
         if name == "prism_sync":
             ctx = get_project(project_id)

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -177,8 +177,10 @@ TOOLS: list[Tool] = [
             "Bounded BFS over the call graph starting at ``entity``. "
             "Returns a flat edge list [{from, to, kind, relation, hop}] "
             "so you can reconstruct 'what does this entity transitively "
-            "call'. Use to understand flow without Reading multiple "
-            "files."
+            "call'. By default only follows ``calls`` edges so "
+            "structural relations (contains/method/uses/imports_from) "
+            "don't fill the depth+limit budget; pass ``relation=\"*\"`` "
+            "to include every kind."
         ),
         inputSchema={
             "type": "object",
@@ -187,6 +189,16 @@ TOOLS: list[Tool] = [
                 "depth": {"type": "integer", "default": 2,
                           "description": "max hops (default 2)"},
                 "limit": {"type": "integer", "default": 50},
+                "relation": {
+                    "type": "string",
+                    "default": "calls",
+                    "description": (
+                        "Edge-kind filter: 'calls' (default) follows "
+                        "only call edges; '*' (or empty) includes "
+                        "every relation kind; any other value (e.g. "
+                        "'uses', 'inherits') filters to that one kind."
+                    ),
+                },
             },
             "required": ["entity"],
         },
@@ -2177,6 +2189,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 entity=arguments["entity"],
                 depth=arguments.get("depth", 2),
                 limit=arguments.get("limit", 50),
+                relation=arguments.get("relation", "calls"),
             )
             return [TextContent(type="text", text=_json(results))]
 

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -1571,7 +1571,7 @@ def _install_manifest(project_id: str) -> dict:
         "SessionStart": [
             {
                 "type": "command",
-                "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-sync.py",
+                "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-sync.py",
                 "timeout": 30000,
             },
         ],
@@ -1581,7 +1581,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-feedback-signal.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-feedback-signal.py",
                         "description": (
                             "Implicit retrieval feedback: correlate "
                             "brain_search results with Read/Edit and emit "
@@ -1595,7 +1595,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-skill-usage.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-skill-usage.py",
                         "description": (
                             "Record skill invocations to scores.db via "
                             "record_skill_usage — populates /skills."
@@ -1608,7 +1608,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-edit-learn.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-edit-learn.py",
                         "description": (
                             "Auto-ingest edited source files into Brain via "
                             "prism_refresh (skip_graph) so brain_search "
@@ -1624,7 +1624,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-stop.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-stop.py",
                         "description": (
                             "Record session-level metrics (duration, "
                             "tokens, files, skills) via "
@@ -1633,7 +1633,7 @@ def _install_manifest(project_id: str) -> dict:
                     },
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-idle-rebuild.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-idle-rebuild.py",
                         "description": (
                             "Flush in-session edits into the code graph via "
                             "graph_rebuild iff the edit-learn hook left a "
@@ -1649,7 +1649,7 @@ def _install_manifest(project_id: str) -> dict:
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "python ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-subagent.py",
+                        "command": "python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/prism-subagent.py",
                         "description": (
                             "Record sub-agent outcome (recommendation, "
                             "evidence count, timing) via "

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -175,12 +175,12 @@ TOOLS: list[Tool] = [
         name="brain_call_chain",
         description=(
             "Bounded BFS over the call graph starting at ``entity``. "
-            "Returns a flat edge list [{from, to, kind, relation, hop}] "
-            "so you can reconstruct 'what does this entity transitively "
-            "call'. By default only follows ``calls`` edges so "
-            "structural relations (contains/method/uses/imports_from) "
-            "don't fill the depth+limit budget; pass ``relation=\"*\"`` "
-            "to include every kind."
+            "Returns a flat edge list [{from, to, kind, relation, hop, "
+            "direction}] so you can reconstruct call flow OR blast "
+            "radius. By default follows only ``calls`` edges and walks "
+            "forward (callees). Set direction='callers' to answer "
+            "'who would break if I change this?' or direction='both' "
+            "for full impact analysis."
         ),
         inputSchema={
             "type": "object",
@@ -197,6 +197,17 @@ TOOLS: list[Tool] = [
                         "only call edges; '*' (or empty) includes "
                         "every relation kind; any other value (e.g. "
                         "'uses', 'inherits') filters to that one kind."
+                    ),
+                },
+                "direction": {
+                    "type": "string",
+                    "enum": ["callees", "callers", "both"],
+                    "default": "callees",
+                    "description": (
+                        "BFS direction. 'callees' (default) = forward "
+                        "call flow; 'callers' = blast radius (who "
+                        "calls this); 'both' = union, with each edge "
+                        "tagged by how it was discovered."
                     ),
                 },
             },
@@ -2190,6 +2201,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 depth=arguments.get("depth", 2),
                 limit=arguments.get("limit", 50),
                 relation=arguments.get("relation", "calls"),
+                direction=arguments.get("direction", "callees"),
             )
             return [TextContent(type="text", text=_json(results))]
 

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -160,13 +160,23 @@ TOOLS: list[Tool] = [
             "Each result is {caller_name, caller_kind, caller_file, "
             "relation}. Use find_symbol() on a caller_name to fetch its "
             "chunk content. Replaces 'grep for foo(' with a semantic "
-            "query that respects function boundaries."
+            "query that respects function boundaries. By default skips "
+            "rationale-comment edges; set include_rationale=true to "
+            "include them when surfacing intent metadata."
         ),
         inputSchema={
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
                 "limit": {"type": "integer", "default": 20},
+                "include_rationale": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Include rationale-comment edges "
+                        "(rationale_for relation). Default false."
+                    ),
+                },
             },
             "required": ["name"],
         },
@@ -391,13 +401,29 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="brain_graph",
-        description="Query the knowledge graph for entity relationships",
+        description=(
+            "Query the knowledge graph for entity relationships. By "
+            "default excludes rationale nodes (kind='rationale') so "
+            "graph traversal returns code-flow targets, not "
+            "graphify-extracted comment metadata."
+        ),
         inputSchema={
             "type": "object",
             "properties": {
-                "entity": {"type": "string", "description": "Entity name to query"},
-                "relation": {"type": "string", "description": "Filter by relation type"},
-                "limit": {"type": "integer", "description": "Max results", "default": 10},
+                "entity": {"type": "string",
+                           "description": "Entity name to query"},
+                "relation": {"type": "string",
+                             "description": "Filter by relation type"},
+                "limit": {"type": "integer",
+                          "description": "Max results", "default": 10},
+                "include_rationale": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Include rationale nodes (kind='rationale') "
+                        "in results. Default false."
+                    ),
+                },
             },
             "required": ["entity"],
         },
@@ -2169,6 +2195,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
             results = brain_svc.find_references(
                 name=arguments["name"],
                 limit=arguments.get("limit", 20),
+                include_rationale=arguments.get("include_rationale", False),
             )
             return [TextContent(type="text", text=_json(results))]
 
@@ -2288,6 +2315,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 entity=arguments["entity"],
                 relation=arguments.get("relation"),
                 limit=arguments.get("limit", 10),
+                include_rationale=arguments.get("include_rationale", False),
             )
             return [TextContent(type="text", text=_json(results))]
 

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -174,11 +174,20 @@ class BrainService:
         entity: str,
         relation: Optional[str] = None,
         limit: int = 10,
+        include_rationale: bool = False,
     ) -> list[dict]:
-        """Query the knowledge graph."""
+        """Query the knowledge graph.
+
+        Rationale nodes (kind='rationale', graphify-extracted intent
+        comments) are excluded by default. Pass include_rationale=True
+        to include them.
+        """
         if not self._available or self._brain is None:
             return []
-        return self._brain.graph_query(entity, relation=relation, limit=limit)
+        return self._brain.graph_query(
+            entity, relation=relation, limit=limit,
+            include_rationale=include_rationale,
+        )
 
     def find_symbol(
         self,
@@ -199,11 +208,19 @@ class BrainService:
 
     def find_references(
         self, name: str, limit: int = 20,
+        include_rationale: bool = False,
     ) -> list[dict]:
-        """Return callers of ``name`` from the graph (caller_name/kind/file)."""
+        """Return callers of ``name`` from the graph (caller_name/kind/file).
+
+        Rationale-comment "callers" (rationale_for edges) are excluded
+        by default; pass include_rationale=True to surface them.
+        """
         if not self._available or self._brain is None:
             return []
-        return self._brain.find_references(name=name, limit=limit)
+        return self._brain.find_references(
+            name=name, limit=limit,
+            include_rationale=include_rationale,
+        )
 
     def call_chain(
         self, entity: str, depth: int = 2, limit: int = 50,

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -211,18 +211,19 @@ class BrainService:
         depth: int = 2,
         limit: int = 50,
         relation: str | list[str] | tuple[str, ...] | None = "calls",
+        direction: str = "callees",
     ) -> list[dict]:
         """Bounded BFS over the call graph from ``entity``.
 
-        ``relation`` defaults to ``"calls"`` so structural edges
-        (contains/method/uses/imports_from) don't crowd out real call
-        edges within the depth+limit budget. Pass ``None`` or ``"*"``
-        for legacy unfiltered behavior.
+        ``direction`` is the blast-radius primitive — ``"callees"``
+        (default) walks forward, ``"callers"`` walks backward (who would
+        break if I change ``entity``?), ``"both"`` unions the two.
         """
         if not self._available or self._brain is None:
             return []
         return self._brain.call_chain(
             entity=entity, depth=depth, limit=limit, relation=relation,
+            direction=direction,
         )
 
     def record_session_outcome(

--- a/services/prism-service/app/services/brain_service.py
+++ b/services/prism-service/app/services/brain_service.py
@@ -206,13 +206,23 @@ class BrainService:
         return self._brain.find_references(name=name, limit=limit)
 
     def call_chain(
-        self, entity: str, depth: int = 2, limit: int = 50,
+        self,
+        entity: str,
+        depth: int = 2,
+        limit: int = 50,
+        relation: str | list[str] | tuple[str, ...] | None = "calls",
     ) -> list[dict]:
-        """Bounded BFS over the call graph from ``entity``."""
+        """Bounded BFS over the call graph from ``entity``.
+
+        ``relation`` defaults to ``"calls"`` so structural edges
+        (contains/method/uses/imports_from) don't crowd out real call
+        edges within the depth+limit budget. Pass ``None`` or ``"*"``
+        for legacy unfiltered behavior.
+        """
         if not self._available or self._brain is None:
             return []
         return self._brain.call_chain(
-            entity=entity, depth=depth, limit=limit,
+            entity=entity, depth=depth, limit=limit, relation=relation,
         )
 
     def record_session_outcome(

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -51,12 +51,27 @@ def _graph_schema_migrations(conn: sqlite3.Connection) -> None:
         ("file_type",       "ALTER TABLE entities ADD COLUMN file_type TEXT"),
         ("community",       "ALTER TABLE entities ADD COLUMN community INTEGER"),
         ("source_location", "ALTER TABLE entities ADD COLUMN source_location TEXT"),
+        # AC4: graphify emits a normalized label per node
+        # ("brain.search" → "brain_search") for fuzzy entity lookup
+        # when the user-provided name doesn't match the canonical
+        # name exactly. Indexed below for cheap fallback resolution.
+        ("norm_label",      "ALTER TABLE entities ADD COLUMN norm_label TEXT"),
     ):
         if col not in ent_cols:
             try:
                 conn.execute(sql); conn.commit()
             except sqlite3.OperationalError:
                 pass
+    # Index norm_label for the call_chain fallback lookup. Skip if
+    # column never landed (older sqlite returning OperationalError).
+    try:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ent_norm_label "
+            "ON entities(norm_label) WHERE norm_label IS NOT NULL"
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
 
     # relationships extensions
     rel_cols = {row[1] for row in conn.execute("PRAGMA table_info(relationships)").fetchall()}
@@ -686,22 +701,31 @@ class GraphService:
                 community = node.get("community")
                 source_file = node.get("source_file", "")
                 source_location = node.get("source_location", "")
+                # AC4: graphify emits norm_label for fuzzy lookup.
+                # Fall back to a derived form so legacy graph.json
+                # without that field still gets a useful default.
+                norm_label = (
+                    node.get("norm_label")
+                    or _derive_norm_label(label)
+                )
                 # Derive "kind" from file_type or label for legacy queries
                 kind = file_type or "node"
                 cur = conn.execute(
                     "INSERT INTO entities "
                     "(name, kind, file, line, graphify_id, label, file_type, "
-                    " community, source_location) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                    " community, source_location, norm_label) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
                     "ON CONFLICT(name, file) DO UPDATE SET "
                     "  kind=excluded.kind, "
                     "  graphify_id=excluded.graphify_id, "
                     "  label=excluded.label, "
                     "  file_type=excluded.file_type, "
                     "  community=excluded.community, "
-                    "  source_location=excluded.source_location",
+                    "  source_location=excluded.source_location, "
+                    "  norm_label=excluded.norm_label",
                     (label, kind, source_file, _extract_line(source_location),
-                     gid, label, file_type, community, source_location),
+                     gid, label, file_type, community, source_location,
+                     norm_label),
                 )
                 # Retrieve id (RETURNING not universally available pre-3.35)
                 row = conn.execute(
@@ -870,3 +894,20 @@ def _extract_line(source_location: str) -> Optional[int]:
         return int(s)
     except (ValueError, AttributeError):
         return None
+
+
+def _derive_norm_label(label: str) -> str:
+    """Local fallback when graphify doesn't emit norm_label.
+
+    Strips call/dot syntax and lowercases so 'Brain.search()' and
+    'brain.search' both resolve to 'brain_search'. Mirrors graphify's
+    own normalization so the index column remains useful even on
+    pre-norm_label graph.json output.
+    """
+    if not label:
+        return ""
+    import re as _re
+    s = label.strip().rstrip("()")
+    s = _re.sub(r"[.\s]+", "_", s)
+    s = _re.sub(r"[^A-Za-z0-9_]", "", s)
+    return s.lower()

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -503,10 +503,18 @@ class GraphService:
         try:
             b = _sq3.connect(brain_db_path); b.row_factory = _sq3.Row
             out["docs"] = b.execute("SELECT COUNT(*) FROM docs").fetchone()[0]
+            # Issue #41: multi-granular chunking emits N rows per
+            # source_file (::win_N, ::__file__, ::__module__, ::EntName).
+            # Comparing chunk-rows vs disk-files (staged_files counts
+            # files) made `stale: true` fire on every project where
+            # chunks-per-file > 1 — typically every project. Count
+            # DISTINCT source_files so the unit matches staged_files.
+            allowed = {s.lstrip(".") for s in GRAPHIFY_CODE_SUFFIXES}
             out["code_docs"] = sum(1 for r in b.execute(
-                "SELECT source_file FROM docs"
+                "SELECT DISTINCT source_file FROM docs "
+                "WHERE source_file IS NOT NULL"
             ) if (r["source_file"] or "").lower().rsplit(".", 1)[-1]
-               in {s.lstrip(".") for s in GRAPHIFY_CODE_SUFFIXES})
+               in allowed)
             b.close()
         except _sq3.Error:
             pass

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -80,6 +80,12 @@ def _graph_schema_migrations(conn: sqlite3.Connection) -> None:
         ("confidence_score",  "ALTER TABLE relationships ADD COLUMN confidence_score REAL"),
         ("weight",            "ALTER TABLE relationships ADD COLUMN weight REAL"),
         ("source_location",   "ALTER TABLE relationships ADD COLUMN source_location TEXT"),
+        # AC5: graphify emits source_file per edge — the FILE where
+        # the call site lives (distinct from the source ENTITY's
+        # defining file when the entity is defined elsewhere). Store
+        # as call_site_file to disambiguate; surface in call_chain
+        # results so users can jump straight to the call site.
+        ("call_site_file",    "ALTER TABLE relationships ADD COLUMN call_site_file TEXT"),
     ):
         if col not in rel_cols:
             try:
@@ -748,14 +754,22 @@ class GraphService:
                 confidence_score = float(link.get("confidence_score", 1.0))
                 weight = float(link.get("weight", 1.0))
                 source_location = link.get("source_location", "")
+                # AC5: per-edge source_file is the FILE where the call
+                # site lives (e.g. for an A→B call where A is defined
+                # in src/a.py but the call site is in src/handler.py
+                # because A was inlined or aliased). Distinct from the
+                # source entity's defining file.
+                call_site_file = link.get("source_file", "")
                 try:
                     conn.execute(
                         "INSERT OR REPLACE INTO relationships "
                         "(source_id, target_id, relation, confidence, "
-                        " confidence_score, weight, source_location) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        " confidence_score, weight, source_location, "
+                        " call_site_file) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                         (src_id, tgt_id, relation, confidence,
-                         confidence_score, weight, source_location),
+                         confidence_score, weight, source_location,
+                         call_site_file),
                     )
                     result["imported_relationships"] += 1
                 except sqlite3.IntegrityError:

--- a/services/prism-service/app/ui/components/nav.py
+++ b/services/prism-service/app/ui/components/nav.py
@@ -21,6 +21,36 @@ body, .q-page, .nicegui-content {
 """
 
 
+def resolve_active_project(
+    qs_proj: str | None,
+    stored: str | None,
+    projects: list[str],
+) -> str:
+    """Pick the active project from a cascade of signals.
+
+    Issue resolve-io/.prism#43: nav.py used to seed `app.storage.user['project']`
+    to the literal `'default'` sentinel even when real projects existed,
+    then pass that sentinel as `value=` to a `ui.select(options=projects)`
+    where `'default'` was NOT in `options`. NiceGUI raised ValueError and
+    every dashboard page 500'd. Resolve everything against the live
+    `projects` list so the chosen value is guaranteed to be in options.
+
+    Order:
+      1. URL ?project= if it points at a real project
+      2. Stored user value if it points at a real project
+      3. First available project
+      4. ``'default'`` sentinel only if `projects` is empty
+         (matches the `or ['default']` fallback for the options list).
+    """
+    if qs_proj and qs_proj in projects:
+        return qs_proj
+    if stored and stored in projects:
+        return stored
+    if projects:
+        return projects[0]
+    return 'default'
+
+
 def create_nav():
     """Shared navigation header with project selector and page links."""
     from app.project_context import get_all_projects
@@ -34,13 +64,12 @@ def create_nav():
         _qs_proj = _ctx.client.request.query_params.get('project')
     except Exception:
         _qs_proj = None
-    if _qs_proj:
-        app.storage.user['project'] = _qs_proj
-    elif 'project' not in app.storage.user:
-        app.storage.user['project'] = 'default'
 
-    current = app.storage.user['project']
     projects = get_all_projects() or ['default']
+    stored = app.storage.user.get('project')
+    current = resolve_active_project(_qs_proj, stored, projects)
+    # Persist the resolved value so subsequent renders skip the cascade.
+    app.storage.user['project'] = current
 
     with ui.header().classes('items-center justify-between bg-indigo-700 px-6 shadow-md'):
         with ui.row().classes('items-center gap-3'):

--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -8,6 +8,14 @@ services:
       - ./data:/data
     environment:
       - PRISM_DATA_DIR=/data
+      # NiceGUI persists per-client storage under cwd/.nicegui by default.
+      # If cwd ever lands on a read-only mount (common when callers bind
+      # /project read-only and set working_dir there for `git diff`-style
+      # access), every storage-using page silently 500s with an
+      # OSError that doesn't surface to the browser. Pin storage to
+      # the writable /data volume so the failure mode can't recur.
+      # Closes resolve-io/.prism#48.
+      - NICEGUI_STORAGE_PATH=/data/.nicegui
       # MiniLM is the +11pt LongMemEval default (vs potion baseline).
       # Override per project if needed: potion | minilm | bge-small | jina-code
       - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}

--- a/services/prism-service/tests/unit/test_brain_call_chain_call_site.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_call_site.py
@@ -1,0 +1,95 @@
+"""AC5 tests — per-edge call_site_file + call_site_location.
+
+Task: 7471514b. AC5: graphify emits source_file per edge (the FILE
+where the call site lives, distinct from where the source ENTITY is
+defined). _import_graph_json now persists it as
+relationships.call_site_file. Brain.call_chain surfaces it on every
+edge so callers can jump straight to the call site.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed(graph_db: str) -> None:
+    """A defined in src/a.py calls B (defined in src/b.py).
+    The CALL SITE happens in src/handler.py — distinct from A's own file.
+    Plus a legacy edge with no call_site populated."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        ids = {}
+        for n, f in (("A", "src/a.py"), ("B", "src/b.py"),
+                     ("Legacy", "src/legacy.py")):
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (n, "function", f, 1),
+            )
+            ids[n] = cur.lastrowid
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation, call_site_file, "
+            " source_location) "
+            "VALUES (?, ?, 'calls', 'src/handler.py', 'L42')",
+            (ids["A"], ids["B"]),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) "
+            "VALUES (?, ?, 'calls')",
+            (ids["A"], ids["Legacy"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_call_site_file_surfaced_on_edges(brain):
+    """AC5: edges carry call_site_file pointing at where the call
+    actually happens, not where the source entity is defined."""
+    edges = brain.call_chain("A", limit=100)
+    a_to_b = next(e for e in edges if e["to"] == "B")
+    assert a_to_b["call_site_file"] == "src/handler.py"
+    assert a_to_b["call_site_location"] == "L42"
+
+
+def test_legacy_edge_with_no_call_site_returns_empty_string(brain):
+    """AC5: edges without call_site populated get empty strings, not
+    null/missing — keeps the result schema stable."""
+    edges = brain.call_chain("A", limit=100)
+    a_to_legacy = next(e for e in edges if e["to"] == "Legacy")
+    assert a_to_legacy["call_site_file"] == ""
+    assert a_to_legacy["call_site_location"] == ""
+
+
+def test_call_site_flows_in_callers_direction(brain):
+    """AC2 + AC5: the call_site is per-edge, not per-direction —
+    same value whether you walk the edge forward or backward."""
+    edges = brain.call_chain("B", direction="callers")
+    e = edges[0]
+    assert e["call_site_file"] == "src/handler.py"
+    assert e["call_site_location"] == "L42"
+    assert e["from"] == "A"

--- a/services/prism-service/tests/unit/test_brain_call_chain_confidence.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_confidence.py
@@ -1,0 +1,110 @@
+"""AC3 tests — surface confidence + confidence_score in call_chain.
+
+Task: 7471514b. AC3: brain_call_chain returns the per-edge confidence
+tier (EXTRACTED/INFERRED/AMBIGUOUS) and confidence_score (0.0-1.0).
+Already stored on relationships, just needs to flow through the SELECT
+and result mapping.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed(graph_db: str) -> None:
+    """A → B (EXTRACTED, 1.0), A → C (INFERRED, 0.6),
+       A → D (no confidence columns populated — legacy edge)."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        # Apply graphify schema migrations so the confidence columns
+        # exist on the relationships table (production code calls these
+        # during _import_graph_json; tests bypass that path).
+        from app.services.graph_service import _graph_schema_migrations
+        _graph_schema_migrations(conn)
+        ids = {}
+        for n in ("A", "B", "C", "D"):
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (n, "function", f"src/{n.lower()}.py", 1),
+            )
+            ids[n] = cur.lastrowid
+        # Two edges with confidence populated, one legacy edge with NULLs.
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation, confidence, "
+            " confidence_score) VALUES (?, ?, 'calls', 'EXTRACTED', 1.0)",
+            (ids["A"], ids["B"]),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation, confidence, "
+            " confidence_score) VALUES (?, ?, 'calls', 'INFERRED', 0.6)",
+            (ids["A"], ids["C"]),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) "
+            "VALUES (?, ?, 'calls')",
+            (ids["A"], ids["D"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_extracted_edge_carries_full_confidence(brain):
+    edges = brain.call_chain("A", limit=100)
+    a_to_b = next(e for e in edges if e["to"] == "B")
+    assert a_to_b["confidence"] == "EXTRACTED"
+    assert a_to_b["confidence_score"] == 1.0
+
+
+def test_inferred_edge_carries_lower_score(brain):
+    edges = brain.call_chain("A", limit=100)
+    a_to_c = next(e for e in edges if e["to"] == "C")
+    assert a_to_c["confidence"] == "INFERRED"
+    assert a_to_c["confidence_score"] == pytest.approx(0.6)
+
+
+def test_legacy_edge_with_null_confidence_defaults_to_extracted_1(brain):
+    """AC3: legacy tree-sitter edges (pre-graphify) have NULL
+    confidence columns. Default to EXTRACTED / 1.0 so the result
+    schema is uniform — matches what _import_graph_json writes for
+    new edges with no explicit confidence."""
+    edges = brain.call_chain("A", limit=100)
+    a_to_d = next(e for e in edges if e["to"] == "D")
+    assert a_to_d["confidence"] == "EXTRACTED"
+    assert a_to_d["confidence_score"] == 1.0
+
+
+def test_callers_direction_also_carries_confidence(brain):
+    """AC2 + AC3 interaction: confidence flows through in both
+    directions (no shared SQL means we have to verify)."""
+    edges = brain.call_chain("B", direction="callers")
+    e = edges[0]
+    assert e["confidence"] == "EXTRACTED"
+    assert e["confidence_score"] == 1.0
+    assert e["from"] == "A"

--- a/services/prism-service/tests/unit/test_brain_call_chain_direction.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_direction.py
@@ -1,0 +1,168 @@
+"""AC2 tests — brain_call_chain `direction` blast-radius primitive.
+
+Task: 7471514b. AC2: brain_call_chain accepts direction in
+{'callees','callers','both'}. 'callers' answers "who would break if I
+change this?" — the actual blast-radius primitive. 'both' returns the
+union with each edge tagged so callers can partition.
+
+Stacks on top of AC1 (relation filter). Tests build a tiny chain
+A → B → C with branching so we can verify hop counts and edge tags.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed(graph_db: str) -> dict:
+    """Seed graph: A→B→C (linear chain) plus X→B (extra caller of B).
+
+    From B's perspective:
+      callees: B → C
+      callers: A → B  AND  X → B
+      both: union of the above
+    """
+    conn = sqlite3.connect(graph_db)
+    try:
+        ids: dict[str, int] = {}
+        for n in ("A", "B", "C", "X"):
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (n, "function", f"src/{n.lower()}.py", 1),
+            )
+            ids[n] = cur.lastrowid
+        for src, tgt in (("A", "B"), ("B", "C"), ("X", "B")):
+            conn.execute(
+                "INSERT INTO relationships "
+                "(source_id, target_id, relation) VALUES (?, ?, ?)",
+                (ids[src], ids[tgt], "calls"),
+            )
+        conn.commit()
+        return ids
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_callees_default_unchanged(brain):
+    """AC2 default: direction='callees' is the existing behavior —
+    walk forward from B to find C."""
+    edges = brain.call_chain("B")  # default direction='callees'
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("B", "C")}
+    assert all(e["direction"] == "callees" for e in edges)
+
+
+def test_callers_finds_blast_radius(brain):
+    """AC2 blast radius: direction='callers' from B returns A AND X
+    (both call B)."""
+    edges = brain.call_chain("B", direction="callers")
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("A", "B"), ("X", "B")}
+    assert all(e["direction"] == "callers" for e in edges)
+
+
+def test_both_unions_callers_and_callees(brain):
+    """AC2 union: direction='both' returns the call-flow forward AND
+    the blast radius, with each edge tagged."""
+    edges = brain.call_chain("B", direction="both")
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("A", "B"), ("X", "B"), ("B", "C")}
+    by_dir = {e["direction"] for e in edges}
+    assert by_dir == {"callees", "callers"}
+    # Each edge appears exactly once even though 'both' runs two BFS
+    # passes — de-dup by (src, tgt, relation) prevents duplicates.
+    keys = [(e["from"], e["to"], e["relation"]) for e in edges]
+    assert len(keys) == len(set(keys))
+
+
+def test_callers_walks_multiple_hops(brain):
+    """AC2 + depth: from C, callers=2 should reach B (hop 1) and
+    A + X (hop 2)."""
+    edges = brain.call_chain("C", direction="callers", depth=2)
+    by_hop: dict[int, set] = {}
+    for e in edges:
+        by_hop.setdefault(e["hop"], set()).add((e["from"], e["to"]))
+    assert by_hop[1] == {("B", "C")}
+    assert by_hop[2] == {("A", "B"), ("X", "B")}
+
+
+def test_unknown_direction_falls_back_to_callees(brain):
+    """AC2 robustness: garbage direction string defaults to callees,
+    not crashes."""
+    edges = brain.call_chain("B", direction="sideways")
+    pairs = {(e["from"], e["to"]) for e in edges}
+    assert pairs == {("B", "C")}
+
+
+def test_direction_aliases(brain):
+    """AC2 ergonomics: common alternate spellings normalize."""
+    for alias in ("caller", "up", "blast_radius"):
+        edges = brain.call_chain("B", direction=alias)
+        pairs = {(e["from"], e["to"]) for e in edges}
+        assert pairs == {("A", "B"), ("X", "B")}, (
+            f"alias {alias!r} should map to 'callers'"
+        )
+    for alias in ("callee", "down", "forward"):
+        edges = brain.call_chain("B", direction=alias)
+        pairs = {(e["from"], e["to"]) for e in edges}
+        assert pairs == {("B", "C")}
+
+
+def test_relation_filter_still_works_with_direction(brain):
+    """AC1 + AC2 interaction: the relation filter applies in both
+    directions. Add a non-call edge from Z to B; filtering for 'calls'
+    excludes it whether walking forward or backward."""
+    import sqlite3 as _sq
+    conn = _sq.connect(brain._graph_db_path) if hasattr(
+        brain, "_graph_db_path") else None
+    # Use the brain's own graph cursor instead.
+    brain._graph.execute(
+        "INSERT INTO entities (name, kind, file, line) VALUES (?,?,?,?)",
+        ("Z", "function", "src/z.py", 1),
+    )
+    z_id = brain._graph.execute(
+        "SELECT id FROM entities WHERE name='Z'"
+    ).fetchone()["id"]
+    b_id = brain._graph.execute(
+        "SELECT id FROM entities WHERE name='B'"
+    ).fetchone()["id"]
+    brain._graph.execute(
+        "INSERT INTO relationships (source_id, target_id, relation) "
+        "VALUES (?, ?, ?)",
+        (z_id, b_id, "uses"),
+    )
+    brain._graph.commit()
+
+    # callers default 'calls' — Z is NOT a caller (uses, not calls)
+    callers = brain.call_chain("B", direction="callers")
+    names = {e["from"] for e in callers}
+    assert "Z" not in names
+    # callers with relation='*' — Z shows up
+    callers_all = brain.call_chain(
+        "B", direction="callers", relation="*",
+    )
+    names_all = {e["from"] for e in callers_all}
+    assert "Z" in names_all

--- a/services/prism-service/tests/unit/test_brain_call_chain_norm_label.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_norm_label.py
@@ -1,0 +1,126 @@
+"""AC4 tests — norm_label fuzzy entity resolution in call_chain.
+
+Task: 7471514b. AC4: graphify emits per-node norm_label so
+'Brain.search()' / 'brain.search' / 'brain_search' all resolve to the
+same entity. _import_graph_json now persists it to entities.norm_label
+with an index, and Brain.call_chain falls back to it when the
+canonical-name lookup misses.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+from app.services.graph_service import _derive_norm_label
+
+
+def _seed(graph_db: str) -> None:
+    """Single entity 'Brain.search()' with norm_label='brain_search'.
+    Plus an outbound edge so call_chain has something to return."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line, norm_label) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("Brain.search()", "method", "src/brain.py", 100, "brain_search"),
+        )
+        src_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line, norm_label) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("Cache.lookup", "method", "src/cache.py", 1, "cache_lookup"),
+        )
+        tgt_id = cur.lastrowid
+        conn.execute(
+            "INSERT INTO relationships (source_id, target_id, relation) "
+            "VALUES (?, ?, 'calls')",
+            (src_id, tgt_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed(str(tmp_path / "graph.db"))
+    return b
+
+
+# ---------------------------------------------------------------------------
+# _derive_norm_label unit tests (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_derive_strips_call_syntax():
+    assert _derive_norm_label("Brain.search()") == "brain_search"
+
+
+def test_derive_dotted_name():
+    assert _derive_norm_label("Brain.search") == "brain_search"
+
+
+def test_derive_already_normalized():
+    assert _derive_norm_label("brain_search") == "brain_search"
+
+
+def test_derive_empty():
+    assert _derive_norm_label("") == ""
+    assert _derive_norm_label(None) == ""
+
+
+def test_derive_strips_punctuation():
+    assert _derive_norm_label("Brain::search") == "brainsearch"
+    assert _derive_norm_label("foo->bar") == "foobar"
+
+
+# ---------------------------------------------------------------------------
+# call_chain fuzzy lookup
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_name_still_works(brain):
+    """AC4 baseline: exact name still resolves — fuzzy fallback only
+    fires when canonical lookup misses."""
+    edges = brain.call_chain("Brain.search()")
+    assert edges
+    assert edges[0]["from"] == "Brain.search()"
+
+
+def test_normalized_form_resolves_via_fallback(brain):
+    """AC4 main case: passing 'brain_search' (the norm_label form)
+    resolves to the entity stored as 'Brain.search()'."""
+    edges = brain.call_chain("brain_search")
+    assert edges, "fuzzy norm_label lookup should have hit"
+    assert edges[0]["from"] == "Brain.search()"
+
+
+def test_dotted_form_resolves_via_fallback(brain):
+    """AC4: 'Brain.search' (no parens) also resolves to the
+    'Brain.search()' entity via norm_label."""
+    edges = brain.call_chain("Brain.search")
+    assert edges
+    assert edges[0]["from"] == "Brain.search()"
+
+
+def test_unknown_name_still_returns_empty(brain):
+    """AC4 regression guard: a truly unknown identifier still returns
+    [] — fuzzy fallback isn't a free-for-all match."""
+    assert brain.call_chain("DoesNotExist") == []

--- a/services/prism-service/tests/unit/test_brain_call_chain_relation_filter.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_relation_filter.py
@@ -1,0 +1,138 @@
+"""AC1 tests — brain_call_chain.relation filter.
+
+Task: 7471514b-5ba6-494e-94a8-d695df4cb1e6 (Close graph-quality gap vs
+GitNexus). AC1: brain_call_chain accepts a `relation` filter; default
+"calls" stops contains/method/uses/imports_from from eating the
+depth+limit budget.
+
+These tests construct a minimal in-memory graph by writing rows
+directly into a Brain instance's graph.db so the assertions don't
+depend on the C# fixture or graphify being installed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_graph(graph_db: str) -> None:
+    """Seed graph.db with a single source 'Hub' that has one outbound
+    edge of each relation kind to a distinct target. Lets us assert
+    that the relation filter selects exactly the right edges."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("Hub", "function", "src/hub.py", 1),
+        )
+        hub_id = cur.lastrowid
+        targets = [
+            ("Callee", "calls"),
+            ("Container", "contains"),
+            ("Used", "uses"),
+            ("MethodOf", "method"),
+            ("ImportedFrom", "imports_from"),
+            ("Parent", "inherits"),
+        ]
+        for tgt_name, rel in targets:
+            cur = conn.execute(
+                "INSERT INTO entities (name, kind, file, line) "
+                "VALUES (?, ?, ?, ?)",
+                (tgt_name, "function", f"src/{tgt_name.lower()}.py", 1),
+            )
+            tgt_id = cur.lastrowid
+            conn.execute(
+                "INSERT INTO relationships "
+                "(source_id, target_id, relation) "
+                "VALUES (?, ?, ?)",
+                (hub_id, tgt_id, rel),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    """Brain with a seeded graph but no docs/embeddings — we only
+    exercise the call_chain SQL path here."""
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed_graph(str(tmp_path / "graph.db"))
+    return b
+
+
+def test_default_returns_only_calls_edges(brain):
+    """AC1 default: relation defaults to 'calls'; structural edges
+    (contains/uses/method/imports_from/inherits) are excluded."""
+    edges = brain.call_chain("Hub")
+    assert edges, "expected at least the 'calls' edge to come back"
+    relations = {e["relation"] for e in edges}
+    assert relations == {"calls"}, (
+        f"default relation filter should keep only 'calls'; got "
+        f"{relations!r}"
+    )
+    assert {e["to"] for e in edges} == {"Callee"}
+
+
+def test_wildcard_includes_every_relation_kind(brain):
+    """AC1 escape hatch: relation='*' restores legacy unfiltered
+    behavior so every outbound edge appears."""
+    edges = brain.call_chain("Hub", relation="*", limit=100)
+    relations = {e["relation"] for e in edges}
+    assert relations == {
+        "calls", "contains", "uses", "method", "imports_from", "inherits",
+    }, f"expected every relation kind; got {relations!r}"
+
+
+def test_none_includes_every_relation_kind(brain):
+    """AC1: passing relation=None is equivalent to '*'."""
+    edges = brain.call_chain("Hub", relation=None, limit=100)
+    relations = {e["relation"] for e in edges}
+    assert "calls" in relations and "contains" in relations
+
+
+def test_explicit_kind_filters_to_just_that_kind(brain):
+    """AC1: a non-default relation string filters to exactly that kind."""
+    edges = brain.call_chain("Hub", relation="uses")
+    assert len(edges) == 1
+    assert edges[0]["relation"] == "uses"
+    assert edges[0]["to"] == "Used"
+
+
+def test_list_filter_accepts_multiple_kinds(brain):
+    """AC1: list/tuple input lets callers union several relation kinds
+    (e.g. 'calls' + 'inherits' for OO impact analysis)."""
+    edges = brain.call_chain(
+        "Hub", relation=["calls", "inherits"], limit=100,
+    )
+    relations = {e["relation"] for e in edges}
+    assert relations == {"calls", "inherits"}
+
+
+def test_unknown_relation_returns_empty(brain):
+    """AC1: filtering to a relation that doesn't exist returns []."""
+    edges = brain.call_chain("Hub", relation="does_not_exist")
+    assert edges == []
+
+
+def test_unknown_entity_returns_empty(brain):
+    """AC1 regression guard: missing start entity still returns []
+    regardless of the relation filter."""
+    edges = brain.call_chain("DoesNotExist")
+    assert edges == []

--- a/services/prism-service/tests/unit/test_brain_rationale_filter.py
+++ b/services/prism-service/tests/unit/test_brain_rationale_filter.py
@@ -1,0 +1,168 @@
+"""AC6 tests — rationale node filter on graph_query / find_references.
+
+Task: 7471514b-5ba6-494e-94a8-d695df4cb1e6 (Close graph-quality gap vs
+GitNexus). AC6: rationale nodes (kind='rationale', graphify-extracted
+# WHY: / # HACK: / # NOTE: comments) should NOT pollute graph
+traversal results by default — they account for ~43% of nodes in a
+typical PRISM graph and answer different questions than code-flow
+traversal. Surface them only when callers ask via include_rationale=True.
+
+Seeds graph.db directly so tests don't depend on graphify being
+installed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_graph(graph_db: str) -> None:
+    """Seed a tiny graph: 'Target' is referenced by one real caller
+    ('RealCaller', kind='function') AND one rationale node
+    ('RationaleNote', kind='rationale'). Also gives 'Target' an
+    outbound edge to a real callee plus an outbound rationale_for
+    edge to verify graph_query filtering on the target side."""
+    conn = sqlite3.connect(graph_db)
+    try:
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("Target", "function", "src/target.py", 10),
+        )
+        target_id = cur.lastrowid
+
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("RealCaller", "function", "src/caller.py", 5),
+        )
+        real_caller_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("RationaleNote", "rationale", "src/target.py", 9),
+        )
+        rationale_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("RealCallee", "function", "src/callee.py", 1),
+        )
+        real_callee_id = cur.lastrowid
+        cur = conn.execute(
+            "INSERT INTO entities (name, kind, file, line) "
+            "VALUES (?, ?, ?, ?)",
+            ("WhyTargetExists", "rationale", "src/callee.py", 1),
+        )
+        rationale_callee_id = cur.lastrowid
+
+        # Inbound edges to Target — one real call, one rationale_for
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (real_caller_id, target_id, "calls"),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (rationale_id, target_id, "rationale_for"),
+        )
+        # Outbound edges from Target — one real call, one rationale_for
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (target_id, real_callee_id, "calls"),
+        )
+        conn.execute(
+            "INSERT INTO relationships "
+            "(source_id, target_id, relation) VALUES (?, ?, ?)",
+            (target_id, rationale_callee_id, "rationale_for"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain(tmp_path):
+    from app.engines.brain_engine import Brain
+    b = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    _seed_graph(str(tmp_path / "graph.db"))
+    return b
+
+
+# ---------------------------------------------------------------------------
+# find_references
+# ---------------------------------------------------------------------------
+
+
+def test_find_references_excludes_rationale_by_default(brain):
+    """AC6 default: only real callers come back; rationale_for edges
+    are filtered."""
+    refs = brain.find_references("Target")
+    callers = {r["caller_name"] for r in refs}
+    assert callers == {"RealCaller"}, (
+        f"default should exclude rationale callers; got {callers!r}"
+    )
+
+
+def test_find_references_includes_rationale_when_opted_in(brain):
+    """AC6 opt-in: include_rationale=True surfaces both real callers
+    and rationale_for edges."""
+    refs = brain.find_references("Target", include_rationale=True)
+    callers = {r["caller_name"] for r in refs}
+    assert callers == {"RealCaller", "RationaleNote"}
+
+
+# ---------------------------------------------------------------------------
+# graph_query
+# ---------------------------------------------------------------------------
+
+
+def test_graph_query_excludes_rationale_targets_by_default(brain):
+    """AC6 default: outbound traversal skips rationale-kind targets."""
+    rows = brain.graph_query("Target")
+    names = {r["name"] for r in rows}
+    assert names == {"RealCallee"}
+
+
+def test_graph_query_includes_rationale_when_opted_in(brain):
+    """AC6 opt-in: include_rationale=True returns rationale targets too."""
+    rows = brain.graph_query("Target", include_rationale=True)
+    names = {r["name"] for r in rows}
+    assert names == {"RealCallee", "WhyTargetExists"}
+
+
+def test_graph_query_with_relation_filter_still_filters_rationale(brain):
+    """AC6 + existing relation filter: combining both works — asking
+    for rationale_for relation returns nothing by default (the targets
+    of rationale_for are themselves kind='rationale')."""
+    rows = brain.graph_query("Target", relation="rationale_for")
+    assert rows == [], (
+        "rationale_for edges point at rationale-kind nodes; should be "
+        "filtered when include_rationale=False"
+    )
+    rows_with = brain.graph_query(
+        "Target", relation="rationale_for", include_rationale=True,
+    )
+    names = {r["name"] for r in rows_with}
+    assert names == {"WhyTargetExists"}
+
+
+def test_graph_query_unknown_entity_returns_empty(brain):
+    """AC6 regression guard: missing start entity still returns []."""
+    assert brain.graph_query("DoesNotExist") == []

--- a/services/prism-service/tests/unit/test_graph_sync_status_chunk_count.py
+++ b/services/prism-service/tests/unit/test_graph_sync_status_chunk_count.py
@@ -1,0 +1,173 @@
+"""Issue #41 tests — sync_status counts files, not chunks.
+
+resolve-io/.prism#41: prism_status was reporting `stale: true` with
+"only 8454/82150 code docs are staged" — the 9.7x ratio was the
+chunks-per-file ratio, not a real gap. Multi-granular chunking emits
+N rows per source_file (::win_N, ::__file__, ::__module__,
+::EntityName); comparing total rows against the disk file count made
+the staleness check trigger on every project.
+
+The fix: count DISTINCT source_files in the docs table so the unit
+matches staged_files (which already counts files on disk).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_brain(brain_db: str, files: list[tuple[str, int]]) -> None:
+    """Create a docs table that mimics multi-granular chunking output.
+
+    `files` is a list of (source_file, chunk_count) tuples — one row
+    is inserted per chunk so the test sees the realistic N-rows-per-
+    file pattern that triggered #41.
+    """
+    conn = sqlite3.connect(brain_db)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS docs ("
+            "  id TEXT PRIMARY KEY, "
+            "  source_file TEXT, "
+            "  content TEXT, "
+            "  content_hash TEXT"
+            ")"
+        )
+        for source_file, n_chunks in files:
+            for i in range(n_chunks):
+                doc_id = f"{source_file}::chunk_{i}"
+                conn.execute(
+                    "INSERT INTO docs (id, source_file, content) "
+                    "VALUES (?, ?, ?)",
+                    (doc_id, source_file, f"chunk {i} content"),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_graph_service(tmp_path):
+    """Build a GraphService whose staging_dir matches a known file count."""
+    from app.services.graph_service import GraphService
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    graph_db = str(proj / "graph.db")
+    # GraphService creates the schema lazily; an empty file is fine.
+    sqlite3.connect(graph_db).close()
+    return GraphService(
+        project_data_dir=str(proj),
+        graph_db_path=graph_db,
+    )
+
+
+def _stage_files(svc, files: list[str]) -> None:
+    """Stage `files` (relative paths) under svc._staging_dir with a
+    one-line body so they count as is_file() in sync_status."""
+    for rel in files:
+        p = svc._staging_dir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("// stub", encoding="utf-8")
+
+
+def test_code_docs_counts_distinct_files_not_chunks(tmp_path):
+    """Issue #41 root cause: with 3 files × 10 chunks each = 30 rows
+    in docs, the old code returned code_docs=30 and compared against
+    staged_files=3, falsely reporting stale. Fix returns code_docs=3
+    matching staged_files=3."""
+    files = [
+        ("src/a.py", 10),
+        ("src/b.py", 10),
+        ("src/c.py", 10),
+    ]
+    brain_db = str(tmp_path / "brain.db")
+    _seed_brain(brain_db, files)
+
+    svc = _make_graph_service(tmp_path)
+    _stage_files(svc, ["src/a.py", "src/b.py", "src/c.py"])
+
+    status = svc.sync_status(brain_db)
+
+    assert status["docs"] == 30, (
+        f"raw chunk count should still be 30; got {status['docs']}"
+    )
+    assert status["code_docs"] == 3, (
+        f"code_docs should count UNIQUE source_files (3), not chunks "
+        f"(30); got {status['code_docs']}"
+    )
+    assert status["staged_files"] == 3
+    assert status["stale"] is False, (
+        f"three files in Brain + three on disk = in sync; "
+        f"reasons: {status['reasons']!r}"
+    )
+
+
+def test_genuine_drift_still_detected(tmp_path):
+    """Issue #41 regression guard: the fix must not silence ACTUAL
+    staleness. Five files in Brain, only one staged on disk → still
+    stale (4/5 missing from staging)."""
+    files = [(f"src/f{i}.py", 5) for i in range(5)]  # 5 files × 5 chunks
+    brain_db = str(tmp_path / "brain.db")
+    _seed_brain(brain_db, files)
+
+    svc = _make_graph_service(tmp_path)
+    _stage_files(svc, ["src/f0.py"])  # only one staged
+
+    status = svc.sync_status(brain_db)
+    assert status["code_docs"] == 5
+    assert status["staged_files"] == 1
+    assert status["stale"] is True
+    assert any("staged" in r for r in status["reasons"]), (
+        f"expected staleness reason mentioning staging; "
+        f"reasons: {status['reasons']!r}"
+    )
+
+
+def test_non_code_docs_do_not_inflate_count(tmp_path):
+    """Issue #41 sanity: only files with code-suffix extensions count.
+    Markdown / arbitrary docs should not be included in code_docs."""
+    files = [
+        ("src/a.py", 5),
+        ("docs/README.md", 5),  # .md IS in GRAPHIFY_CODE_SUFFIXES
+        ("notes.txt", 5),       # .txt is NOT
+    ]
+    brain_db = str(tmp_path / "brain.db")
+    _seed_brain(brain_db, files)
+
+    svc = _make_graph_service(tmp_path)
+    status = svc.sync_status(brain_db)
+    # .py + .md count, .txt does not → 2 distinct code-suffix files
+    assert status["code_docs"] == 2, (
+        f"expected 2 code files (.py + .md), got {status['code_docs']}"
+    )
+
+
+def test_resolve_platform_scenario_no_false_stale(tmp_path):
+    """Replicate the exact ratio from the issue body: 9.7 chunks per
+    file. Old code: code_docs=9700, staged=1000, stale=True. New code:
+    code_docs=1000, staged=1000, stale=False."""
+    # 100 files × ~10 chunks each = ~1000 chunks
+    files = [(f"src/file_{i:03d}.py", 10) for i in range(100)]
+    brain_db = str(tmp_path / "brain.db")
+    _seed_brain(brain_db, files)
+
+    svc = _make_graph_service(tmp_path)
+    _stage_files(svc, [f"src/file_{i:03d}.py" for i in range(100)])
+
+    status = svc.sync_status(brain_db)
+    assert status["docs"] == 1000  # raw chunk count
+    assert status["code_docs"] == 100  # distinct files
+    assert status["staged_files"] == 100
+    assert status["stale"] is False, (
+        f"100 files indexed, 100 staged — must NOT be stale; "
+        f"reasons: {status['reasons']!r}"
+    )

--- a/services/prism-service/tests/unit/test_install_manifest.py
+++ b/services/prism-service/tests/unit/test_install_manifest.py
@@ -87,6 +87,22 @@ def test_install_settings_wires_all_shipped_hooks():
         "hook commands must use ${CLAUDE_PROJECT_DIR} so they resolve "
         "regardless of the subprocess cwd"
     )
+    # Issue #36: hook commands must invoke `python3`, not bare `python`.
+    # Modern Linux distros (Ubuntu 20.04+, Debian 11+, Fedora, Arch) ship
+    # only `/usr/bin/python3`; bare `python` exits with `command not found`
+    # and Claude Code reports `SessionStart:startup hook error`. Guard
+    # against any future drift back to the broken default.
+    assert "python " not in rendered, (
+        "hook commands must invoke `python3`, not bare `python` "
+        "(see resolve-io/.prism#36)"
+    )
+    # Sanity: every hook entry uses the python3 prefix.
+    import re as _re
+    py3_count = len(_re.findall(r'"python3 ', rendered))
+    assert py3_count >= 7, (
+        f"expected >=7 hook commands prefixed with `python3 `, found "
+        f"{py3_count}"
+    )
 
 
 def test_plugin_hook_registration_is_noop():

--- a/services/prism-service/tests/unit/test_install_manifest.py
+++ b/services/prism-service/tests/unit/test_install_manifest.py
@@ -124,9 +124,13 @@ def test_stop_hook_calls_mark_stale_no_subprocess():
     files = _files_by_path(_manifest())
     content = files[".claude/hooks/prism-stop.py"]["content"]
     assert "janitor_mark_stale" in content
-    # No subprocess or claude -p invocation in the hook
-    assert "subprocess.run" not in content
+    # No `claude -p` shellout — janitor reflection runs server-side via
+    # MCP, never by spawning an LLM subprocess from the hook. (Issue #49
+    # added a `git rev-parse HEAD` subprocess, which IS legitimate;
+    # specifically guard against the old claude-shellout pattern.)
     assert '"claude"' not in content and "'claude'" not in content
+    assert "claude -p" not in content
+    assert "claude --" not in content
 
 
 def test_stop_hook_latency_under_500ms(tmp_path):

--- a/services/prism-service/tests/unit/test_install_manifest.py
+++ b/services/prism-service/tests/unit/test_install_manifest.py
@@ -16,9 +16,9 @@ if str(_SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(_SERVICE_ROOT))
 
 
-def _manifest():
+def _manifest(host_platform=None):
     from app.mcp.tools import _install_manifest
-    return _install_manifest(project_id="test")
+    return _install_manifest(project_id="test", host_platform=host_platform)
 
 
 def _files_by_path(manifest):
@@ -66,43 +66,95 @@ def test_install_manifest_keeps_required_client_adapter_files():
             assert spec["action"] == "upsert"
 
 
-def test_install_settings_wires_all_shipped_hooks():
-    files = _files_by_path(_manifest())
+_HOOK_FRAGMENTS = (
+    "/.claude/hooks/prism-sync.py",
+    "/.claude/hooks/prism-feedback-signal.py",
+    "/.claude/hooks/prism-stop.py",
+    "/.claude/hooks/prism-subagent.py",
+    "/.claude/hooks/prism-skill-usage.py",
+    "/.claude/hooks/prism-edit-learn.py",
+    "/.claude/hooks/prism-idle-rebuild.py",
+)
+
+
+def _hooks_rendered(host_platform=None):
+    files = _files_by_path(_manifest(host_platform=host_platform))
     settings = json.loads(files[".claude/settings.json"]["content"])
-    hooks = settings["hooks"]
-    rendered = json.dumps(hooks)
-    # Hook commands use ${CLAUDE_PROJECT_DIR} so they survive cwd shifts —
-    # match on the trailing path fragment, not the full command line.
-    for fragment in (
-        "/.claude/hooks/prism-sync.py",
-        "/.claude/hooks/prism-feedback-signal.py",
-        "/.claude/hooks/prism-stop.py",
-        "/.claude/hooks/prism-subagent.py",
-        "/.claude/hooks/prism-skill-usage.py",
-        "/.claude/hooks/prism-edit-learn.py",
-        "/.claude/hooks/prism-idle-rebuild.py",
-    ):
+    return json.dumps(settings["hooks"])
+
+
+def test_install_settings_wires_all_shipped_hooks():
+    """Default (no host_platform) is POSIX — every shipped hook is wired
+    with the `python3 ${CLAUDE_PROJECT_DIR}/...` form."""
+    rendered = _hooks_rendered()
+    for fragment in _HOOK_FRAGMENTS:
         assert fragment in rendered
     assert "${CLAUDE_PROJECT_DIR}" in rendered, (
         "hook commands must use ${CLAUDE_PROJECT_DIR} so they resolve "
         "regardless of the subprocess cwd"
     )
-    # Issue #36: hook commands must invoke `python3`, not bare `python`.
-    # Modern Linux distros (Ubuntu 20.04+, Debian 11+, Fedora, Arch) ship
-    # only `/usr/bin/python3`; bare `python` exits with `command not found`
-    # and Claude Code reports `SessionStart:startup hook error`. Guard
-    # against any future drift back to the broken default.
-    assert "python " not in rendered, (
-        "hook commands must invoke `python3`, not bare `python` "
-        "(see resolve-io/.prism#36)"
-    )
-    # Sanity: every hook entry uses the python3 prefix.
+    # PEP 394: POSIX uses `python3`. Modern Linux distros (Ubuntu 20.04+,
+    # Debian 11+, Fedora, Arch) ship only `/usr/bin/python3` — bare
+    # `python` exits with `command not found` and Claude Code reports
+    # `SessionStart:startup hook error`. (Issue #36.)
     import re as _re
     py3_count = len(_re.findall(r'"python3 ', rendered))
     assert py3_count >= 7, (
-        f"expected >=7 hook commands prefixed with `python3 `, found "
-        f"{py3_count}"
+        f"expected >=7 hook commands prefixed with `python3 ` on POSIX, "
+        f"found {py3_count}"
     )
+
+
+def test_install_settings_uses_py_launcher_on_windows():
+    """PEP 397: Windows uses the `py.exe` launcher (`py -3`). The
+    python.org installer ships `py.exe` to PATH but does NOT ship a
+    bare `python3.exe`, so the POSIX form would break every Windows
+    host. The hook scripts carry `#!/usr/bin/env python3` shebangs,
+    which `py.exe` reads to route to a Python 3 interpreter."""
+    rendered = _hooks_rendered(host_platform="win32")
+    for fragment in _HOOK_FRAGMENTS:
+        assert fragment in rendered
+    assert "${CLAUDE_PROJECT_DIR}" in rendered
+    # Every hook entry must use the `py -3 ` prefix on Windows.
+    import re as _re
+    py_count = len(_re.findall(r'"py -3 ', rendered))
+    assert py_count >= 7, (
+        f"expected >=7 hook commands prefixed with `py -3 ` on Windows, "
+        f"found {py_count}"
+    )
+    # And no `python3 ` (which doesn't exist on Windows by default).
+    assert "python3 " not in rendered, (
+        "Windows manifest must not emit `python3 ...` — python.org "
+        "installer doesn't ship `python3.exe`. Use `py -3` (PEP 397)."
+    )
+
+
+def test_install_settings_never_emits_bare_python():
+    """Cross-platform guard: bare `python ` (with trailing space) breaks
+    on modern Linux (no `/usr/bin/python`) and is ambiguous on Windows
+    (Python 2 vs Python 3). Must never appear, regardless of platform."""
+    for host in (None, "linux", "darwin", "win32", "windows", "posix"):
+        rendered = _hooks_rendered(host_platform=host)
+        assert '"python ' not in rendered, (
+            f"hook commands must not invoke bare `python` "
+            f"(host_platform={host!r}). See resolve-io/.prism#36."
+        )
+
+
+def test_install_manifest_accepts_platform_aliases():
+    """Caller may pass either `sys.platform` values or human aliases.
+    Anything starting with `win`/`nt` selects the Windows launcher;
+    everything else is POSIX."""
+    from app.mcp.tools import _hook_python_cmd
+    assert _hook_python_cmd("win32") == "py -3"
+    assert _hook_python_cmd("windows") == "py -3"
+    assert _hook_python_cmd("Windows") == "py -3"
+    assert _hook_python_cmd("nt") == "py -3"
+    assert _hook_python_cmd("linux") == "python3"
+    assert _hook_python_cmd("darwin") == "python3"
+    assert _hook_python_cmd("posix") == "python3"
+    assert _hook_python_cmd("") == "python3"
+    assert _hook_python_cmd(None) == "python3"
 
 
 def test_plugin_hook_registration_is_noop():

--- a/services/prism-service/tests/unit/test_nav_resolve_active_project.py
+++ b/services/prism-service/tests/unit/test_nav_resolve_active_project.py
@@ -1,0 +1,105 @@
+"""Issue #43 tests — resolve_active_project never returns a value
+that's outside the projects list.
+
+resolve-io/.prism#43: nav.py used to seed app.storage.user['project']
+to the literal 'default' sentinel even when real projects existed,
+then pass that sentinel as value= to ui.select(options=projects)
+where 'default' was not in options. NiceGUI raised ValueError and
+every dashboard page 500'd.
+
+The fix extracts a pure helper resolve_active_project(qs_proj, stored,
+projects) that always returns a value guaranteed to be in projects
+(or the 'default' sentinel only when projects is empty, in which case
+the caller's `or ['default']` fallback covers it).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+from app.ui.components.nav import resolve_active_project
+
+
+PROJECTS = ['resolve-platform', 'talentsync', 'prism']
+
+
+def test_url_project_wins_when_valid():
+    """URL ?project= overrides stored value when it points at a real project."""
+    assert resolve_active_project(
+        'talentsync', 'prism', PROJECTS,
+    ) == 'talentsync'
+
+
+def test_url_project_ignored_when_not_in_options():
+    """The bug from #43 — never return a value outside projects.
+    Falls back to stored, then to first project."""
+    assert resolve_active_project(
+        'does-not-exist', 'prism', PROJECTS,
+    ) == 'prism'
+
+
+def test_stored_value_used_when_valid():
+    """No URL hint, stored value is real → keep it."""
+    assert resolve_active_project(None, 'prism', PROJECTS) == 'prism'
+
+
+def test_stored_default_sentinel_replaced_by_real_project():
+    """The exact #43 scenario: stored = 'default', real projects exist.
+    Old code: returned 'default', NiceGUI 500. New code: first project."""
+    assert resolve_active_project(
+        None, 'default', PROJECTS,
+    ) == 'resolve-platform'
+
+
+def test_first_project_when_no_stored_value():
+    """First visit, no cookies, projects exist → first project."""
+    assert resolve_active_project(None, None, PROJECTS) == 'resolve-platform'
+
+
+def test_first_project_when_stored_value_is_stale():
+    """Project was deleted but cookie still references it → fall back."""
+    assert resolve_active_project(
+        None, 'deleted-project', PROJECTS,
+    ) == 'resolve-platform'
+
+
+def test_default_sentinel_only_when_projects_empty():
+    """Truly empty install (first run, nothing onboarded) → return
+    'default' so the caller's `or ['default']` options fallback aligns."""
+    assert resolve_active_project(None, None, []) == 'default'
+    assert resolve_active_project('foo', 'bar', []) == 'default'
+
+
+def test_empty_string_qs_proj_does_not_match():
+    """Empty string from URL parsing isn't a real project."""
+    assert resolve_active_project('', 'prism', PROJECTS) == 'prism'
+
+
+def test_returned_value_always_in_options_or_default():
+    """Property test: for any combination of inputs, the result is
+    either in projects OR the literal 'default' sentinel (which is
+    fine because the caller falls back to `['default']` options when
+    projects is empty)."""
+    test_cases = [
+        ('valid', 'valid-stored', PROJECTS),
+        ('invalid', 'invalid', PROJECTS),
+        (None, None, PROJECTS),
+        ('', '', PROJECTS),
+        ('resolve-platform', 'talentsync', PROJECTS),
+        (None, None, []),
+        ('foo', 'bar', []),
+    ]
+    for qs, stored, projects in test_cases:
+        result = resolve_active_project(qs, stored, projects)
+        assert result in projects or result == 'default', (
+            f"resolve_active_project({qs!r}, {stored!r}, {projects!r}) "
+            f"returned {result!r} which is neither in projects nor 'default'"
+        )

--- a/services/prism-service/tests/unit/test_stop_hook_merge_tagging.py
+++ b/services/prism-service/tests/unit/test_stop_hook_merge_tagging.py
@@ -1,0 +1,176 @@
+"""Issue #49 tests — Stop hook auto-tags in-progress tasks with HEAD.
+
+resolve-io/.prism#49: /learning and /consolidation never populated
+because the install bundle had no caller-side wiring to set
+tasks.merge_sha or call janitor_enqueue. Both pages stayed empty
+forever after a fresh install.
+
+Stop hook now: rev-parse HEAD, find in_progress tasks with no
+merge_sha, tag each with HEAD + enqueue for consolidation. Idempotent
+(tagged tasks are skipped on subsequent stops).
+
+Tests use a unittest.mock-friendly approach: load the hook module
+fresh, patch its _mcp_call and _git_head, drive _tag_active_tasks
+directly with controlled task_list responses.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+_HOOK_SRC = _SERVICE_ROOT / "app" / "assets" / "stop_record_hook.py"
+
+
+def _load_hook():
+    """Import the hook script as a module so we can call its helpers."""
+    spec = importlib.util.spec_from_file_location(
+        "stop_record_hook_under_test", _HOOK_SRC,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["stop_record_hook_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _mock_task_list_response(tasks: list[dict]) -> bytes:
+    """Build a fake MCP task_list response wrapped as SSE."""
+    body = {
+        "jsonrpc": "2.0", "id": 1,
+        "result": {
+            "content": [{
+                "type": "text",
+                "text": json.dumps(tasks),
+            }],
+        },
+    }
+    return f"event: message\ndata: {json.dumps(body)}\n".encode()
+
+
+def test_tags_in_progress_task_without_merge_sha(tmp_path):
+    """Issue #49 happy path: in_progress task with no merge_sha gets
+    task_update(merge_sha=HEAD) AND janitor_enqueue."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "t1", "status": "in_progress", "merge_sha": None},
+    ]
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    calls = [c.args for c in mock_call.call_args_list]
+    tools = [args[2] for args in calls]
+    assert "task_update" in tools
+    assert "janitor_enqueue" in tools
+    update_args = next(c.args[3] for c in mock_call.call_args_list
+                       if c.args[2] == "task_update")
+    assert update_args == {"id": "t1", "merge_sha": "abc123"}
+    enqueue_args = next(c.args[3] for c in mock_call.call_args_list
+                        if c.args[2] == "janitor_enqueue")
+    assert enqueue_args == {"task_id": "t1"}
+
+
+def test_skips_task_already_tagged(tmp_path):
+    """Issue #49 idempotency: task with merge_sha already set is
+    skipped on subsequent Stops."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "t1", "status": "in_progress", "merge_sha": "old_sha"},
+    ]
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    assert mock_call.call_count == 0, (
+        "no MCP writes expected when task is already tagged"
+    )
+
+
+def test_skips_non_in_progress_tasks(tmp_path):
+    """Issue #49: only in_progress tasks get auto-tagged. pending,
+    completed, deleted are ignored."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "t1", "status": "pending", "merge_sha": None},
+        {"id": "t2", "status": "completed", "merge_sha": None},
+        {"id": "t3", "status": "in_progress", "merge_sha": None},
+    ]
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    update_args = [c.args[3] for c in mock_call.call_args_list
+                   if c.args[2] == "task_update"]
+    assert len(update_args) == 1
+    assert update_args[0] == {"id": "t3", "merge_sha": "abc123"}
+
+
+def test_no_git_head_skips_silently(tmp_path):
+    """Issue #49 robustness: no git repo → exit cleanly, no MCP writes."""
+    mod = _load_hook()
+    with patch.object(mod, "_git_head", return_value=None), \
+         patch.object(mod, "_mcp_call") as mock_call:
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    assert mock_call.call_count == 0
+
+
+def test_unreachable_mcp_skips_silently(tmp_path):
+    """Issue #49 robustness: MCP server down → exit cleanly, no error
+    propagation."""
+    mod = _load_hook()
+    with patch.object(mod, "_git_head", return_value="abc123"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen", side_effect=OSError("boom")):
+        # Should not raise.
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    assert mock_call.call_count == 0
+
+
+def test_multiple_in_progress_tasks_all_tagged(tmp_path):
+    """Issue #49: each in_progress task is independently tagged. No
+    'pick the active one' heuristic — if you have N in_progress tasks
+    you're tracking N concurrent workstreams and want them all scored."""
+    mod = _load_hook()
+    tasks = [
+        {"id": "a", "status": "in_progress", "merge_sha": None},
+        {"id": "b", "status": "in_progress", "merge_sha": None},
+        {"id": "c", "status": "in_progress", "merge_sha": "old"},
+    ]
+    with patch.object(mod, "_git_head", return_value="HEADSHA"), \
+         patch.object(mod, "_mcp_call") as mock_call, \
+         patch("urllib.request.urlopen") as mock_urlopen:
+        ctx = MagicMock()
+        ctx.__enter__.return_value.read.return_value = (
+            _mock_task_list_response(tasks)
+        )
+        mock_urlopen.return_value = ctx
+        mod._tag_active_tasks_with_head("http://x", "p", tmp_path)
+    update_calls = [c.args[3] for c in mock_call.call_args_list
+                    if c.args[2] == "task_update"]
+    enqueue_calls = [c.args[3] for c in mock_call.call_args_list
+                     if c.args[2] == "janitor_enqueue"]
+    assert {u["id"] for u in update_calls} == {"a", "b"}
+    assert {e["task_id"] for e in enqueue_calls} == {"a", "b"}


### PR DESCRIPTION
## Why

Issue #36 fixed the original Linux breakage by swapping `python` → `python3` in every hook command emitted by `_install_manifest`. That works on every modern Linux distro and macOS, but silently broke every Windows host: the python.org Windows installer creates `python.exe` and `py.exe`, but **not** `python3.exe`. Windows users get the same `'python3' is not recognized` failure that #36 originally fixed on Linux — drift-sync, edit-learn, idle-rebuild, stop-record, subagent-record all die at the shell.

## What

Pick the launcher per host:

- **POSIX (Linux, macOS)** → `python3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/<name>.py` (PEP 394).
- **Windows** → `py -3 ${CLAUDE_PROJECT_DIR}/.claude/hooks/<name>.py` (PEP 397 launcher, ships with every python.org installer, on PATH by default, reads the `#!/usr/bin/env python3` shebang our hooks already carry).

Both `prism_install` and `project_onboard` accept an optional `host_platform` parameter — `sys.platform` value (`linux` / `darwin` / `win32`) or alias (`windows` / `macos` / `posix`). The MCP service runs in Linux containers and can't detect the host OS, so the calling agent passes its own `sys.platform`. Default is POSIX (back-compat with v4.6.0 Linux behavior).

## Why these are 2026 best practices

- **PEP 394** (Python on Linux): `python3` is the canonical Python 3 entry point. Modern distros (Ubuntu 20.04+, Debian 11+, Fedora, Arch) drop `/usr/bin/python` entirely.
- **PEP 397** (Windows launcher): `py.exe` is the official cross-version Python launcher on Windows. `py -3` selects Python 3 deterministically and respects shebang lines, so a script with `#!/usr/bin/env python3` runs the right interpreter even on machines with multiple Pythons installed. It's the only invocation that's reliably available across every supported Windows Python install.
- **No reliance on `python.exe`**: bare `python` is ambiguous on Windows (could be Python 2 if installed) and absent on modern Linux. Never emitted on either platform.

## Test plan

- [x] Existing POSIX assertion (`python3 ` count ≥ 7) still passes on the default code path.
- [x] New `test_install_settings_uses_py_launcher_on_windows` asserts every hook prefixed with `py -3 ` and zero `python3 ` when `host_platform="win32"`.
- [x] New `test_install_settings_never_emits_bare_python` runs across `None`, `linux`, `darwin`, `win32`, `windows`, `posix` — bare `python ` (with trailing space) must never appear.
- [x] New `test_install_manifest_accepts_platform_aliases` covers every accepted alias.
- [x] `pytest tests/unit/test_install_manifest.py` — 15/15 passing locally on Windows + Python 3.12.6.