### PR TITLE
fix(mcp): close TCP socket after each response (closes #64)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "prism": {
       "type": "http",
-      "url": "http://localhost:7777/mcp/?project=prism"
+      "url": "http://127.0.0.1:7777/mcp/?project=prism"
     }
   }
 }

--- a/services/prism-service/SETUP.md
+++ b/services/prism-service/SETUP.md
@@ -20,13 +20,15 @@ In your project root, create `.mcp.json`:
   "mcpServers": {
     "prism": {
       "type": "url",
-      "url": "http://localhost:7777/mcp?project=my-project-slug"
+      "url": "http://127.0.0.1:7777/mcp?project=my-project-slug"
     }
   }
 }
 ```
 
 Replace `my-project-slug` with a short name for your project (e.g. `talentsync`, `my-api`). Each project gets its own isolated brain, tasks, memory, and workflow — nothing bleeds between projects.
+
+> **Use `127.0.0.1`, not `localhost`.** On Windows, `localhost` resolves to `::1` first, where `wslrelay.exe` listens to proxy WSL2 traffic and intercepts MCP traffic before Docker's `0.0.0.0:7777` binding can handle it. Forcing IPv4 with `127.0.0.1` bypasses the relay. (Issue #64.)
 
 ## 3. Onboard your project
 
@@ -136,9 +138,41 @@ docker compose logs
 
 **MCP not connecting?**
 ```bash
