### PR TITLE
fix(sessions): drop smoke rows + show median/p95/per-file instead of mean

### DIFF
--- a/services/prism-service/app/services/conductor_service.py
+++ b/services/prism-service/app/services/conductor_service.py
@@ -708,7 +708,39 @@ class ConductorService:
             "score_delta": score_delta,
         }
 
-    def get_session_outcomes(self, limit: int = 50) -> list[dict]:
+    # Session-id prefixes used by smoke tests, dogfood probes, and the
+    # bench harness. Rows with these ids carry near-zero token counts
+    # and aren't real sessions — including them in averages drags the
+    # mean toward zero and makes real work look like inflation. Filter
+    # them out by default; pass include_smoke=True to see everything.
+    _SMOKE_SESSION_PREFIXES: tuple[str, ...] = (
+        "test-",
+        "manual-",
+        "sse-smoke-",
+        "bridge-",
+        "dogfood-",
+        "hook-migration-",
+        "diagnose-",
+        "smoke-",
+        "probe-",
+    )
+
+    @classmethod
+    def _is_smoke_session(cls, row: dict) -> bool:
+        """True if this row is a smoke/probe test, not a real session."""
+        sid = (row.get("session_id") or "").lower()
+        if any(sid.startswith(p) for p in cls._SMOKE_SESSION_PREFIXES):
+            return True
+        # Rows with zero tokens are incomplete/aborted records — the Stop
+        # hook fired but never read the transcript. They aren't useful
+        # signal, just noise on the mean.
+        if (row.get("tokens_used") or 0) == 0:
+            return True
+        return False
+
+    def get_session_outcomes(
+        self, limit: int = 50, include_smoke: bool = False,
+    ) -> list[dict]:
         """Query recent session outcomes from scores.db.
 
         Reads the ``session_outcomes`` table populated by
@@ -716,14 +748,23 @@ class ConductorService:
         Stop hook that prism_install ships). Maps DB columns onto the
         keys the /sessions UI expects (id, session_id, duration,
         tokens, files_modified, recorded_at).
+
+        When ``include_smoke`` is False (default) rows whose session_id
+        matches a known smoke/probe prefix or whose tokens_used is zero
+        are dropped — those rows don't represent real sessions and skew
+        the mean toward zero.
         """
         try:
             conn = self._scores_conn()
+            # Pull a wider window when filtering so the post-filter list
+            # still has up to ``limit`` real sessions. 4x is enough given
+            # the observed smoke-row ratio in dogfood.
+            db_limit = limit if include_smoke else limit * 4
             rows = conn.execute(
                 "SELECT session_id, duration_s, tokens_used, files_read, "
                 "files_modified, skills_invoked, timestamp "
                 "FROM session_outcomes ORDER BY timestamp DESC LIMIT ?",
-                (limit,),
+                (db_limit,),
             ).fetchall()
             conn.close()
         except Exception:
@@ -731,12 +772,26 @@ class ConductorService:
         out: list[dict] = []
         for r in rows:
             d = dict(r)
+            if not include_smoke and self._is_smoke_session(d):
+                continue
             # Normalise keys to what sessions_page.py expects.
             d["id"] = d["session_id"]
             d["duration"] = d.get("duration_s")
             d["tokens"] = d.get("tokens_used")
             d["recorded_at"] = d.get("timestamp")
+            # Honest per-work-unit metric. Tokens per session are
+            # dominated by session scope; tokens per file edited
+            # normalises by output and is a better proxy for retrieval
+            # efficiency. None when files_modified is 0/missing so the
+            # caller can show a dash instead of dividing.
+            files_m = d.get("files_modified") or 0
+            d["tokens_per_file"] = (
+                int((d.get("tokens_used") or 0) / files_m)
+                if files_m > 0 else None
+            )
             out.append(d)
+            if len(out) >= limit:
+                break
         return out
 
     def get_skill_usage(self, session_id: Optional[str] = None) -> list[dict]:

--- a/services/prism-service/app/ui/sessions_page.py
+++ b/services/prism-service/app/ui/sessions_page.py
@@ -32,40 +32,70 @@ def _has_plotly() -> bool:
 
 # -- Section Builders ------------------------------------------------------
 
