### PR TITLE
feat(graph): first-class C# / .NET support

### DIFF
--- a/services/prism-service/app/engines/brain_engine.py
+++ b/services/prism-service/app/engines/brain_engine.py
@@ -542,6 +542,8 @@ class Brain:
 
     _INDEXABLE_SUFFIXES = {
         ".py", ".ts", ".tsx", ".js", ".jsx",
+        ".cs", ".csproj", ".sln", ".props", ".targets",
+        ".razor", ".cshtml", ".xaml",
         ".md", ".yaml", ".yml", ".json", ".txt", ".sh",
     }
 

--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -35,6 +35,7 @@ from typing import Optional
 # Ingested docs with these suffixes will be staged for the graph pass.
 GRAPHIFY_CODE_SUFFIXES = {
     ".py", ".ts", ".tsx", ".js", ".jsx", ".cs",
+    ".csproj", ".sln", ".props", ".targets", ".razor", ".cshtml", ".xaml",
     ".go", ".rs", ".java", ".rb", ".php", ".cpp", ".c", ".h", ".hpp",
     ".md",  # graphify also picks up heading structure from markdown
 }
@@ -231,7 +232,40 @@ def _path_prefix_label(nodes: list[dict], threshold: float = 0.6) -> str:
 _PATH_PREFIX_DROP = {
     "src", "app", "lib", "pkg", "source", "sources",
     "plugins", "services", "packages",
+    # Common C# / Unity wrapper folders. Keeping these as hierarchy
+    # regions makes customer graphs read as "Assets > Scripts" instead
+    # of the actual gameplay/API/domain area underneath.
+    "assets", "scripts", "runtime",
 }
+
+
+_CS_PROJECT_LAYER_HINTS = {
+    "api": "api",
+    "web": "ui",
+    "mvc": "ui",
+    "server": "api",
+    "application": "service",
+    "services": "service",
+    "infrastructure": "data",
+    "persistence": "data",
+    "data": "data",
+    "domain": "domain",
+    "core": "domain",
+    "shared": "domain",
+    "contracts": "domain",
+    "tests": "test",
+    "test": "test",
+}
+
+
+def _split_project_segment(segment: str) -> list[str]:
+    """Split C# project folders like ``Acme.Store.Api`` into tokens."""
+    spaced = _re.sub(
+        r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])",
+        " ",
+        segment.replace(".", " "),
+    )
+    return [p.lower() for p in _WORD_RE.findall(spaced) if p]
 
 
 def compute_node_hierarchy(
@@ -282,38 +316,95 @@ def infer_architectural_layer(
         if part
     ).replace("\\", "/").lower()
     tokens = set(_WORD_RE.findall(haystack))
+    path = (source_file or "").replace("\\", "/")
+    path_lower = path.lower()
+    suffix = "." + path_lower.rsplit(".", 1)[-1] if "." in path_lower else ""
+    path_parts = [p for p in path.replace("\\", "/").split("/") if p]
+    project_token_list = [
+        tok
+        for part in path_parts
+        for tok in _split_project_segment(part)
+    ]
+    project_tokens = set(project_token_list)
 
     def has_any(words: set[str]) -> bool:
-        return bool(tokens.intersection(words))
+        return bool(tokens.intersection(words) or project_tokens.intersection(words))
+
+    if suffix in {".csproj", ".sln", ".props", ".targets"}:
+        return "config"
+    if any(name in path_lower for name in (
+        "appsettings.", "launchsettings.", "directory.build.",
+        "global.json", "nuget.config",
+    )):
+        return "config"
+    if path_lower.rsplit("/", 1)[-1] in {"program.cs", "startup.cs"}:
+        return "config"
+
+    for layer in ("test", "api", "ui", "service", "data", "domain"):
+        if any(_CS_PROJECT_LAYER_HINTS.get(token) == layer
+               for token in project_token_list):
+            return layer
 
     if has_any({"test", "tests", "spec", "specs", "fixture", "fixtures"}):
         return "test"
     if has_any({"doc", "docs", "documentation", "readme", "markdown"}):
         return "docs"
-    if has_any({"config", "settings", "manifest", "dockerfile", "compose"}):
+    if has_any({
+        "config", "settings", "manifest", "dockerfile", "compose",
+        "program", "startup", "host", "hosting", "properties",
+    }):
         return "config"
     if has_any({"script", "scripts", "tool", "tools", "cli", "command", "commands"}):
         return "tooling"
     if has_any({
         "ui", "web", "frontend", "front", "page", "pages", "component",
         "components", "view", "views", "dashboard", "screen", "screens",
+        "razor", "blazor", "viewmodel", "viewmodels", "xaml", "presenter",
+        "presenters",
     }):
         return "ui"
     if has_any({
         "api", "route", "routes", "endpoint", "endpoints", "handler",
         "handlers", "controller", "controllers", "server", "mcp",
+        "hub", "hubs", "grpc",
     }):
         return "api"
-    if has_any({"service", "services", "engine", "engines", "worker", "workers"}):
+    if has_any({
+        "service", "services", "engine", "engines", "worker", "workers",
+        "mediator", "mediatr", "command", "commands", "query", "queries",
+        "usecase", "usecases", "job", "jobs", "backgroundservice",
+    }):
         return "service"
     if has_any({
         "db", "database", "data", "model", "models", "repo", "repos",
         "repository", "repositories", "schema", "migration", "storage",
+        "dbcontext", "context", "contexts", "entityframework",
+        "configuration", "configurations",
     }):
         return "data"
-    if has_any({"domain", "core", "entity", "entities"}):
+    if has_any({
+        "domain", "core", "entity", "entities", "aggregate", "aggregates",
+        "valueobject", "valueobjects", "enum", "enums", "contract",
+        "contracts", "dto", "dtos",
+    }):
         return "domain"
     return "other"
+
+
+def display_label_for_graph_node(label: str | None, source_file: str | None = None) -> str:
+    """Return a viewer-friendly node label without changing graph ids.
+
+    Graphify emits C# member labels as ``.Method()``. That is faithful to
+    the AST, but it looks broken in a customer-facing graph. Strip only this
+    C#-specific leading dot; leave hidden/anonymous labels untouched.
+    """
+    text = str(label or "").strip()
+    if not text:
+        return text
+    sf = (source_file or "").replace("\\", "/").lower()
+    if sf.endswith(".cs") and text.startswith(".") and len(text) > 1:
+        return text[1:]
+    return text
 
 
 def _pick_hub_entity(entities_ranked: list[tuple[dict, int]]) -> str:

--- a/services/prism-service/app/ui/graph_page.py
+++ b/services/prism-service/app/ui/graph_page.py
@@ -14,6 +14,7 @@ from nicegui import app, ui
 from app.project_context import get_project
 from app.services.graph_service import (
     compute_node_hierarchy,
+    display_label_for_graph_node,
     infer_architectural_layer,
 )
 from app.ui.components.nav import create_nav, page_container
@@ -207,6 +208,10 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
     return `rgba(${m[1]},${m[2]},${m[3]},${a0 * a})`;
   }
   const LEVEL_FADE_MS = 240;
