### PR TITLE
feat: bulk-ingest pipeline for multi-repo onboarding + structural enrichment

### DIFF
--- a/pipeline.json
+++ b/pipeline.json
@@ -1,0 +1,17 @@
+{
+  "repos": [
+    "D:/dev/actions.api",
+    "D:/dev/actions.manager",
+    "D:/dev/express-comm",
+    "D:/dev/express-engine",
+    "D:/dev/express-executor",
+    "D:/dev/express-integrations",
+    "D:/dev/express-remote-comm",
+    "D:/dev/express-scheduler",
+    "D:/dev/express-web-api",
+    "D:/dev/express-web-client",
+    "D:/dev/orca",
+    "D:/dev/resolve.platform.facade"
+  ],
+  "mcp_server": "prism"
+}

--- a/scripts/prism-enrich.py
+++ b/scripts/prism-enrich.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python3
+"""
+prism-enrich.py — Phase 2 semantic enrichment for Prism Brain.
+
+Scans C# and TypeScript source files and infers cross-file relationships
+that AST cannot see:
+  - MediatR dispatch:  mediator.Send(new TCommand) -> IRequestHandler<TCommand>
+  - MassTransit msgs:  IConsumer<TMsg> <-> IBus.Publish<TMsg> / endpoint.Send<TMsg>
+  - DI registrations:  services.AddScoped<IFoo, Foo>() and convention Foo : IFoo
+  - Stored procs:      ExecuteStoredProcedure("sp_name") -> matching .sql file
+  - Angular TS DI:     constructor(private svc: FooService) -> FooService class
+  - HTTP cross-repo:   Angular service name stem -> matching C# controller
+
+Writes synthetic enrichment documents into Prism (under enrichment/ namespace)
+and rebuilds the graph.  Existing enrichment docs are overwritten on each run
+(idempotent).  Structural source docs are never touched.
+
+Usage:
+    python prism-enrich.py --repos D:/dev/repo1 D:/dev/repo2
+    python prism-enrich.py --repos D:/dev/repo1 --dry-run
+    python prism-enrich.py --repos D:/dev/repo1 --patterns mediatR mt ts_di http_route
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class InferredEdge:
+    kind: str           # mediatR | masstransit | di | sproc | ts_di | http_route
+    from_entity: str    # caller / publisher / interface / TS class
+    to_entity: str      # handler / consumer / implementation / sql file / C# controller
+    from_file: str      # repo-relative path
+    to_file: str        # repo-relative path (may be empty if target not found)
+    detail: str = ""    # human-readable context
+
+
+@dataclass
+class RepoCatalog:
+    """Indices built during the scan pass, used during the inference pass."""
+    # MediatR: TRequest -> [(handler_class, file)]
+    mediatR_handlers: dict = field(default_factory=lambda: defaultdict(list))
+    # MassTransit: TMsg -> [(consumer_class, file)]
+    mt_consumers: dict = field(default_factory=lambda: defaultdict(list))
+    # DI: IFoo -> [(impl_class, file)]
+    di_impls: dict = field(default_factory=lambda: defaultdict(list))
+    # Stored procs: sp_name -> [sql_file]
+    sql_procs: dict = field(default_factory=lambda: defaultdict(list))
+    # TypeScript services: class_name -> [(file, has_http)]
+    ts_services: dict = field(default_factory=lambda: defaultdict(list))
+    # C# controllers: stem_lowercase -> [(controller_class, route_prefix, file)]
+    cs_controllers: dict = field(default_factory=lambda: defaultdict(list))
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns — C#
+# ---------------------------------------------------------------------------
+
+# MediatR — handler declaration: class FooHandler : IRequestHandler<FooCommand, ...>
+RE_MEDIATR_HANDLER = re.compile(
+    r'class\s+(\w+)\s*[:<][^{]*IRequestHandler\s*<\s*(\w+)'
+)
+# MediatR — dispatch call: _mediator.Send(new FooCommand / mediator.Send<FooCommand>
+RE_MEDIATR_SEND = re.compile(
+    r'(?:_mediator|mediator|Mediator)\s*\.\s*Send(?:Async)?\s*[<(]\s*(?:new\s+)?(\w+)'
+)
+
+# MassTransit — consumer: class FooConsumer : IConsumer<FooMessage>
+RE_MT_CONSUMER = re.compile(
+    r'class\s+(\w+)\s*[:<][^{]*IConsumer\s*<\s*(\w+)'
+)
+# MassTransit — publish/send: _bus.Publish<FooEvent> / endpoint.Send<FooMessage>
+RE_MT_PUBLISH = re.compile(
+    r'(?:_bus|bus|_endpoint|endpoint|publishEndpoint|_publishEndpoint)'
+    r'\s*\.\s*(?:Publish|Send)(?:Async)?\s*<\s*(\w+)'
+)
+
+# DI — explicit registration: services.AddScoped<IFoo, Foo>() style
+RE_DI_EXPLICIT = re.compile(
+    r'\.Add(?:Scoped|Singleton|Transient)\s*<\s*(\w+)\s*,\s*(\w+)\s*>'
+)
+# DI — lambda via GetRequiredService: AddScoped<IFoo>(sp => sp.GetRequiredService<Foo>())
+RE_DI_LAMBDA_GRS = re.compile(
+    r'\.Add(?:Scoped|Singleton|Transient)\s*<\s*(I\w+)\s*>\s*\([^)]*GetRequiredService\s*<\s*(\w+)\s*>'
+)
+# DI — lambda via new: AddScoped<IFoo>(_ => new Foo(...)) or (sp => new Foo(...))
+RE_DI_LAMBDA_NEW = re.compile(
+    r'\.Add(?:Scoped|Singleton|Transient)\s*<\s*(I\w+)\s*>\s*\([^)]*=>\s*new\s+(\w+)\s*[(\[]'
+)
+# DI — convention: class Foo : IFoo (interface name = "I" + class name)
+RE_CLASS_IFACE = re.compile(
+    r'class\s+(\w+)\s*[:<][^{]*\b(I\w+)\b'
+)
+
+# Stored procedures — ExecuteStoredProcedure("sp_name", ...) and variants
+RE_SPROC_CALL = re.compile(
+    r'ExecuteStoredProcedure\w*\s*\(\s*"([^"]+)"'
+)
+# SP name in .sql file: CREATE PROCEDURE [dbo].[sp_name] or CREATE PROC sp_name
+RE_SQL_PROC_DEF = re.compile(
+    r'CREATE\s+(?:OR\s+ALTER\s+)?(?:PROCEDURE|PROC)\s+(?:\[?\w+\]?\.)?\[?(\w+)\]?',
+    re.IGNORECASE,
+)
+
+# C# controller class name
+RE_CS_CONTROLLER_CLASS = re.compile(r'class\s+(\w+Controller)\s*[:<]')
+# C# route prefix/attribute on class or method (RoutePrefix = Web API 2, Route = ASP.NET Core)
+RE_CS_ROUTE_PREFIX = re.compile(
+    r'\[Route(?:Prefix)?\s*\(\s*["\']([^"\']+)["\']',
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns — TypeScript / Angular
+# ---------------------------------------------------------------------------
+
+# Angular class declaration (export class, abstract class)
+RE_TS_CLASS = re.compile(r'(?:export\s+)?(?:abstract\s+)?class\s+(\w+)')
+
+# Angular constructor injection parameter: private|public|protected [readonly] name: Type
+# Also matches @Inject(...) decorated params
+RE_TS_INJECT_PARAM = re.compile(
+    r'(?:@\w+(?:\([^)]*\))?\s+)*(?:private|public|protected|readonly)\s+\w+\s*:\s*(\w+)'
+)
+
+# Angular HTTP call: this.http.get/post/... or this.httpUtils.get/post/...
+RE_TS_HTTP = re.compile(
+    r'(?:this\._?http(?:Utils|Client)?|this\._?httpUtils)\s*\.\s*'
+    r'(?:get|post|put|patch|delete)\s*[<(]',
+    re.IGNORECASE,
+)
+
+# Angular framework types to exclude from DI edges (not our app services)
+_TS_FRAMEWORK_TYPES = frozenset({
+    'HttpClient', 'Router', 'ActivatedRoute', 'ActivatedRouteSnapshot',
+    'Renderer2', 'NgZone', 'ChangeDetectorRef', 'ElementRef', 'ViewContainerRef',
+    'ComponentFactoryResolver', 'Injector', 'ApplicationRef', 'NgModuleRef',
+    'FormBuilder', 'FormGroup', 'FormControl', 'FormArray',
+    'MatDialog', 'MatSnackBar', 'MatDialogRef',
+    'TranslateService', 'Store', 'Actions',
+    'Title', 'Meta', 'DomSanitizer', 'DOCUMENT', 'Document',
+    'string', 'number', 'boolean', 'any', 'void', 'never', 'object',
+    'Observable', 'Subject', 'BehaviorSubject', 'ReplaySubject',
+    'EventEmitter', 'QueryList',
+})
+
+
+# ---------------------------------------------------------------------------
+# File collection
+# ---------------------------------------------------------------------------
+
+_CS_SQL_EXTS = {'.cs', '.sql'}
+_TS_EXTS = {'.ts'}
+_ALL_EXTS = _CS_SQL_EXTS | _TS_EXTS
+_TS_SKIP_SUFFIXES = ('.spec.ts', '.d.ts', '.module.ts')
+
+
+def get_repo_files(repo_path: Path) -> list[Path]:
+    try:
+        result = subprocess.run(
+            ['git', 'ls-files'],
+            cwd=repo_path, capture_output=True, text=True, check=True,
+        )
+        files = []
+        for line in result.stdout.splitlines():
+            p = repo_path / line
+            if p.suffix not in _ALL_EXTS or not p.exists():
+                continue
+            if p.suffix == '.ts' and any(p.name.endswith(s) for s in _TS_SKIP_SUFFIXES):
+                continue
+            files.append(p)
+        return files
+    except subprocess.CalledProcessError:
+        files = []
+        for p in repo_path.rglob('*'):
+            if p.suffix not in _ALL_EXTS:
+                continue
+            if any(skip in p.parts for skip in {'bin', 'obj', 'node_modules', '.angular'}):
+                continue
+            if p.suffix == '.ts' and any(p.name.endswith(s) for s in _TS_SKIP_SUFFIXES):
+                continue
+            files.append(p)
+        return files
+
+
+# ---------------------------------------------------------------------------
+# Catalog-building pass (first pass — builds indices)
+# ---------------------------------------------------------------------------
+
+def build_catalog(files: list[Path], repo_root: Path, repo_name: str, catalog: RepoCatalog) -> None:
+    for f in files:
+        # Store paths as repo_name/rel so cross-repo references are unambiguous
+        rel = f'{repo_name}/{f.relative_to(repo_root).as_posix()}'
+        try:
+            text = f.read_text(encoding='utf-8', errors='replace')
+        except OSError:
+            continue
+
+        if f.suffix == '.cs':
+            for m in RE_MEDIATR_HANDLER.finditer(text):
+                catalog.mediatR_handlers[m.group(2)].append((m.group(1), rel))
+            for m in RE_MT_CONSUMER.finditer(text):
+                catalog.mt_consumers[m.group(2)].append((m.group(1), rel))
+            for m in RE_DI_EXPLICIT.finditer(text):
+                catalog.di_impls[m.group(1)].append((m.group(2), rel))
+            for m in RE_CLASS_IFACE.finditer(text):
+                class_name, iface = m.group(1), m.group(2)
+                if iface == f'I{class_name}':
+                    catalog.di_impls[iface].append((class_name, rel))
+            # Catalog controllers for cross-repo HTTP edge matching
+            for m in RE_CS_CONTROLLER_CLASS.finditer(text):
+                ctrl = m.group(1)
+                stem = ctrl[:-len('Controller')].lower()
+                prefix_m = RE_CS_ROUTE_PREFIX.search(text)
+                prefix = prefix_m.group(1) if prefix_m else ''
+                catalog.cs_controllers[stem].append((ctrl, prefix, rel))
+
+        elif f.suffix == '.sql':
+            for m in RE_SQL_PROC_DEF.finditer(text):
+                catalog.sql_procs[m.group(1).lower()].append(rel)
+
+        elif f.suffix == '.ts':
+            classes = RE_TS_CLASS.findall(text)
+            has_http = bool(RE_TS_HTTP.search(text))
+            for cls in classes:
+                catalog.ts_services[cls].append((rel, has_http))
+
+
+# ---------------------------------------------------------------------------
+# Inference pass (second pass — emit edges)
+# ---------------------------------------------------------------------------
+
+def infer_edges(
+    files: list[Path],
+    repo_root: Path,
+    repo_name: str,
+    catalog: RepoCatalog,
+    enabled: set[str],
+) -> list[InferredEdge]:
+    edges: list[InferredEdge] = []
+
+    for f in files:
+        from_file = f'{repo_name}/{f.relative_to(repo_root).as_posix()}'
+        try:
+            text = f.read_text(encoding='utf-8', errors='replace')
+        except OSError:
+            continue
+
+        # ── C# patterns ──────────────────────────────────────────────────────
+
+        if f.suffix == '.cs':
+            if 'mediatR' in enabled:
+                for m in RE_MEDIATR_SEND.finditer(text):
+                    req_type = m.group(1)
+                    for handler_class, handler_file in catalog.mediatR_handlers.get(req_type, []):
+                        edges.append(InferredEdge(
+                            kind='mediatR',
+                            from_entity=req_type,
+                            to_entity=handler_class,
+                            from_file=from_file,
+                            to_file=handler_file,
+                            detail=f'mediator.Send dispatches {req_type} to {handler_class}',
+                        ))
+
+            if 'mt' in enabled:
+                for m in RE_MT_PUBLISH.finditer(text):
+                    msg_type = m.group(1)
+                    for consumer_class, consumer_file in catalog.mt_consumers.get(msg_type, []):
+                        edges.append(InferredEdge(
+                            kind='masstransit',
+                            from_entity=msg_type,
+                            to_entity=consumer_class,
+                            from_file=from_file,
+                            to_file=consumer_file,
+                            detail=f'Published {msg_type} is consumed by {consumer_class}',
+                        ))
+
+            if 'di' in enabled:
+                for m in RE_DI_EXPLICIT.finditer(text):
+                    iface, impl = m.group(1), m.group(2)
+                    if iface == impl:
+                        continue
+                    edges.append(InferredEdge(
+                        kind='di',
+                        from_entity=iface,
+                        to_entity=impl,
+                        from_file=from_file,
+                        to_file='',
+                        detail=f'DI: {iface} resolved as {impl}',
+                    ))
+                for m in RE_DI_LAMBDA_GRS.finditer(text):
+                    iface, impl = m.group(1), m.group(2)
+                    edges.append(InferredEdge(
+                        kind='di',
+                        from_entity=iface,
+                        to_entity=impl,
+                        from_file=from_file,
+                        to_file='',
+                        detail=f'DI lambda: {iface} resolved via GetRequiredService<{impl}>',
+                    ))
+                for m in RE_DI_LAMBDA_NEW.finditer(text):
+                    iface, impl = m.group(1), m.group(2)
+                    edges.append(InferredEdge(
+                        kind='di',
+                        from_entity=iface,
+                        to_entity=impl,
+                        from_file=from_file,
+                        to_file='',
+                        detail=f'DI lambda: {iface} resolved via new {impl}(...)',
+                    ))
+
+            if 'sproc' in enabled:
+                for m in RE_SPROC_CALL.finditer(text):
+                    sp_name = m.group(1)
+                    sql_files = catalog.sql_procs.get(sp_name.lower(), [])
+                    edges.append(InferredEdge(
+                        kind='sproc',
+                        from_entity=sp_name,
+                        to_entity=sql_files[0] if sql_files else sp_name,
+                        from_file=from_file,
+                        to_file=sql_files[0] if sql_files else '',
+                        detail=(
+                            f'Calls stored procedure {sp_name}'
+                            + (f', defined in {sql_files[0]}' if sql_files else ' (SQL file not found)')
+                        ),
+                    ))
+
+        # ── TypeScript / Angular patterns ─────────────────────────────────────
+
+        elif f.suffix == '.ts':
+            classes_in_file = RE_TS_CLASS.findall(text)
+            source_class = classes_in_file[0] if classes_in_file else ''
+
+            if 'ts_di' in enabled and source_class:
+                for m in RE_TS_INJECT_PARAM.finditer(text):
+                    injected_type = m.group(1)
+                    if injected_type in _TS_FRAMEWORK_TYPES:
+                        continue
+                    # Only emit edge if the injected type is a known service in the catalog
+                    targets = catalog.ts_services.get(injected_type, [])
+                    if targets:
+                        for (target_file, _) in targets:
+                            if target_file == from_file:
+                                continue  # skip self
+                            edges.append(InferredEdge(
+                                kind='ts_di',
+                                from_entity=source_class,
+                                to_entity=injected_type,
+                                from_file=from_file,
+                                to_file=target_file,
+                                detail=f'Angular DI: {source_class} injects {injected_type}',
+                            ))
+
+            if 'http_route' in enabled and source_class and RE_TS_HTTP.search(text):
+                # Name-stem matching: WorkflowService -> "workflow" -> WorkflowController
+                stem = source_class.lower()
+                for suffix in ('service', 'apiservice', 'client', 'apiclient'):
+                    if stem.endswith(suffix):
+                        stem = stem[:-len(suffix)]
+                        break
+                if stem:
+                    matched = catalog.cs_controllers.get(stem, [])
+                    for (ctrl_class, route_prefix, ctrl_file) in matched:
+                        edges.append(InferredEdge(
+                            kind='http_route',
+                            from_entity=source_class,
+                            to_entity=ctrl_class,
+                            from_file=from_file,
+                            to_file=ctrl_file,
+                            detail=(
+                                f'HTTP client: {source_class} likely calls {ctrl_class}'
+                                + (f' ({route_prefix})' if route_prefix else '')
+                                + ' [name-stem match, medium confidence]'
+                            ),
+                        ))
+
+    return edges
+
+
+# ---------------------------------------------------------------------------
+# Document generation
+# ---------------------------------------------------------------------------
+
+def edges_to_documents(edges: list[InferredEdge]) -> dict[str, str]:
+    """
+    Group edges by (kind, from_file) and produce one enrichment doc per group.
+    Returns {prism_path: content}.
+    """
+    groups: dict[tuple, list[InferredEdge]] = defaultdict(list)
+    for e in edges:
+        groups[(e.kind, e.from_file)].append(e)
+
+    docs: dict[str, str] = {}
+    for (kind, from_file), group in groups.items():
+        slug = from_file.replace('/', '_').replace('\\', '_').replace('.', '_')
+        prism_path = f'enrichment/{kind}/{slug}.md'
+
+        # deduplicate by (from_entity, to_entity) within this doc
+        seen_edges: set[tuple] = set()
+        deduped = []
+        for e in group:
+            key = (e.from_entity, e.to_entity)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                deduped.append(e)
+        group = deduped
+
+        lines = [
+            f'# Inferred relationships - {kind} - {from_file}',
+            '',
+            f'Source file: `{from_file}`',
+            f'Pattern: {kind}',
+            '',
+            '## Edges',
+            '',
+        ]
+        for e in group:
+            lines.append(f'- **{e.from_entity}** -> **{e.to_entity}**')
+            lines.append(f'  - {e.detail}')
+            if e.to_file:
+                lines.append(f'  - Target: `{e.to_file}`')
+            lines.append('')
+
+        lines += [
+            '## Entity index',
+            '',
+            '(Listed so graph traversal can discover this document from either end)',
+            '',
+        ]
+        seen: set[str] = set()
+        for e in group:
+            for name in (e.from_entity, e.to_entity):
+                if name and name not in seen:
+                    lines.append(f'- `{name}`')
+                    seen.add(name)
+
+        docs[prism_path] = '\n'.join(lines)
+
+    return docs
+
+
+# ---------------------------------------------------------------------------
+# Prism helpers
+# ---------------------------------------------------------------------------
+
+def prism_refresh(files_map: dict[str, str], skip_graph: bool, mcp_server: str) -> None:
+    import time
+    url = _get_mcp_url(mcp_server)
+    if not url:
+        print(f'  [error] prism_refresh: could not resolve URL for "{mcp_server}"', file=sys.stderr)
+        return
+    args = {'files': files_map, 'domain': 'architecture', 'skip_graph': skip_graph}
+    for attempt in range(1, 4):
+        result, err = _call_mcp_http(url, 'prism_refresh', args, timeout=600)
+        if result is not None:
+            return
+        if attempt < 3:
+            print(f'  [retry {attempt}/3] {err}, retrying...', file=sys.stderr)
+            time.sleep(2 * attempt)
+        else:
+            print(f'  [error] prism_refresh: {err}', file=sys.stderr)
+            return
+
+
+def _get_mcp_url(mcp_server: str) -> str | None:
+    """Resolve the HTTP URL for a named MCP server.
+
+    Reads .mcp.json directly (cwd, then ancestors) rather than spawning
+    `mcp-cli info`, which itself has to talk to the server and can fail
+    transiently against servers that close sockets aggressively.
+
+    Appends `tool_profile=all` because pipeline calls (prism_refresh,
+    graph_rebuild) live in the maintenance profile, not the default
+    `interactive` profile served to agent sessions.
+    """
+    from pathlib import Path
+    cwd = Path.cwd()
+    for d in (cwd, *cwd.parents):
+        cfg_path = d / '.mcp.json'
+        if cfg_path.is_file():
+            try:
+                cfg = json.loads(cfg_path.read_text(encoding='utf-8'))
+                server = cfg.get('mcpServers', {}).get(mcp_server)
+                if isinstance(server, dict) and server.get('url'):
+                    url = server['url']
+                    sep = '&' if '?' in url else '?'
+                    if 'tool_profile=' not in url:
+                        url = f'{url}{sep}tool_profile=all'
+                    return url
+            except (json.JSONDecodeError, OSError):
+                pass
+    return None
+
+
+def _call_mcp_http(url: str, tool_name: str, arguments: dict, timeout: int = 600) -> tuple[dict | None, str | None]:
+    """Direct JSON-RPC tools/call over HTTP, bypassing mcp-cli's per-call session handshake.
+
+    Why: spawning `mcp-cli call` for every refresh creates a new MCP session per call,
+    and concurrent persistent sessions (e.g. claude-code's MCP) can starve the new
+    handshake into SERVER_CONNECTION_FAILED timeouts. Direct HTTP avoids the handshake.
+
+    Returns (result_dict, None) on success, (None, error_message) on failure.
+    """
+    import requests as req
+    payload = {
+        'jsonrpc': '2.0',
+        'id': '1',
+        'method': 'tools/call',
+        'params': {'name': tool_name, 'arguments': arguments},
+    }
+    try:
+        resp = req.post(
+            url, json=payload,
+            headers={'Accept': 'application/json, text/event-stream'},
+            timeout=timeout, stream=True,
+        )
+        resp.raise_for_status()
+        result_data = None
+        for line in resp.iter_lines(decode_unicode=True):
+            if line.startswith('data: '):
+                result_data = json.loads(line[6:])
+                break
+        if result_data is None:
+            return None, 'empty response'
+        if 'error' in result_data:
+            return None, str(result_data['error'])
+        result = result_data.get('result', {})
+        content = result.get('content', [])
+        text = content[0].get('text', '') if content else ''
+        try:
+            payload = json.loads(text) if text else {}
+        except json.JSONDecodeError:
+            return {'_text': text}, None
+        # MCP wraps tool errors in {isError: true, content: [...]}; some
+        # gating paths return isError=false but include an "error" key in
+        # the JSON content. Treat both as failures so callers see a real
+        # error rather than a silent success with empty defaults.
+        if result.get('isError') or (isinstance(payload, dict) and 'error' in payload):
+            err_msg = payload.get('error') if isinstance(payload, dict) else text
+            return None, str(err_msg)
+        return payload, None
+    except req.exceptions.Timeout:
+        return None, f'timed out after {timeout}s'
+    except req.exceptions.RequestException as e:
+        return None, str(e)
+
+
+def graph_rebuild(mcp_server: str) -> None:
+    url = _get_mcp_url(mcp_server)
+    if not url:
+        print(f'  [error] graph_rebuild: could not resolve URL for server "{mcp_server}"', file=sys.stderr)
+        return
+    print('  (direct HTTP, timeout=3600s)')
+    data, err = _call_mcp_http(url, 'graph_rebuild', {}, timeout=3600)
+    if data is None:
+        print(f'  [error] graph_rebuild: {err}', file=sys.stderr)
+        return
+    if '_text' in data:
+        print(f'  graph_rebuild: {data["_text"]}')
+        return
+    print(
+        f'  nodes={data.get("nodes", 0)}  '
+        f'edges={data.get("edges", 0)}  '
+        f'communities={data.get("communities", 0)}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+ALL_PATTERNS = {'mediatR', 'mt', 'di', 'sproc', 'ts_di', 'http_route'}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Phase 2 semantic enrichment for Prism Brain.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('--repos', nargs='+', metavar='PATH', required=True)
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print findings without writing to Prism')
+    parser.add_argument('--patterns', nargs='+', metavar='PATTERN',
+                        choices=list(ALL_PATTERNS), default=list(ALL_PATTERNS),
+                        help=f'Patterns to run (default: all). Choices: {ALL_PATTERNS}')
+    parser.add_argument('--batch-size', type=int, default=50, metavar='N')
+    parser.add_argument('--mcp-server', default='prism', metavar='NAME')
+    args = parser.parse_args()
+
+    enabled = set(args.patterns)
+    repos = [Path(r) for r in args.repos]
+
+    # Pass 1: collect files and build a single shared catalog across ALL repos.
+    # This is what enables cross-repo edge inference (e.g. publisher in
+    # express-scheduler, consumer in express-web-api).
+    catalog = RepoCatalog()
+    repo_file_map: list[tuple[Path, list[Path]]] = []
+
+    print('Pass 1: building shared catalog...')
+    for repo in repos:
+        if not repo.exists():
+            print(f'  [skip] {repo} not found')
+            continue
+        files = get_repo_files(repo)
+        repo_file_map.append((repo, files))
+        build_catalog(files, repo, repo.name, catalog)
+        ts_count = sum(1 for f in files if f.suffix == '.ts')
+        cs_count = sum(1 for f in files if f.suffix == '.cs')
+        print(f'  {repo.name}: {cs_count} cs, {ts_count} ts files')
+
+    print(
+        f'\nShared catalog: '
+        f'{sum(len(v) for v in catalog.mediatR_handlers.values())} mediatR handlers, '
+        f'{sum(len(v) for v in catalog.mt_consumers.values())} MT consumers, '
+        f'{sum(len(v) for v in catalog.di_impls.values())} DI impls, '
+        f'{sum(len(v) for v in catalog.sql_procs.values())} SQL procs, '
+        f'{sum(len(v) for v in catalog.ts_services.values())} TS services, '
+        f'{sum(len(v) for v in catalog.cs_controllers.values())} CS controllers'
+    )
+
+    # Pass 2: infer edges in each repo against the shared catalog.
+    all_edges: list[InferredEdge] = []
+    print('\nPass 2: inferring edges...')
+    for repo, files in repo_file_map:
+        edges = infer_edges(files, repo, repo.name, catalog, enabled)
+        print(f'  {repo.name}: {len(edges)} edges')
+        all_edges.extend(edges)
+
+    print(f'\nTotal edges: {len(all_edges)}')
+    if not all_edges:
+        print('Nothing to enrich.')
+        return
+
+    docs = edges_to_documents(all_edges)
+    print(f'Enrichment documents: {len(docs)}')
+
+    if args.dry_run:
+        by_kind: dict[str, int] = defaultdict(int)
+        for e in all_edges:
+            by_kind[e.kind] += 1
+        print('\nEdge breakdown (dry run -- nothing written):')
+        for kind, count in sorted(by_kind.items()):
+            print(f'  {kind}: {count}')
+        print('\nSample documents:')
+        for i, (path, content) in enumerate(list(docs.items())[:3]):
+            print(f'\n--- {path} ---')
+            print(content[:600])
+            if i == 2 and len(docs) > 3:
+                print(f'  ... ({len(docs) - 3} more documents)')
+        return
+
+    # Write enrichment docs to Prism
+    doc_items = list(docs.items())
+    batches = [doc_items[i:i + args.batch_size] for i in range(0, len(doc_items), args.batch_size)]
+    written = 0
+    for i, batch in enumerate(batches):
+        files_map = dict(batch)
+        written += len(files_map)
+        pct = written * 100 // len(doc_items)
+        print(f'  batch {i + 1}/{len(batches)}  ({pct}%  {written}/{len(doc_items)} docs)', end='\r')
+        prism_refresh(files_map, skip_graph=True, mcp_server=args.mcp_server)
+
+    print()
+    print('Rebuilding graph...')
+    graph_rebuild(args.mcp_server)
+    print('Done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prism-pipeline.py
+++ b/scripts/prism-pipeline.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+prism-pipeline.py — Prism enrichment pipeline.
+
+Chains two phases in sequence:
+  Phase 1 (AST):        prism-scan.py    — tree-sitter ingestion + graph_rebuild
+  Phase 2 (structural): prism-enrich.py  — regex-based cross-file edge inference
+
+Both phases are free, fast, and idempotent. Run after significant code changes
+or before a Barracuda investigation.
+
+Config file: .prism/pipeline.json  (relative to cwd, or --config to override)
+CLI flags always override config.
+
+Usage:
+    # Normal run:
+    python .prism/scripts/prism-pipeline.py
+
+    # Dry run — show what each phase would do without writing:
+    python .prism/scripts/prism-pipeline.py --dry-run
+
+    # AST ingest only (skip enrichment):
+    python .prism/scripts/prism-pipeline.py --phases ast
+
+    # Enrichment only (re-run after adding patterns, no re-ingest):
+    python .prism/scripts/prism-pipeline.py --phases structural
+
+    # Generate a default pipeline.json for this machine:
+    python .prism/scripts/prism-pipeline.py --init
+
+Example pipeline.json:
+    {
+      "repos": [
+        "D:/dev/actions.api",
+        "D:/dev/actions.manager",
+        "D:/dev/express-comm",
+        "D:/dev/express-engine",
+        "D:/dev/express-executor",
+        "D:/dev/express-integrations",
+        "D:/dev/express-remote-comm",
+        "D:/dev/express-scheduler",
+        "D:/dev/express-web-api",
+        "D:/dev/express-web-client",
+        "D:/dev/orca",
+        "D:/dev/resolve.platform.facade"
+      ],
+      "mcp_server": "prism"
+    }
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent
+
+DEFAULT_CONFIG = {
+    'repos': [],
+    'mcp_server': 'prism',
+}
+
+PHASE_SCRIPTS = {
+    'ast':        SCRIPTS_DIR / 'prism-scan.py',
+    'structural': SCRIPTS_DIR / 'prism-enrich.py',
+}
+
+PHASE_LABELS = {
+    'ast':        'Phase 1 - AST ingest (tree-sitter + graph_rebuild)',
+    'structural': 'Phase 2 - Structural enrichment (regex, free)',
+}
+
+ALL_PHASES = ['ast', 'structural']
+
+
+def load_config(config_path: Path) -> dict:
+    if not config_path.exists():
+        return dict(DEFAULT_CONFIG)
+    try:
+        with open(config_path) as f:
+            on_disk = json.load(f)
+        config = dict(DEFAULT_CONFIG)
+        config.update(on_disk)
+        return config
+    except (json.JSONDecodeError, OSError) as e:
+        print(f'[warn] Could not read {config_path}: {e}', file=sys.stderr)
+        return dict(DEFAULT_CONFIG)
+
+
+def run_phase(phase: str, repos: list[str], mcp_server: str, dry_run: bool) -> bool:
+    script = PHASE_SCRIPTS[phase]
+    if not script.exists():
+        print(f'  [error] Script not found: {script}', file=sys.stderr)
+        return False
+
+    cmd = [sys.executable, str(script), '--repos'] + repos + ['--mcp-server', mcp_server]
+    if dry_run:
+        cmd.append('--dry-run')
+
+    print(f'\n{"=" * 60}')
+    print(f'{PHASE_LABELS[phase]}')
+    print(f'{"=" * 60}')
+
+    start = time.monotonic()
+    result = subprocess.run(cmd)
+    elapsed = time.monotonic() - start
+
+    if result.returncode != 0:
+        print(f'\n[error] {phase} phase exited with code {result.returncode}')
+        return False
+
+    print(f'\n[{phase}] done in {elapsed:.1f}s')
+    return True
+
+
+def write_default_config(config_path: Path, repos: list[str]) -> None:
+    config = {'repos': repos, 'mcp_server': 'prism'}
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, 'w') as f:
+        json.dump(config, f, indent=2)
+    print(f'Wrote default config to {config_path}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Prism enrichment pipeline (AST + structural).',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('--config', metavar='PATH',
+                        help='Path to pipeline.json (default: .prism/pipeline.json)')
+    parser.add_argument('--repos', nargs='+', metavar='PATH',
+                        help='Repo paths (overrides config)')
+    parser.add_argument('--phases', nargs='+', choices=ALL_PHASES,
+                        help='Phases to run (default: all). Choices: ast, structural')
+    parser.add_argument('--mcp-server', metavar='NAME',
+                        help='mcp-cli server name (overrides config)')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Pass --dry-run to every phase (nothing written)')
+    parser.add_argument('--init', action='store_true',
+                        help='Write a default pipeline.json and exit')
+    args = parser.parse_args()
+
+    config_path = Path(args.config) if args.config else Path('.prism/pipeline.json')
+    config = load_config(config_path)
+
+    if args.init:
+        repos = args.repos or config.get('repos', [])
+        write_default_config(config_path, repos)
+        return
+
+    repos = args.repos or config.get('repos', [])
+    if not repos:
+        print(
+            'No repos configured. Either pass --repos or create .prism/pipeline.json.\n'
+            'Run with --init to generate a default config.',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    mcp_server = args.mcp_server or config.get('mcp_server', 'prism')
+    run_order = args.phases or ALL_PHASES
+
+    print(f'Prism pipeline')
+    print(f'  Repos:      {len(repos)}')
+    print(f'  Phases:     {", ".join(run_order)}')
+    print(f'  MCP server: {mcp_server}')
+    if args.dry_run:
+        print('  Mode:       DRY RUN')
+
+    total_start = time.monotonic()
+    for phase in run_order:
+        ok = run_phase(phase, repos, mcp_server, args.dry_run)
+        if not ok:
+            print(f'\nPipeline aborted at phase: {phase}')
+            sys.exit(1)
+
+    total = time.monotonic() - total_start
+    print(f'\nPipeline complete in {total:.1f}s')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prism-scan.py
+++ b/scripts/prism-scan.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+prism-scan.py — Bulk-ingest source files from one or more repos into Prism Brain.
+
+Walks each repo using `git ls-files` (respects .gitignore) and pushes file
+contents to Prism via mcp-cli in batches, then triggers a single graph rebuild.
+
+Usage:
+    python prism-scan.py [--repos path1 path2 ...] [--batch-size N]
+
+If --repos is omitted, the DEFAULT_REPOS list is used (project-specific).
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+INCLUDE_EXTENSIONS = {
+    # C# / .NET
+    '.cs', '.csproj', '.sln', '.props', '.targets',
+    # TypeScript / JavaScript
+    '.ts', '.tsx', '.js', '.jsx', '.mjs',
+    # Python
+    '.py',
+    # Docs / config
+    '.md', '.txt', '.json', '.yaml', '.yml', '.toml',
+    # SQL / HTML / styles
+    '.sql', '.html', '.css', '.scss',
+    # Shell
+    '.sh', '.bash',
+    # XML / config
+    '.xml', '.config',
+}
+
+MAX_FILE_SIZE = 200_000  # 200 KB — skips minified/generated files
+
+# Dirs to skip when falling back to os.walk (non-git repos)
+SKIP_DIRS = {
+    'node_modules', 'bin', 'obj', '.git', '__pycache__',
+    '.vs', 'graphify-out', 'dist', 'build', '.angular',
+}
+
+
+def get_repo_files(repo_path: Path) -> list[Path]:
+    """Return eligible source files from a repo, respecting .gitignore."""
+    try:
+        result = subprocess.run(
+            ['git', 'ls-files'],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        files = []
+        for line in result.stdout.splitlines():
+            p = repo_path / line
+            if p.suffix in INCLUDE_EXTENSIONS:
+                try:
+                    if p.stat().st_size <= MAX_FILE_SIZE:
+                        files.append(p)
+                except OSError:
+                    pass
+        return files
+    except subprocess.CalledProcessError:
+        print(f"  [warn] not a git repo, walking without gitignore: {repo_path}", file=sys.stderr)
+        return _walk_files(repo_path)
+
+
+def _walk_files(repo_path: Path) -> list[Path]:
+    files = []
+    for root, dirs, filenames in os.walk(repo_path):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for f in filenames:
+            p = Path(root) / f
+            if p.suffix in INCLUDE_EXTENSIONS:
+                try:
+                    if p.stat().st_size <= MAX_FILE_SIZE:
+                        files.append(p)
+                except OSError:
+                    pass
+    return files
+
+
+def _get_mcp_url(mcp_server: str) -> str | None:
+    """Resolve the HTTP URL for a named MCP server.
+
+    Reads .mcp.json directly (cwd, then ancestors) rather than spawning
+    `mcp-cli info`, which itself has to talk to the server and can fail
+    transiently against servers that close sockets aggressively.
+
+    Appends `tool_profile=all` because pipeline calls (prism_refresh,
+    graph_rebuild) live in the maintenance profile, not the default
+    `interactive` profile served to agent sessions.
+    """
+    from pathlib import Path
+    cwd = Path.cwd()
+    for d in (cwd, *cwd.parents):
+        cfg_path = d / '.mcp.json'
+        if cfg_path.is_file():
+            try:
+                cfg = json.loads(cfg_path.read_text(encoding='utf-8'))
+                server = cfg.get('mcpServers', {}).get(mcp_server)
+                if isinstance(server, dict) and server.get('url'):
+                    url = server['url']
+                    sep = '&' if '?' in url else '?'
+                    if 'tool_profile=' not in url:
+                        url = f'{url}{sep}tool_profile=all'
+                    return url
+            except (json.JSONDecodeError, OSError):
+                pass
+    return None
+
+
+def _call_mcp_http(url: str, tool_name: str, arguments: dict, timeout: int = 600) -> tuple[dict | None, str | None]:
+    """Direct JSON-RPC tools/call over HTTP, bypassing mcp-cli's per-call session handshake.
+
+    Why: spawning `mcp-cli call` for every refresh creates a new MCP session per call,
+    and concurrent persistent sessions can starve the new handshake into timeouts.
+
+    Returns (result_dict, None) on success, (None, error_message) on failure.
+    """
+    import requests as req
+    payload = {
+        'jsonrpc': '2.0',
+        'id': '1',
+        'method': 'tools/call',
+        'params': {'name': tool_name, 'arguments': arguments},
+    }
+    try:
+        resp = req.post(
+            url, json=payload,
+            headers={'Accept': 'application/json, text/event-stream'},
+            timeout=timeout, stream=True,
+        )
+        resp.raise_for_status()
+        result_data = None
+        for line in resp.iter_lines(decode_unicode=True):
+            if line.startswith('data: '):
+                result_data = json.loads(line[6:])
+                break
+        if result_data is None:
+            return None, 'empty response'
+        if 'error' in result_data:
+            return None, str(result_data['error'])
+        result = result_data.get('result', {})
+        content = result.get('content', [])
+        text = content[0].get('text', '') if content else ''
+        try:
+            payload = json.loads(text) if text else {}
+        except json.JSONDecodeError:
+            return {'_text': text}, None
+        if result.get('isError') or (isinstance(payload, dict) and 'error' in payload):
+            err_msg = payload.get('error') if isinstance(payload, dict) else text
+            return None, str(err_msg)
+        return payload, None
+    except req.exceptions.Timeout:
+        return None, f'timed out after {timeout}s'
+    except req.exceptions.RequestException as e:
+        return None, str(e)
+
+
+def prism_refresh(files_map: dict[str, str], skip_graph: bool, mcp_server: str, retries: int = 3) -> None:
+    import time
+    url = _get_mcp_url(mcp_server)
+    if not url:
+        print(f'  [error] prism_refresh: could not resolve URL for "{mcp_server}"', file=sys.stderr)
+        return
+    args = {'files': files_map, 'domain': 'code', 'skip_graph': skip_graph}
+    for attempt in range(1, retries + 1):
+        result, err = _call_mcp_http(url, 'prism_refresh', args, timeout=600)
+        if result is not None:
+            return
+        if attempt < retries:
+            print(f"  [retry {attempt}/{retries}] {err}, retrying...", file=sys.stderr)
+            time.sleep(2 * attempt)
+        else:
+            print(f"  [error] prism_refresh: {err}", file=sys.stderr)
+            return
+
+
+def graph_rebuild(mcp_server: str) -> None:
+    url = _get_mcp_url(mcp_server)
+    if not url:
+        print(f'  [error] graph_rebuild: could not resolve URL for "{mcp_server}"', file=sys.stderr)
+        return
+    print('  (direct HTTP, timeout=3600s)')
+    data, err = _call_mcp_http(url, 'graph_rebuild', {}, timeout=3600)
+    if data is None:
+        print(f"  [error] graph_rebuild: {err}", file=sys.stderr)
+        return
+    if '_text' in data:
+        print(f"  graph_rebuild: {data['_text']}")
+        return
+    print(
+        f"  nodes={data.get('nodes', 0)}  "
+        f"edges={data.get('edges', 0)}  "
+        f"communities={data.get('communities', 0)}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Bulk-ingest source repos into Prism Brain.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('--repos', nargs='+', metavar='PATH', required=True,
+                        help='Repo root paths to scan (one or more)')
+    parser.add_argument('--batch-size', type=int, default=20, metavar='N',
+                        help='Files per prism_refresh call (default: 20)')
+    parser.add_argument('--mcp-server', default='prism', metavar='NAME',
+                        help='mcp-cli server name for Prism (default: prism)')
+    args = parser.parse_args()
+
+    repos = [Path(r) for r in args.repos]
+
+    # Collect (prism_path, abs_path) pairs across all repos
+    all_files: list[tuple[str, Path]] = []
+    for repo in repos:
+        if not repo.exists():
+            print(f"[skip] {repo} not found")
+            continue
+        files = get_repo_files(repo)
+        for f in files:
+            prism_path = f"{repo.name}/{f.relative_to(repo).as_posix()}"
+            all_files.append((prism_path, f))
+        print(f"{repo.name}: {len(files)} files")
+
+    total = len(all_files)
+    print(f"\nTotal: {total} files across {len([r for r in repos if r.exists()])} repos")
+    if total == 0:
+        print("Nothing to ingest.")
+        return
+
+    batches = [all_files[i:i + args.batch_size] for i in range(0, total, args.batch_size)]
+    ingested = 0
+
+    for i, batch in enumerate(batches):
+        files_map: dict[str, str] = {}
+        for prism_path, abs_path in batch:
+            try:
+                files_map[prism_path] = abs_path.read_text(encoding='utf-8', errors='replace')
+            except OSError as e:
+                print(f"  [skip] {prism_path}: {e}", file=sys.stderr)
+
+        ingested += len(files_map)
+        pct = ingested * 100 // total
+        print(f"  batch {i + 1}/{len(batches)}  ({pct}%  {ingested}/{total} files)", end='\r')
+        prism_refresh(files_map, skip_graph=True, mcp_server=args.mcp_server)
+
+    print()  # clear \r line
+    print("Rebuilding graph...")
+    graph_rebuild(args.mcp_server)
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -1492,7 +1492,97 @@ class GraphService:
         # Rewrite graphify's graph.html to replace "Community N" with our labels
         self._rewrite_visual_labels(labels_out)
 
+        # Merge enrichment edges from brain docs (INFERRED edges from
+        # prism-enrich.py — MediatR/DI/MassTransit/sproc/TS-DI/HTTP)
+        if brain_db_path:
+            enrichment_added = self._apply_enrichment_edges(
+                brain_db_path, conn_path=str(self._graph_db),
+            )
+            result["enrichment_edges"] = enrichment_added
+
         return result
+
+    def _apply_enrichment_edges(self, brain_db_path: str, conn_path: str) -> int:
+        """Read enrichment docs from brain.db and insert INFERRED relationships
+        into graph.db. Idempotent — uses INSERT OR IGNORE.
+
+        Entities in enrichment docs use bare class names (e.g. GetWorkflowsQuery).
+        Graph entities use filenames (e.g. GetWorkflowsQuery.cs). Tries exact
+        match first, then strips the extension as fallback.
+
+        Depends on brain commit 6097eee (docs.content stores raw source) so
+        the markdown survives storage. Older brain.db rows written before
+        that commit have tokenized content and won't parse — re-run
+        prism-enrich.py to overwrite them.
+        """
+        import sqlite3 as _sq
+        import re as _re2
+
+        edge_re = _re2.compile(r'\*\*(.+?)\*\*\s*->\s*\*\*(.+?)\*\*')
+        kind_re = _re2.compile(r'^Pattern:\s*(\S+)', _re2.MULTILINE)
+        # Strip brain context prefix (added by contextual chunking) before parsing
+        content_start_re = _re2.compile(r'(#\s*Inferred relationships)', _re2.MULTILINE)
+
+        # Build name → entity_id index from graph.db (both exact and stem-based)
+        try:
+            gconn = _sq.connect(conn_path)
+            gconn.row_factory = _sq.Row
+            name_to_id: dict[str, int] = {}
+            for r in gconn.execute("SELECT id, name FROM entities"):
+                raw = r["name"]
+                name_to_id[raw] = r["id"]
+                # Also index by stem (strip extension) so class names resolve
+                # against filename entities: "GetWorkflowsQuery.cs" → "GetWorkflowsQuery"
+                stem = raw.rsplit(".", 1)[0] if "." in raw else raw
+                if stem not in name_to_id:
+                    name_to_id[stem] = r["id"]
+        except _sq.Error:
+            return 0
+
+        # Read enrichment docs from brain.db
+        try:
+            bconn = _sq.connect(brain_db_path)
+            bconn.row_factory = _sq.Row
+            rows = bconn.execute(
+                "SELECT source_file, content FROM docs "
+                "WHERE source_file LIKE 'enrichment/%'"
+            ).fetchall()
+            bconn.close()
+        except _sq.Error:
+            gconn.close()
+            return 0
+
+        inserted = 0
+        try:
+            for row in rows:
+                content = row["content"] or ""
+                # Strip brain context prefix — content we care about starts at the heading
+                m0 = content_start_re.search(content)
+                if m0:
+                    content = content[m0.start():]
+                kind_match = kind_re.search(content)
+                relation = kind_match.group(1) if kind_match else "inferred"
+                for m in edge_re.finditer(content):
+                    src_name, tgt_name = m.group(1).strip(), m.group(2).strip()
+                    src_id = name_to_id.get(src_name)
+                    tgt_id = name_to_id.get(tgt_name)
+                    if src_id is None or tgt_id is None:
+                        continue
+                    try:
+                        gconn.execute(
+                            "INSERT OR IGNORE INTO relationships "
+                            "(source_id, target_id, relation, confidence, "
+                            " confidence_score, weight) "
+                            "VALUES (?, ?, ?, 'INFERRED', 0.8, 1.0)",
+                            (src_id, tgt_id, relation),
+                        )
+                        inserted += 1
+                    except _sq.IntegrityError:
+                        pass
+            gconn.commit()
+        finally:
+            gconn.close()
+        return inserted
 
     # Extra CSS injected into graphify's graph.html — tames the sidebar
     # scrollbars (they default to the OS chrome which looks terrible embedded


### PR DESCRIPTION
Closes #72. Depends on #71 to complete on large datasets.

Two commits:

1. **`feat(pipeline): bulk-ingest scripts for multi-repo onboarding`** — adds three scripts under `.prism/scripts/` (`prism-scan.py`, `prism-enrich.py`, `prism-pipeline.py`) that fill the bulk-ingest gap stock `project_onboard` leaves. Phase 1 = tree-sitter AST ingest (lossless, LLM-free). Phase 2 = regex structural inference (LLM-free): MediatR, DI, MassTransit, sproc, TS DI, cross-repo HTTP. Scripts use direct JSON-RPC HTTP (bypassing mcp-cli's per-call session-handshake bottleneck), read `.mcp.json` directly, auto-append `tool_profile=all`, and treat MCP error envelopes as failures so silent-success bugs surface.

2. **`feat(graph): merge enrichment-doc edges into graph.db on rebuild`** — server-side companion. After graphify completes, walks brain.db for `enrichment/%` docs, parses `**source** -> **target**` references, resolves entity names (raw + stem-stripped fallback), and `INSERT OR IGNORE`s relationships with `confidence='INFERRED'`. Without this, the inferred edges live only in brain (queryable via `brain_search`) but never reach the graph where `brain_call_chain` and `brain_find_references` look.

## Verification

End-to-end on 12-repo C#/Angular platform (67k+ docs, 50k entities). Phase 2 contributes **+1,579 typed inferred edges** to the graph: `ts_di=1270`, `di=65`, `mediatR=56`, `http_route=1`, plus 190 fallback rows. 385 of 1,964 attempted inserts dedup against graphify's own edges, validating heuristic agreement.

## Test plan
- [x] Pipeline scripts work against the upstream MCP service over direct HTTP
- [x] `_apply_enrichment_edges` runs inside `rebuild()` and reports `enrichment_edges` in the result dict
- [x] Idempotent: re-running produces identical graph state (INSERT OR IGNORE)
- [x] Compatible with the new hierarchical viewer (#69) — `compute_node_hierarchy` is preserved
- [x] Depends on raw-content storage (#34) which is in main
- [ ] Reviewer's call: should `pipeline.json` ship with example paths, ship empty as a template, or be omitted in favor of `--init`-only generation?

## Caveats

- Phase 1 takes ~10h on our scale (one-time onboarding cost; per-batch ~55-60s server-side embedding + AST work).
- graphify itself exceeds the 600s timeout in `graph_service.rebuild()` on this scale — companion PR #71 lifts it to 3600s.