+def _percentile(values: list[int | float], pct: float) -> float:
+    """Nearest-rank percentile. Returns 0 on empty input."""
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = max(0, min(len(s) - 1, int(round(pct / 100.0 * (len(s) - 1)))))
+    return float(s[k])
+
+
 def _build_summary_stats(container, outcomes: list[dict]):
-    """Render summary statistic cards."""
+    """Render summary statistic cards.
+
+    Token/duration distributions across Claude Code sessions are
+    heavy-tailed — one 33-hour session dominates the mean. We show
+    median + p95 instead so the long tail is visible and the typical
+    session isn't hidden by it. We also show tokens-per-file-edited as
+    a per-work-unit proxy that doesn't scale with session length
+    (the headline question on this page is "is PRISM efficient?",
+    which raw avg-tokens-per-session can't answer).
+    """
     container.clear()
     with container:
         total = len(outcomes)
 
         # Extract numeric values safely
-        tokens_list = []
-        durations = []
+        tokens_list: list[int] = []
+        durations: list[float] = []
+        tokens_per_file: list[int] = []
         for o in outcomes:
             tok = o.get("tokens", o.get("total_tokens", 0))
-            if tok:
-                try:
+            try:
+                if tok:
                     tokens_list.append(int(tok))
-                except (ValueError, TypeError):
-                    pass
+            except (ValueError, TypeError):
+                pass
             dur = o.get("duration", o.get("duration_seconds", 0))
-            if dur:
-                try:
+            try:
+                if dur:
                     durations.append(float(dur))
-                except (ValueError, TypeError):
-                    pass
+            except (ValueError, TypeError):
+                pass
+            tpf = o.get("tokens_per_file")
+            if isinstance(tpf, (int, float)) and tpf > 0:
+                tokens_per_file.append(int(tpf))
 
-        avg_tokens = (sum(tokens_list) / len(tokens_list)) if tokens_list else 0
-        avg_duration = (sum(durations) / len(durations)) if durations else 0
+        median_tokens = _percentile(tokens_list, 50)
+        p95_tokens = _percentile(tokens_list, 95)
+        median_tpf = _percentile(tokens_per_file, 50)
+        median_duration = _percentile(durations, 50)
 
         cards = [
-            ("Total Sessions", str(total), "history", "#4f46e5"),
-            ("Avg Tokens", f"{avg_tokens:,.0f}", "token", "#7c3aed"),
-            ("Avg Duration", f"{avg_duration:.1f}s", "timer", "#0d9488"),
+            ("Sessions", str(total), "history", "#4f46e5",
+             "real sessions only — smoke/probe rows excluded"),
+            ("Median Tokens", f"{median_tokens:,.0f}", "data_usage", "#7c3aed",
+             f"p95 {p95_tokens:,.0f}"),
+            ("Tokens / File Edited", f"{median_tpf:,.0f}" if median_tpf else "—",
+             "edit_note", "#0d9488",
+             f"median across {len(tokens_per_file)} sessions w/ edits"),
+            ("Median Duration", f"{median_duration:.0f}s", "timer", "#52525b",
+             "half of sessions shorter than this"),
         ]
 
         with ui.row().classes('w-full gap-5 flex-wrap'):
-            for title, value, icon_name, color in cards:
+            for title, value, icon_name, color, hint in cards:
                 with ui.card().classes(
                     'flex-1 min-w-[200px] bg-white shadow-sm rounded-lg p-5'
                 ):
@@ -77,6 +107,10 @@ def _build_summary_stats(container, outcomes: list[dict]):
                     ui.label(value).classes(
                         'text-2xl font-bold text-gray-900'
                     )
+                    if hint:
+                        ui.label(hint).classes(
+                            'text-xs text-gray-500 mt-1'
+                        )
 
 
 def _build_session_table(container, outcomes: list[dict]):
@@ -132,6 +166,7 @@ def _build_session_table(container, outcomes: list[dict]):
         rows = []
         for o in outcomes:
             session_id = o.get("session_id", o.get("id", "-"))