-curl -X POST http://localhost:7777/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+curl -X POST http://127.0.0.1:7777/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
 # Should return a JSON-RPC response with server capabilities
 ```
+
+**MCP not connecting on Windows after `docker restart`?**
+On Windows + Docker Desktop, `docker restart` does NOT reinitialize
+Docker Desktop's port proxy (`com.docker.backend`) — TCP connects but
+HTTP responses never come back. Use `stop` + `start` instead:
+```bash
+docker stop prism-service-prism-service-1 && docker start prism-service-prism-service-1
+```
+Symptom check: container logs show no `172.x.x.x:* GET /mcp/` entries
+after the restart, and `Test-NetConnection 127.0.0.1:7777` reports
+`True` while `curl` hangs or returns no response. (Issue #64.)
+
+**MCP server stops responding after many sessions?**
+If the server has been running a long time and starts refusing
+HTTP requests (TCP still accepts), check for CLOSE_WAIT socket
+exhaustion inside the container:
+```bash
+docker exec prism-service-prism-service-1 python3 -c "
+data = open('/proc/net/tcp').readlines()[1:]
+states = {}
+for line in data:
+    parts = line.split()
+    if len(parts) > 3:
+        states[parts[3]] = states.get(parts[3], 0) + 1
+print({'01': 'ESTABLISHED', '08': 'CLOSE_WAIT', '0A': 'LISTEN'})
+print(states)
+"
+```
+Healthy: CLOSE_WAIT count stays in single digits across many
+sessions. The fix in #64 (`Connection: close` on every MCP response)
+should keep this near zero — if you see it growing again, file a
+new issue.
 
 **Brain search returns 0 results?**
 The project hasn't been onboarded yet. Tell Claude to onboard it.

--- a/services/prism-service/app/mcp/server.py
+++ b/services/prism-service/app/mcp/server.py
@@ -92,8 +92,32 @@ async def handle_mcp(scope, receive, send):
         tool_profile=tool_profile,
     )
 
+    # Force `Connection: close` on every MCP response so uvicorn closes
+    # the TCP socket and sends FIN immediately after the response body
+    # — instead of holding the socket in keep-alive and stranding it in
+    # CLOSE_WAIT when the (short-lived hook) client closes its side
+    # first. See issue #64: stateless StreamableHTTP doesn't reuse
+    # connections anyway, and ~3-5 requests per session-start hook
+    # otherwise leak a socket apiece.
     with use_request_context(request_ctx):
-        await session_manager.handle_request(scope, receive, send)
+        await session_manager.handle_request(
+            scope, receive, _wrap_send_with_close(send)
+        )
+
+
+def _wrap_send_with_close(send):
+    """Return an ASGI ``send`` wrapper that injects ``Connection: close``
+    on every ``http.response.start`` message. See issue #64."""
+    async def _send(message):
+        if message.get("type") == "http.response.start":
+            headers = [
+                (k, v) for k, v in (message.get("headers") or [])
+                if k.lower() != b"connection"
+            ]
+            headers.append((b"connection", b"close"))
+            message = {**message, "headers": headers}
+        await send(message)
+    return _send
 
 
 @contextlib.asynccontextmanager

--- a/services/prism-service/tests/unit/test_mcp_connection_close.py
+++ b/services/prism-service/tests/unit/test_mcp_connection_close.py
@@ -1,0 +1,91 @@
+"""Issue #64 — verify every MCP response carries `Connection: close`.
+
+The MCP server wraps the ASGI ``send`` callable in
+``_wrap_send_with_close`` so uvicorn closes the TCP socket
+(and sends FIN) immediately after each response body. Without
+this wrapper, stateless StreamableHTTP responses sat in
+keep-alive and accumulated CLOSE_WAIT sockets on the server
+side once the hook clients closed first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.mcp.server import _wrap_send_with_close
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_response_start_gets_connection_close_header():
+    captured: list[dict] = []
+
+    async def fake_send(message: dict) -> None:
+        captured.append(message)
+
+    wrapped = _wrap_send_with_close(fake_send)
+
+    async def drive() -> None:
+        await wrapped({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json")],
+        })
+        await wrapped({"type": "http.response.body", "body": b"{}"})
+
+    _run(drive())
+
+    assert len(captured) == 2
+    start = captured[0]
+    assert start["type"] == "http.response.start"
+    headers = dict(start["headers"])
+    assert headers.get(b"connection") == b"close"
+    assert headers.get(b"content-type") == b"application/json"
+    assert captured[1] == {"type": "http.response.body", "body": b"{}"}
+
+
+def test_existing_connection_header_is_replaced():
+    captured: list[dict] = []
+
+    async def fake_send(message: dict) -> None:
+        captured.append(message)
+
+    wrapped = _wrap_send_with_close(fake_send)
+
+    async def drive() -> None:
+        await wrapped({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"connection", b"keep-alive"),
+            ],
+        })
+
+    _run(drive())
+
+    headers = captured[0]["headers"]
+    connection_values = [v for k, v in headers if k.lower() == b"connection"]
+    assert connection_values == [b"close"]
+
+
+def test_non_response_start_messages_pass_through():
+    captured: list[dict] = []
+
+    async def fake_send(message: dict) -> None:
+        captured.append(message)
+
+    wrapped = _wrap_send_with_close(fake_send)
+
+    async def drive() -> None:
+        await wrapped({"type": "http.disconnect"})
+        await wrapped({"type": "http.response.body", "body": b"x"})
+
+    _run(drive())
+
+    assert captured == [
+        {"type": "http.disconnect"},
+        {"type": "http.response.body", "body": b"x"},
+    ]


### PR DESCRIPTION
## Summary

- Wrap the MCP server's raw ASGI `send` to inject `Connection: close` on every response, so uvicorn closes the TCP socket and sends FIN immediately. Eliminates the CLOSE_WAIT pile-up that was making the server unreachable after ~10–20 sessions (see #64).
- `.mcp.json` and `SETUP.md` now use `127.0.0.1` instead of `localhost` to bypass `wslrelay.exe` interception on Windows (`::1` resolution path).
- `SETUP.md` troubleshooting documents `docker stop && docker start` (not `docker restart`) on Windows, plus a CLOSE_WAIT diagnostic command for spotting regressions.

## Verification

Rebuilt container, then:

- 30 `initialize` POSTs against `http://127.0.0.1:7777/mcp/?project=prism` → **0 CLOSE_WAIT**, 34 TIME_WAIT (server-actively-closed; the healthy state). Pre-fix #64 reported 126 CLOSE_WAIT after comparable load.
- `curl -i` confirms `connection: close` on the response.
- New `tests/unit/test_mcp_connection_close.py` covers the wrapper: header is injected, replaces an existing `keep-alive`, non-`http.response.start` messages pass through.

## Out of scope (deferred follow-up)

- #64 recommendation 4 (CLOSE_WAIT health-check telemetry / auto-restart). Defensive only; the primary leak is fixed by `Connection: close`. Worth a follow-up if regressions appear.

## Test plan

- [ ] Rebuild container: `docker compose -f services/prism-service/docker-compose.yml up -d --build`
- [ ] Verify header on wire: `curl -i -X POST http://127.0.0.1:7777/mcp/?project=prism -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}'` → expect `connection: close` header
- [ ] Run unit test: `pytest services/prism-service/tests/unit/test_mcp_connection_close.py -v`
- [ ] Smoke test CLOSE_WAIT does not grow:
  ```bash
  for i in $(seq 1 30); do curl -s -o /dev/null -X POST http://127.0.0.1:7777/mcp/?project=prism -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":'$i',"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}'; done
  docker exec prism-service-prism-service-1 python3 -c "data = open('/proc/net/tcp').readlines()[1:]; states = {}; [states.__setitem__(p[3], states.get(p[3], 0) + 1) for p in (l.split() for l in data) if len(p) > 3]; print(states)"
  ```
  Expect CLOSE_WAIT (`'08'`) absent or 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)