### PR TITLE
fix(graph): collapse orphan-entity L0 fallback into single 'external' bucket

### DIFF
--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -241,10 +241,18 @@ def compute_node_hierarchy(
     """Return {l0, l1, l2} parent keys for a leaf's hierarchical rollup.
 
     Strips known container directories from the path, then uses the
-    first 1, 2, 3 surviving segments as the L0, L1, L2 parents. Falls
-    back to ``comm:<id>`` when the path is too shallow to produce a
-    meaningful root segment, so a flat repo without a service layout
-    still gets a usable hierarchy from Leiden community detection.
+    first 1, 2, 3 surviving segments as the L0, L1, L2 parents.
+    Path-less entities (BCL types, unresolved cross-repo references,
+    other graphify-synthetic nodes) collapse into a single ``external``
+    L0 with the community ID preserved at L1/L2, so Leiden structure
+    remains navigable on drill-down without fragmenting the L0 surface.
+
+    Why a single "external" L0 instead of per-community fallback:
+    multi-repo projects with even 1-2% orphan entities can scatter
+    those orphans across hundreds of communities, producing a long
+    tail of singleton L0 categories that bury the real repo L0s.
+    Collapsing all orphans into one L0 keeps the path-based
+    hierarchy visible.
     """
     sf = (source_file or "").replace("\\", "/").strip("/")
     parts = sf.split("/") if sf else []
@@ -253,8 +261,8 @@ def compute_node_hierarchy(
     segs = [p for p in parts if p and p.lower() not in _PATH_PREFIX_DROP]
     if not segs:
         if fallback_community is not None:
-            key = f"comm:{fallback_community}"
-            return {"l0": key, "l1": key, "l2": key}
+            l1 = f"external/comm:{fallback_community}"
+            return {"l0": "external", "l1": l1, "l2": l1}
         return {"l0": None, "l1": None, "l2": None}
     l0 = segs[0]
     l1 = "/".join(segs[:2]) if len(segs) >= 2 else l0

--- a/services/prism-service/tests/unit/test_compute_node_hierarchy.py
+++ b/services/prism-service/tests/unit/test_compute_node_hierarchy.py
@@ -1,0 +1,78 @@
+"""Tests for compute_node_hierarchy — collapse orphan entities into 'external'.
+
+Issue context: in projects with even 1-2% path-less entities (BCL types,
+unresolved cross-repo references, graphify-synthetic nodes), the prior
+per-community fallback scattered orphans across hundreds of singleton L0
+buckets, fragmenting the L0 navigation surface. The fix routes all
+path-less entities into a single 'external' L0, with the community ID
+preserved at L1/L2 for drill-down.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+from app.services.graph_service import compute_node_hierarchy  # noqa: E402
+
+
+def test_path_based_l0_uses_first_segment() -> None:
+    h = compute_node_hierarchy("actions.api/src/Foo/Bar.cs")
+    assert h["l0"] == "actions.api"
+    assert h["l1"] == "actions.api/Foo"  # 'src' stripped via _PATH_PREFIX_DROP
+    assert h["l2"] == "actions.api/Foo"
+
+
+def test_path_based_l1_l2_use_more_segments_when_available() -> None:
+    h = compute_node_hierarchy("repo/area/sub/deep/leaf.cs")
+    assert h["l0"] == "repo"
+    assert h["l1"] == "repo/area"
+    assert h["l2"] == "repo/area/sub"
+
+
+def test_orphan_with_community_collapses_to_external_l0() -> None:
+    h = compute_node_hierarchy(None, fallback_community=42)
+    assert h["l0"] == "external"
+    # Community ID preserved at L1/L2 so Leiden structure is still navigable
+    assert h["l1"] == "external/comm:42"
+    assert h["l2"] == "external/comm:42"
+
+
+def test_orphans_across_many_communities_share_one_l0() -> None:
+    # Regression for the L0-fragmentation bug: 440+ singleton L0s on
+    # multi-repo platforms because each orphan was getting its own
+    # comm:<id> bucket. With the collapse fix, every orphan lands in
+    # the same L0 regardless of its community.
+    l0s = {compute_node_hierarchy(None, fallback_community=c)["l0"]
+           for c in range(500)}
+    assert l0s == {"external"}
+
+
+def test_orphan_without_community_returns_none_keys() -> None:
+    h = compute_node_hierarchy(None, fallback_community=None)
+    assert h == {"l0": None, "l1": None, "l2": None}
+
+
+def test_empty_string_source_file_treated_as_orphan() -> None:
+    h = compute_node_hierarchy("", fallback_community=7)
+    assert h["l0"] == "external"
+
+
+def test_windows_path_separators_normalized() -> None:
+    h = compute_node_hierarchy("repo\\area\\file.cs")
+    assert h["l0"] == "repo"
+    assert h["l1"] == "repo/area"
+
+
+def test_filename_dropped_before_segmenting() -> None:
+    # Single-segment paths (just a filename) should fall back, not use
+    # the bare filename as L0.
+    h = compute_node_hierarchy("just_a_file.cs", fallback_community=99)
+    assert h["l0"] == "external"


### PR DESCRIPTION
Closes #74.

`compute_node_hierarchy` previously routed each path-less entity into a per-community L0 (`comm:<id>`). On a 12-repo platform with 51,772 entities and 1.7% orphans, this scattered them across 440 communities → 452 L0s total, 440 of which are noise (359 singletons). The 12 useful repo L0s get buried.

Fix: route all orphans into a single `external` L0 with community ID preserved at L1/L2 so drill-down still respects Leiden structure.

## Test plan
- [x] 8 new unit tests in `tests/unit/test_compute_node_hierarchy.py` covering path-based derivation, orphan collapse with/without community, multi-community-collapse-to-one, Windows path normalization, empty-string handling, bare-filename fallback. All pass.
- [x] Confirmed on the 12-repo platform: orphan count and community spread match the issue's empirical numbers.
- [x] No call sites change — `graph_page.py:1319` continues to call with `source_file`/`fallback_community` unchanged.

## Why this matters at scale

The new hierarchical viewer (`5f90dd4`) calls out 15K leaves as the design target. At that size, even with 1-2% orphans you'd see ~10-20 fallback L0s — manageable. At our scale (51K leaves, 3.4× the design target), the same percentage produces 440 fallback L0s. The fix is a tiny change but makes the difference between an unusable L0 surface and a navigable one for any project at the upper end of the design envelope or beyond.