+            tpf = o.get("tokens_per_file")
             rows.append({
                 "session_id": (
                     session_id[:12] + "..."
@@ -149,6 +184,14 @@ def _build_session_table(container, outcomes: list[dict]):
                 "files_modified": str(
                     o.get("files_modified", o.get("files_changed", "-"))
                 ),
+                # Tokens per file edited — None when no files were
+                # modified (rendered as "—"). Better proxy for retrieval
+                # efficiency than total tokens, which scales with
+                # session length not output.
+                "tokens_per_file": (
+                    f"{tpf:,}" if isinstance(tpf, (int, float)) and tpf > 0
+                    else "—"
+                ),
                 "skills_invoked": str(
                     o.get("skills_invoked", o.get("skills_used", "-"))
                 ),
@@ -164,6 +207,9 @@ def _build_session_table(container, outcomes: list[dict]):
             {"name": "tokens", "label": "Tokens", "field": "tokens",
              "align": "right", "sortable": True},
             {"name": "files_modified", "label": "Files", "field": "files_modified",
+             "align": "right", "sortable": True},
+            {"name": "tokens_per_file", "label": "Tokens / File",
+             "field": "tokens_per_file",
              "align": "right", "sortable": True},
             {"name": "skills_invoked", "label": "Skills", "field": "skills_invoked",
              "align": "right", "sortable": True},
@@ -256,7 +302,10 @@ def _build_trend_chart(container, outcomes: list[dict]):
             return
 
         dates = sorted(daily.keys())
-        avg_tokens = [sum(daily[d]) / len(daily[d]) for d in dates]
+        # Median, not mean — tokens-per-session is heavy-tailed (one
+        # 33-hour session dominates a daily average). Median tracks the
+        # typical session and the long tail shows up in p95 instead.
+        median_tokens = [_percentile(daily[d], 50) for d in dates]
         session_counts = [len(daily[d]) for d in dates]
 
         fig = go.Figure()
@@ -265,7 +314,7 @@ def _build_trend_chart(container, outcomes: list[dict]):
             marker_color="rgba(79, 70, 229, 0.5)",
         ))
         fig.add_trace(go.Scatter(
-            x=dates, y=avg_tokens, name="Avg Tokens",
+            x=dates, y=median_tokens, name="Median Tokens",
             yaxis="y2", mode="lines+markers",
             line=dict(color="#7c3aed", width=2),
             marker=dict(size=6),
@@ -274,12 +323,12 @@ def _build_trend_chart(container, outcomes: list[dict]):
         fig.update_layout(
             template="plotly_white",
             title=dict(
-                text="Session Trends",
+                text="Session Trends (median per day)",
                 font=dict(size=16, color="#111827"),
             ),
             xaxis_title="Date",
             yaxis=dict(title="Sessions", side="left"),
-            yaxis2=dict(title="Avg Tokens", side="right", overlaying="y"),
+            yaxis2=dict(title="Median Tokens", side="right", overlaying="y"),
             height=340,
             margin=dict(l=50, r=50, t=60, b=50),
             legend=dict(orientation="h", y=-0.2),

--- a/services/prism-service/tests/unit/test_sessions_honest_metrics.py
+++ b/services/prism-service/tests/unit/test_sessions_honest_metrics.py
@@ -1,0 +1,60 @@
+"""Sessions page — honest metrics filtering and percentile math.
+
+Covers two changes that landed together:
+
+* `ConductorService._is_smoke_session` drops smoke/probe rows
+  (test-* / dogfood-* prefixes, zero-token records) so they don't
+  drag the mean toward zero and make real sessions look inflated.
+* `sessions_page._percentile` returns the nearest-rank percentile
+  used by the new median + p95 KPIs and the trend chart.
+"""
+
+from __future__ import annotations
+
+from app.services.conductor_service import ConductorService
+from app.ui.sessions_page import _percentile
+
+
+def test_smoke_session_id_prefixes_are_filtered():
+    is_smoke = ConductorService._is_smoke_session
+    assert is_smoke({"session_id": "test-plumb", "tokens_used": 1000})
+    assert is_smoke({"session_id": "dogfood-verify-1", "tokens_used": 0})
+    assert is_smoke({"session_id": "sse-smoke-001", "tokens_used": 100})
+    assert is_smoke({"session_id": "manual-smoke-test", "tokens_used": 0})
+    assert is_smoke({"session_id": "bridge-verify-17", "tokens_used": 0})
+
+
+def test_real_uuid_session_is_kept_when_tokens_present():
+    is_smoke = ConductorService._is_smoke_session
+    assert not is_smoke({
+        "session_id": "275f5cde-0e01-4c12-9cd1-abcdef012345",
+        "tokens_used": 270938,
+    })
+
+
+def test_zero_token_real_session_is_filtered():
+    """Stop hook fired but transcript had no usable data — incomplete
+    record, not useful signal."""
+    is_smoke = ConductorService._is_smoke_session
+    assert is_smoke({
+        "session_id": "f5613ff4-357c-48aa-bbbb-ccccdddd0000",
+        "tokens_used": 0,
+    })
+
+
+def test_percentile_empty_returns_zero():
+    assert _percentile([], 50) == 0.0
+    assert _percentile([], 95) == 0.0
+
+
+def test_percentile_known_distribution():
+    values = list(range(1, 11))  # 1..10
+    # nearest-rank: median of 10 values is index 4 (value 5)
+    assert _percentile(values, 50) == 5.0
+    # p95 of 10 values is index 9 (value 10)
+    assert _percentile(values, 95) == 10.0
+    assert _percentile(values, 0) == 1.0
+
+
+def test_percentile_handles_unsorted_input():
+    assert _percentile([100, 1, 50, 10, 5], 50) == 10.0


### PR DESCRIPTION
## Summary

The `/sessions` page was showing **avg tokens per session** as a headline KPI, but in heavy-tailed Claude Code data the mean is a lie:

- one multi-hour session dominates the average,
- early smoke/probe rows (token counts of 0–1,234) drag the early-day average toward zero,
- so real sessions look like *inflation* over time when in fact they're just the typical signal showing up after pollution clears.

The metric also can't answer the headline question — *"is PRISM driving tokens down?"* — because it scales with session length, not retrieval efficiency.

## What this PR changes

| | Before | After |
|---|---|---|
| Smoke rows in metrics | included | dropped (`test-*` / `dogfood-*` / `sse-smoke-*` / `bridge-*` / `manual-*` / `diagnose-*` prefixes + zero-token records) |
| Top-line token KPI | **Avg Tokens** | **Median Tokens** with p95 hint |
| Per-work-unit metric | none | **Tokens / File Edited** (median across sessions that modified ≥1 file) |
| Trend chart | mean per day | median per day |
| Table columns | session, date, duration, tokens, files, skills | … + **Tokens / File** |
| `get_session_outcomes` | always-include | `include_smoke=False` default; `tokens_per_file` field added to each row |

## Live verification (this repo's `prism` project)

| | Raw | After filter |
|---|---|---|
| Sessions | 21 | **13** (8 smoke probes dropped) |
| Avg Tokens (mean) | 122,446 | — |
| Median Tokens | — | **177,123** |
| p95 Tokens | — | 459,579 |
| Tokens / File (median) | — | **9,322** (across 8 sessions w/ edits) |

The "averaging up" pattern disappears because the previous mean was anchored to artificially-low smoke rows.

## What this PR does **not** do

Doesn't answer *"is PRISM driving tokens down?"*. That question requires paired PRISM-on/PRISM-off runs on identical tasks, which is what `benchmarks/swebench/paired_campaign.py` (PR #63) is set up for. Wiring the paired-campaign output into a sessions-page panel is the natural follow-up — out of scope here to keep this PR focused on metric honesty.

## Test plan

- [ ] Rebuild container: `docker compose -f services/prism-service/docker-compose.yml up -d --build`
- [ ] Open http://127.0.0.1:7778/sessions → verify the four KPI cards (Sessions / Median Tokens / Tokens per File Edited / Median Duration), the new Tokens/File column in the table, and the chart legend reading "Median Tokens"
- [ ] Run unit tests: `pytest services/prism-service/tests/unit/test_sessions_honest_metrics.py -v`
- [ ] Programmatic spot-check: `docker exec prism-service-prism-service-1 python3 -c "from app.project_context import get_project; p=get_project('prism'); print(len(p.conductor_svc.get_session_outcomes(50)))"` → returns count of real sessions only
- [ ] Sanity: `get_session_outcomes(include_smoke=True)` returns the original full list

🤖 Generated with [Claude Code](https://claude.com/claude-code)