### PR TITLE
fix(graph): keep orphan-only graphs visible

### DIFF
--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -416,7 +416,7 @@ def compute_node_hierarchy(
         l2 = f"{root}/{'/'.join(segs[:2])}" if len(segs) >= 2 else l1
         return {"l0": root, "l1": l1, "l2": l2}
     if not segs:
-        return {"l0": None, "l1": None, "l2": None}
+        return {"l0": "external", "l1": "external", "l2": "external"}
     l0 = segs[0]
     l1 = "/".join(segs[:2]) if len(segs) >= 2 else l0
     l2 = "/".join(segs[:3]) if len(segs) >= 3 else l1

--- a/services/prism-service/app/ui/graph_page.py
+++ b/services/prism-service/app/ui/graph_page.py
@@ -714,6 +714,9 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
         1: buildSupers("l1", 1),
         2: buildSupers("l2", 2),
       };
+      const overviewLevel = lodCount[0] > 0 ? 0 : 3;
+      currentLevel = overviewLevel;
+      prevLevel = overviewLevel;
       buildSuperEdges("l0", 0);
       buildSuperEdges("l1", 1);
       buildSuperEdges("l2", 2);
@@ -1359,7 +1362,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
       // physics first settles (see startPhysics tick).
       camera.setState({ x: 0.5, y: 0.5, ratio: 1.0 });
       currentRatio = 1.0;
-      currentLevel = 0;
+      currentLevel = overviewLevel;
       let lodAnchorRatio = 1.0;
       let lodLockedUntil = 0;
       const LOD_ZOOM_IN_RATIO = 0.52;
@@ -1369,6 +1372,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
       // ratio=1.8 left a tiny L0 blob floating in 92% empty canvas
       // when the full graph extent (driven by L3 leaves) is huge.
       function fitCameraToLevel(targetLvl, opts = {}) {
+        if (targetLvl < 3 && lodCount[targetLvl] === 0) targetLvl = 3;
         let mnx = Infinity, mxx = -Infinity, mny = Infinity, mxy = -Infinity;
         let count = 0;
         g.forEachNode((id, attrs) => {
@@ -1440,6 +1444,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
       // (status text, legend rebuild, physics nudge), and refreshes.
       function setLevel(next, opts = {}) {
         next = Math.max(0, Math.min(3, next));
+        if (next < 3 && lodCount[next] === 0) next = 3;
         if (!opts.keepWhole) wholeGraphMode = false;
         if (next === currentLevel) return;
         prevLevel = currentLevel;
@@ -1465,8 +1470,8 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
         inspectorPinned = false;
         updateInspector(null);
         focusPath = [];
-        if (currentLevel !== 0) {
-          setLevel(0, { anchorRatio: currentRatio, lockMs: 650 });
+        if (currentLevel !== overviewLevel) {
+          setLevel(overviewLevel, { anchorRatio: currentRatio, lockMs: 650 });
         } else {
           statusEl.textContent = baseStatus();
           rebuildLegend();
@@ -1474,7 +1479,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           renderer.refresh();
           startPhysics();
         }
-        fitCameraToLevel(0, { duration: 650, lockMs: 720 });
+        fitCameraToLevel(overviewLevel, { duration: 650, lockMs: 720 });
       }
 
       function backOneLevel() {

--- a/services/prism-service/tests/unit/test_graph_hierarchy_lod.py
+++ b/services/prism-service/tests/unit/test_graph_hierarchy_lod.py
@@ -63,6 +63,18 @@ def test_node_hierarchy_treats_bcl_like_symbols_as_external():
     }
 
 
+def test_node_hierarchy_uses_external_without_source_or_community():
+    from app.services.graph_service import compute_node_hierarchy
+
+    hierarchy = compute_node_hierarchy(None, fallback_community=None)
+
+    assert hierarchy == {
+        "l0": "external",
+        "l1": "external",
+        "l2": "external",
+    }
+
+
 def test_architectural_layer_inference_prefers_semantic_roles():
     from app.services.graph_service import infer_architectural_layer
 
@@ -191,6 +203,25 @@ def test_graph_viewer_aggregates_edges_between_visual_leaves():
     assert edges[0]["aggregate_count"] == 2
     assert edges[0]["source"].startswith("type::")
     assert edges[0]["target"].startswith("file::")
+
+
+def test_graph_viewer_keeps_orphan_nodes_visible_at_l0():
+    from app.ui.graph_page import _collapse_visual_graph
+
+    raw_nodes = [
+        {
+            "id": "system_string_length",
+            "label": "Length",
+            "file_type": "property",
+        },
+    ]
+
+    nodes, _edges = _collapse_visual_graph(raw_nodes, [])
+
+    assert len(nodes) == 1
+    assert nodes[0]["l0"] == "external"
+    assert nodes[0]["l1"] == "external"
+    assert nodes[0]["l2"] == "external"
 
 
 def test_node_hierarchy_skips_unity_wrapper_dirs():


### PR DESCRIPTION
## Summary

Follow-up to #86 for the customer blank-graph report.

Root cause class: if graph leaves have no pathable `source_file` and no community metadata, the server emitted `l0/l1/l2 = null`. The viewer starts at L0, so the payload could contain real leaves but build zero overview super-nodes, making the canvas appear empty.

Fix:
- `compute_node_hierarchy(None, None)` now returns the `external` hierarchy instead of null parents.
- viewer startup uses L3 leaves as a safety fallback if L0 has no super-nodes.
- `setLevel` and camera fitting avoid empty overview levels.
- regression tests cover no-source/no-community hierarchy and orphan graph visibility.

## Validation

- `python -m pytest services\\prism-service\\tests\\unit -q` -> `234 passed, 3 warnings`
- `python -m py_compile services\\prism-service\\app\\services\\graph_service.py services\\prism-service\\app\\ui\\graph_page.py`
- `node --check` on embedded viewer module script
- local hierarchy route smoke: `200`, `nodes=2416`, `edges=6170`
- Playwright screenshot smoke of `/graph/viewer/prism`: rendered successfully, screenshot `377181` bytes
- `git diff --check` (clean; CRLF warnings only)