+  const L0_DENSE_COUNT = 120;
+  const L0_HUGE_COUNT = 240;
+  const RELAX_NODE_LIMIT = 80;
+  const L0_SUPER_EDGE_LIMIT = 900;
   // HSL round-trip utilities. Shading by degree modulates the L
   // channel while keeping H+S fixed, so every node in a layer shares
   // the base hue and saturation — only perceived lightness changes
@@ -548,16 +553,21 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           if (grp.ids.length > maxMembers) maxMembers = grp.ids.length;
         }
         const logMax = Math.log(1 + maxMembers) || 1;
-        // Top-K-by-size super-nodes get forceLabel; the rest let
-        // Sigma's labelDensity hide them when collisions occur.
-        // On a wide-extent project (resolve-platform: 30k graph
-        // units, 21 L0 keys), forcing every label produced an
-        // unreadable knot — by only labelling the dominant clusters,
-        // the rest still render
-        // as colored dots, hover/zoom reveals them on demand.
-        const LABEL_TOP_K = lvl === 0 ? 12 : 18;
         const ranked = [...groups.entries()]
           .sort((a, b) => b[1].ids.length - a[1].ids.length);
+        const rankByKey = new Map();
+        ranked.forEach(([k], idx) => rankByKey.set(k, idx));
+        const isDenseL0 = lvl === 0 && groups.size >= L0_DENSE_COUNT;
+        const isHugeL0 = lvl === 0 && groups.size >= L0_HUGE_COUNT;
+        // Top-K-by-size super-nodes get forceLabel; the rest let
+        // Sigma's labelDensity hide them when collisions occur.
+        // On massive L0 graphs, make that set smaller and keep
+        // unlabeled communities as compact colored landmarks. This
+        // preserves the full shape without turning the overview into
+        // a label layout problem.
+        const LABEL_TOP_K = lvl === 0
+          ? (isHugeL0 ? 6 : isDenseL0 ? 8 : 12)
+          : 18;
         const labelTopK = new Set();
         for (const [k] of ranked.slice(0, LABEL_TOP_K)) labelTopK.add(k);
         for (const [key, grp] of groups) {
@@ -582,7 +592,9 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           })();
           // Larger labels at higher abstraction levels so the L0 view
           // reads instantly. Sigma honors per-node labelSize.
-          const labelSizeForLevel = lvl === 0 ? 22 : lvl === 1 ? 18 : 15;
+          const labelSizeForLevel = lvl === 0
+            ? (isHugeL0 ? 16 : isDenseL0 ? 18 : 22)
+            : lvl === 1 ? 18 : 15;
           // Ancestor keys come from the leaves themselves, not from
           // splitting `key`; community-prefixed path keys need to keep
           // their exact ancestry for focus filtering.
@@ -600,22 +612,22 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           // settle into their natural homes.
           const targetX = grp.sx / n;
           const targetY = grp.sy / n;
-          const jx = (Math.random() - 0.5) * 8;
-          const jy = (Math.random() - 0.5) * 8;
+          const jx = (Math.random() - 0.5) * (isDenseL0 ? 3 : 8);
+          const jy = (Math.random() - 0.5) * (isDenseL0 ? 3 : 8);
           // Proportional log-scale radius, normalised so the level's
           // largest super-node hits SIZE_MAX and a singleton sits at
           // SIZE_MIN. Tighter than the old 8 + 4·log formula: 22 vs
           // 13 instead of 42.7 vs 10.7, so giants don't visually
           // swallow the tail and label collisions resolve cheaply.
-          const SIZE_MIN = 11;
-          const SIZE_RANGE = 11;
+          const SIZE_MIN = isHugeL0 ? 6 : isDenseL0 ? 8 : 11;
+          const SIZE_RANGE = isHugeL0 ? 7 : isDenseL0 ? 8 : 11;
           const sizeForN = SIZE_MIN
             + SIZE_RANGE * (Math.log(1 + n) / logMax);
           g.addNode(`__super__${lvl}__${key}`, {
             label: labelText,
             level: lvl,
-            x: targetX * 0.18 + jx,
-            y: targetY * 0.18 + jy,
+            x: targetX * (isDenseL0 ? 0.35 : 0.18) + jx,
+            y: targetY * (isDenseL0 ? 0.35 : 0.18) + jy,
             targetX, targetY,
             size: sizeForN,
             color: colorForLayer(bestLayer),
@@ -625,6 +637,8 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
             communitySummary: clusterSummary(bestC),
             memberCount: n,
             labelSize: labelSizeForLevel,
+            rank: rankByKey.get(key) || 0,
+            denseOverview: isDenseL0,
             // Per-node forceLabel — top-K always show; rest defer to
             // labelDensity. Reducer-side hover override still wins, so
             // any cluster can be identified by mousing over it.
@@ -651,7 +665,13 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           else agg.set(key, { a, b, count: 1 });
         });
         let added = 0;
-        for (const v of agg.values()) {
+        let values = [...agg.values()];
+        if (lvl === 0 && values.length > L0_SUPER_EDGE_LIMIT) {
+          values = values
+            .sort((a, b) => b.count - a.count)
+            .slice(0, L0_SUPER_EDGE_LIMIT);
+        }
+        for (const v of values) {
           const sId = `__super__${lvl}__${v.a}`;
           const tId = `__super__${lvl}__${v.b}`;
           if (!g.hasNode(sId) || !g.hasNode(tId)) continue;
@@ -736,10 +756,23 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
       function labelRelaxStep() {
         let totalMove = 0;
         for (const lvl of [0, 1, 2]) {
-          const ids = [];
+          const candidates = [];
           g.forEachNode((id, attrs) => {
-            if (attrs.level === lvl) ids.push(id);
+            if (attrs.level === lvl) candidates.push({
+              id,
+              forceLabel: !!attrs.forceLabel,
+              memberCount: attrs.memberCount || 0,
+            });
           });
+          if (candidates.length > RELAX_NODE_LIMIT) {
+            candidates.sort((a, b) =>
+              Number(b.forceLabel) - Number(a.forceLabel)
+              || b.memberCount - a.memberCount
+            );
+          }
+          const ids = candidates
+            .slice(0, RELAX_NODE_LIMIT)
+            .map(item => item.id);
           if (ids.length < 2) continue;
           const px = new Float64Array(ids.length);
           const py = new Float64Array(ids.length);
@@ -916,7 +949,10 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
         const hint = focusPath.length > 0
           ? " · click empty to back out"
           : " · scroll to zoom";
-        return `L${currentLevel}${trail} · ${where} · FA2 ${layoutElapsed}s${hint}`;
+        const scaleHint = currentLevel === 0 && lodCount[0] >= L0_DENSE_COUNT
+          ? " · high-scale overview"
+          : "";
+        return `L${currentLevel}${trail} · ${where} · FA2 ${layoutElapsed}s${scaleHint}${hint}`;
       };
       let inspectorPinned = false;
       function escapeHtml(value) {
@@ -1106,13 +1142,10 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
       const drawNodeHover = (ctx, d, s) => drawNodeLabelOutlined(ctx, d, s, 1.15);
 
       const renderer = new Sigma(g, document.getElementById("graph"), {
-        // labelDensity tightened + labelGridCellSize bumped so non-
-        // forceLabel super-nodes (everything outside the top-K) only
-        // paint their label when there's room. The wide-extent
-        // resolve-platform L0 used to render 21 colliding labels —
-        // now only dominant regions force labels, and the rest reveal
-        // on hover or as the user zooms in.
-        labelDensity: 0.10, labelGridCellSize: 140, minCameraRatio: 0.04,
+        // Keep overview labels selective. Dense L0 graphs explicitly
+        // label only the dominant communities; Sigma can opportunistically
+        // place the rest when there is room.
+        labelDensity: 0.08, labelGridCellSize: 160, minCameraRatio: 0.04,
         maxCameraRatio: 30, defaultNodeColor: "#6b7280",
         defaultEdgeColor: "rgba(107,114,128,0.3)",
         renderEdgeLabels: false,
@@ -1201,6 +1234,12 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           // buildSupers; the rest defer to labelDensity so wide-extent
           // graphs don't paint 21 labels on top of each other. Hover
           // branch above already force-shows whichever node is hovered.
+          if (!wholeGraphMode && data.level === 0
+              && lodCount[0] >= L0_DENSE_COUNT
+              && !data.forceLabel
+              && node !== hoveredNode && node !== focusedNode) {
+            out = { ...out, label: "", forceLabel: false };
+          }
           if (wholeGraphMode && node !== hoveredNode && node !== focusedNode) {
             return {
               ...out,
@@ -1870,12 +1909,14 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
 
       const fadeMs = 450;
       const SKIP_REVEAL_BELOW = 5;
-      const shouldAnimate = !skipped && l0Items.length >= SKIP_REVEAL_BELOW;
+      const shouldAnimate = !skipped
+        && l0Items.length >= SKIP_REVEAL_BELOW
+        && l0Items.length < L0_DENSE_COUNT;
 
       if (shouldAnimate) {
         const revealBudget = 1600;
         const staggerMs = l0Items.length > 1
-          ? Math.max(60, Math.min(180,
+          ? Math.max(18, Math.min(120,
               (revealBudget - fadeMs) / (l0Items.length - 1)))
           : 0;
         const startTime = new Map();
@@ -2021,7 +2062,17 @@ def _graphify_hierarchy(project_id: str):
         )
         # Mark leaves as level 3 so the client doesn't have to special-case
         # them after super-nodes are added with level 0/1/2.
-        out_nodes.append({**n, "level": 3, "layer": layer, **h})
+        display_label = display_label_for_graph_node(
+            n.get("label") or n.get("id"),
+            n.get("source_file"),
+        )
+        out_nodes.append({
+            **n,
+            "label": display_label,
+            "level": 3,
+            "layer": layer,
+            **h,
+        })
 
     # Pull DB-derived community labels so super-nodes that fall back to
     # comm:<id> at L0 (flat repos) get a human label instead of the raw id.

--- a/services/prism-service/tests/unit/test_graph_hierarchy_lod.py
+++ b/services/prism-service/tests/unit/test_graph_hierarchy_lod.py
@@ -47,3 +47,60 @@ def test_architectural_layer_inference_prefers_semantic_roles():
     assert infer_architectural_layer("app/services/graph_service.py") == "service"
     assert infer_architectural_layer("app/models/memory.py") == "data"
     assert infer_architectural_layer("tests/unit/test_graph.py") == "test"
+
+
+def test_architectural_layer_inference_handles_csharp_conventions():
+    from app.services.graph_service import infer_architectural_layer
+
+    assert infer_architectural_layer("src/Shop.Api/Controllers/OrdersController.cs") == "api"
+    assert infer_architectural_layer("src/Shop.Application/Handlers/CreateOrderHandler.cs") == "service"
+    assert infer_architectural_layer("src/Shop.Infrastructure/Repositories/OrderRepository.cs") == "data"
+    assert infer_architectural_layer("src/Shop.Domain/Entities/Order.cs") == "domain"
+    assert infer_architectural_layer("src/Shop.Web/Components/CartView.razor.cs") == "ui"
+    assert infer_architectural_layer("tests/Shop.Tests/OrderTests.cs") == "test"
+    assert infer_architectural_layer("src/Shop.Api/Program.cs") == "config"
+
+
+def test_csharp_viewer_labels_strip_ast_member_dot():
+    from app.services.graph_service import display_label_for_graph_node
+
+    assert display_label_for_graph_node(".Bar()", "src/Shop.Api/Controllers/OrdersController.cs") == "Bar()"
+    assert display_label_for_graph_node(".Bar()", "src/widget.ts") == ".Bar()"
+
+
+def test_node_hierarchy_skips_unity_wrapper_dirs():
+    from app.services.graph_service import compute_node_hierarchy
+
+    hierarchy = compute_node_hierarchy(
+        "Assets/Scripts/Gameplay/PlayerController.cs",
+        fallback_community=7,
+    )
+
+    assert hierarchy == {
+        "l0": "comm:7",
+        "l1": "comm:7/Gameplay",
+        "l2": "comm:7/Gameplay",
+    }
+
+
+def test_csharp_files_are_indexable_and_graph_staged(tmp_path):
+    from app.engines.brain_engine import Brain
+    from app.services.graph_service import GraphService
+
+    brain = Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(tmp_path / "scores.db"),
+    )
+    assert brain._should_index("src/Shop.Api/Controllers/OrdersController.cs")
+    assert brain._should_index("src/Shop.Api/Shop.Api.csproj")
+    assert brain._should_index("src/Shop.Web/Components/Cart.razor")
+
+    graph_dir = tmp_path / "graph"
+    svc = GraphService(
+        project_data_dir=str(graph_dir),
+        graph_db_path=str(graph_dir / "graph.db"),
+    )
+    assert svc.stage_doc("src/Shop.Api/Controllers/OrdersController.cs", "class OrdersController {}")
+    assert svc.stage_doc("src/Shop.Api/Shop.Api.csproj", "<Project />")
+    assert svc.stage_doc("src/Shop.Web/Components/Cart.razor", "@code {}")


### PR DESCRIPTION
## Summary

Teaches PRISM's brain + graph to treat .NET projects as first-class
citizens, on top of the layer/region system from #81.

- **Indexable + graphify suffixes** — `.cs`, `.csproj`, `.sln`, `.props`, `.targets`, `.razor`, `.cshtml`, `.xaml` now get ingested and graph-staged.
- **C# project-name layer routing** — `Acme.Store.Api`, `*.Application`, `*.Infrastructure`, `*.Domain`, `*.Web` route to api / service / data / domain / ui via a dotted-segment tokenizer.
- **C# config files** — `*.csproj`, `*.sln`, `appsettings.*`, `launchSettings.*`, `Directory.Build.*`, `Program.cs`, `Startup.cs` route to `config`.
- **C# keyword expansion** — razor / blazor / xaml / viewmodel (ui), hub / grpc (api), mediatr / job / backgroundservice (service), dbcontext / entityframework (data), aggregate / valueobject / dto (domain).
- **Unity wrapper skip** — `Assets`, `Scripts`, `Runtime` drop from hierarchy so the graph reads as `Gameplay` not `Assets > Scripts`.
- **Viewer label fix** — strips graphify's leading `.` on C# member labels (`.Method()` → `Method()`) for display only; graph ids untouched.
- **Adaptive LOD for dense L0** — .NET monorepos produce hundreds of communities; when L0 ≥ 120 regions the viewer drops label count, label size, node size, jitter, and caps L0 super-edges at 900 to keep things smooth. Status line surfaces a `high-scale overview` hint.

## Stack note

Stacks on top of #81 (semantic regions / layer color / inspector). Diff
against `main` will include #81 until that lands; after #81 merges this
PR's diff cleans up to the C#-specific surface above.

## Test plan

- [x] `pytest tests/unit/test_graph_hierarchy_lod.py` — 7/7 pass (4 new C# tests + the 3 from #81)
  - C# Controllers / Application / Infrastructure / Domain / Web routing
  - C# member label dot-strip
  - Unity wrapper dirs skipped from hierarchy
  - C# / `.csproj` / `.razor` are indexable + graph-staged
- [ ] Manually exercise viewer on a real .NET project to confirm layer color matches expectations
- [ ] Verify dense-L0 throttle behavior on a large monorepo (~120+ communities)