### PR TITLE
fix(graph): coarsen huge graph overview

### DIFF
--- a/services/prism-service/app/services/graph_service.py
+++ b/services/prism-service/app/services/graph_service.py
@@ -409,11 +409,12 @@ def compute_node_hierarchy(
 ) -> dict:
     """Return {l0, l1, l2} parent keys for a leaf's hierarchical rollup.
 
-    L0 is the graphify Leiden community when present. L1/L2 are path
-    prefixes nested under that community, so repos with repeated
-    ``src/app`` style layouts do not collapse unrelated communities
-    together as the user drills in. For graph.json files without
-    community metadata, the path-only hierarchy remains as a fallback.
+    L0/L1 are semantic file or .NET project regions, not raw graphify
+    communities. Large monorepos can produce thousands of tiny Leiden
+    communities, which makes the overview unusable if each community is
+    a top-level node. When community metadata is available, keep it at
+    the deepest rollup level so drilldown can still separate dense
+    topology without crushing the first screen.
     """
     sf = (source_file or "").replace("\\", "/").strip("/")
     parts = sf.split("/") if sf else []
@@ -423,13 +424,17 @@ def compute_node_hierarchy(
     if not segs:
         segs = [p for p in parts if p and p.lower() not in _PATH_PREFIX_DROP]
     if fallback_community is not None:
-        root = f"comm:{fallback_community}"
         if not segs:
-            l1 = f"external/{root}"
+            l1 = f"external/comm:{fallback_community}"
             return {"l0": "external", "l1": l1, "l2": l1}
-        l1 = f"{root}/{segs[0]}"
-        l2 = f"{root}/{'/'.join(segs[:2])}" if len(segs) >= 2 else l1
-        return {"l0": root, "l1": l1, "l2": l2}
+        l0 = segs[0]
+        l1 = "/".join(segs[:2]) if len(segs) >= 2 else l0
+        l2_base = "/".join(segs[:3]) if len(segs) >= 3 else l1
+        return {
+            "l0": l0,
+            "l1": l1,
+            "l2": f"{l2_base}/comm:{fallback_community}",
+        }
     if not segs:
         return {"l0": "external", "l1": "external", "l2": "external"}
     l0 = segs[0]

--- a/services/prism-service/app/ui/graph_page.py
+++ b/services/prism-service/app/ui/graph_page.py
@@ -219,6 +219,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
   const L0_HUGE_COUNT = 240;
   const RELAX_NODE_LIMIT = 80;
   const L0_SUPER_EDGE_LIMIT = 900;
+  const FULL_LAYOUT_NODE_LIMIT = 30000;
   // HSL round-trip utilities. Shading by degree modulates the L
   // channel while keeping H+S fixed, so every node in a layer shares
   // the base hue and saturation — only perceived lightness changes
@@ -274,7 +275,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
   }
   // hierarchy.json returns leaves tagged with l0/l1/l2 parent keys + the
   // DB-derived community labels for the legend. One fetch primes both
-  // the LOD super-node assembly (after FA2) and the legend.
+  // the LOD super-node assembly and the legend.
   async function loadGraph() {
       statusEl.textContent = "Fetching graph data...";
       const data = await fetch(`/graphify-visual/${PROJECT_ID}/hierarchy.json`)
@@ -437,7 +438,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
             symbols: Array.isArray(n.symbols) ? n.symbols : [],
             // L3 = leaf. Parent keys at L0/L1/L2 are emitted by the
             // server from the file path; the LOD pass below uses them
-            // to assemble super-nodes after FA2 settles.
+            // to assemble semantic super-nodes.
             level: 3,
             l0: n.l0 || null,
             l1: n.l1 || null,
@@ -491,43 +492,54 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
           `Loading edges ${i.toLocaleString()} / ${edges.length.toLocaleString()}...`;
         await yieldToBrowser();
       }
-      // ----- ForceAtlas2 in a Web Worker (fully invisible) ----------
-      // FA2 is mathematically chaotic during early iterations — watching
-      // it live looks like a spazz attack and even post-warmup the per-
-      // iteration jitter doesn't read as "smooth". The fix: compute the
-      // layout fully off-screen (worker keeps the main thread responsive),
-      // capture the converged positions, then play back a clean cluster-
-      // by-cluster reveal animation that doesn't depend on FA2's frame
-      // timing at all.
-      const settings = forceAtlas2.inferSettings(g);
-      settings.barnesHutOptimize = g.order > 2000;
-      settings.barnesHutTheta = 0.5;
-      settings.gravity = 1.2;
-      settings.scalingRatio = 2;
-      settings.slowDown = 1;
-      settings.adjustSizes = false;
-      settings.outboundAttractionDistribution = false;
-      const computeMs = g.order > 20000 ? 5000 : g.order > 5000 ? 4000 : 3000;
-      const layout = new FA2Layout(g, { settings });
       const t0 = performance.now();
-      layout.start();
-
-      // Click the (still-empty) canvas to skip straight to the result.
-      let skipped = false;
       const graphEl = document.getElementById("graph");
-      graphEl.style.cursor = "wait";
-      const skipHandler = () => { skipped = true; };
-      graphEl.addEventListener("click", skipHandler, { once: true });
-      statusEl.textContent =
-        `Computing layout (${(computeMs / 1000).toFixed(1)}s)...`;
-      const cStart = performance.now();
-      while (performance.now() - cStart < computeMs && !skipped) {
-        await new Promise(r => setTimeout(r, 50));
+      const skipFullLayout = g.order > FULL_LAYOUT_NODE_LIMIT;
+      const layoutMode = skipFullLayout ? "overview" : "FA2";
+      if (skipFullLayout) {
+        // Huge graphs should open at the semantic overview immediately.
+        // Running FA2 over every leaf before L0 exists keeps the canvas
+        // technically correct but makes the browser pay for detail the
+        // user cannot see yet. Cheap seeded positions still give the
+        // visible L0/L1 relaxation enough structure to produce a clean
+        // overview without the full-leaf warmup.
+        statusEl.textContent =
+          `Building overview from ${g.order.toLocaleString()} nodes...`;
+        await yieldToBrowser();
+      } else {
+        // ----- ForceAtlas2 in a Web Worker (fully invisible) ----------
+        // FA2 is mathematically chaotic during early iterations. The fix:
+        // compute the layout fully off-screen (worker keeps the main
+        // thread responsive), capture the converged positions, then play
+        // back a clean cluster-by-cluster reveal animation.
+        const settings = forceAtlas2.inferSettings(g);
+        settings.barnesHutOptimize = g.order > 2000;
+        settings.barnesHutTheta = 0.5;
+        settings.gravity = 1.2;
+        settings.scalingRatio = 2;
+        settings.slowDown = 1;
+        settings.adjustSizes = false;
+        settings.outboundAttractionDistribution = false;
+        const computeMs = g.order > 20000 ? 5000 : g.order > 5000 ? 4000 : 3000;
+        const layout = new FA2Layout(g, { settings });
+        layout.start();
+
+        // Click the (still-empty) canvas to skip straight to the result.
+        let skipped = false;
+        graphEl.style.cursor = "wait";
+        const skipHandler = () => { skipped = true; };
+        graphEl.addEventListener("click", skipHandler, { once: true });
+        statusEl.textContent =
+          `Computing layout (${(computeMs / 1000).toFixed(1)}s)...`;
+        const cStart = performance.now();
+        while (performance.now() - cStart < computeMs && !skipped) {
+          await new Promise(r => setTimeout(r, 50));
+        }
+        graphEl.removeEventListener("click", skipHandler);
+        graphEl.style.cursor = "";
+        layout.stop();
+        layout.kill();
       }
-      graphEl.removeEventListener("click", skipHandler);
-      graphEl.style.cursor = "";
-      layout.stop();
-      layout.kill();
 
       // ----- Super-node assembly (LOD hierarchy) ----------------------
       // For each abstraction level, group the L3 leaves by their l0/l1/l2
@@ -938,7 +950,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
       // closure picks up whatever value it holds when baseStatus() is
       // called, so click handlers reading the status get the right text.
       let layoutElapsed = "...";
-      const LEVEL_NAMES = ["communities", "regions", "modules", "leaves"];
+      const LEVEL_NAMES = ["regions", "modules", "clusters", "leaves"];
       // Counts items the LOD reducer would paint right now — i.e., at
       // currentLevel and inside the active focus subtree if any. So
       // status reads what the user actually sees, not raw level totals.
@@ -958,7 +970,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
         const showing = visibleCount();
         if (wholeGraphMode) {
           return `Whole graph · ${showing.toLocaleString()} leaves · `
-            + `FA2 ${layoutElapsed}s · scroll in for communities`;
+            + `${layoutMode} ${layoutElapsed}s · scroll in for regions`;
         }
         const where = `${showing.toLocaleString()} ${LEVEL_NAMES[currentLevel]}`;
         // Breadcrumb of focused ancestors — rightmost is the deepest.
@@ -973,7 +985,7 @@ _SIGMA_VIEWER_HTML = r"""<!DOCTYPE html>
         const scaleHint = currentLevel === 0 && lodCount[0] >= L0_DENSE_COUNT
           ? " · high-scale overview"
           : "";
-        return `L${currentLevel}${trail} · ${where} · FA2 ${layoutElapsed}s${scaleHint}${hint}`;
+        return `L${currentLevel}${trail} · ${where} · ${layoutMode} ${layoutElapsed}s${scaleHint}${hint}`;
       };
       let inspectorPinned = false;
       function escapeHtml(value) {

--- a/services/prism-service/tests/unit/test_graph_hierarchy_lod.py
+++ b/services/prism-service/tests/unit/test_graph_hierarchy_lod.py
@@ -9,7 +9,7 @@ if str(_SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(_SERVICE_ROOT))
 
 
-def test_node_hierarchy_uses_leiden_community_as_l0():
+def test_node_hierarchy_keeps_leiden_community_below_semantic_regions():
     from app.services.graph_service import compute_node_hierarchy
 
     hierarchy = compute_node_hierarchy(
@@ -18,9 +18,9 @@ def test_node_hierarchy_uses_leiden_community_as_l0():
     )
 
     assert hierarchy == {
-        "l0": "comm:42",
-        "l1": "comm:42/prism-service",
-        "l2": "comm:42/prism-service/ui",
+        "l0": "prism-service",
+        "l1": "prism-service/ui",
+        "l2": "prism-service/ui/comm:42",
     }
 
 
@@ -233,9 +233,9 @@ def test_node_hierarchy_skips_unity_wrapper_dirs():
     )
 
     assert hierarchy == {
-        "l0": "comm:7",
-        "l1": "comm:7/Gameplay",
-        "l2": "comm:7/Gameplay",
+        "l0": "Gameplay",
+        "l1": "Gameplay",
+        "l2": "Gameplay/comm:7",
     }
 
 
@@ -248,9 +248,9 @@ def test_node_hierarchy_prefers_dotnet_project_regions():
     )
 
     assert hierarchy == {
-        "l0": "comm:9",
-        "l1": "comm:9/Shop.Api",
-        "l2": "comm:9/Shop.Api/Controllers",
+        "l0": "Shop.Api",
+        "l1": "Shop.Api/Controllers",
+        "l2": "Shop.Api/Controllers/comm:9",
     }
 
 
@@ -263,10 +263,26 @@ def test_node_hierarchy_skips_dotnet_feature_wrapper():
     )
 
     assert hierarchy == {
-        "l0": "comm:9",
-        "l1": "comm:9/Shop.Application",
-        "l2": "comm:9/Shop.Application/Orders",
+        "l0": "Shop.Application",
+        "l1": "Shop.Application/Orders",
+        "l2": "Shop.Application/Orders/comm:9",
     }
+
+
+def test_node_hierarchy_does_not_make_every_large_repo_community_l0():
+    from app.services.graph_service import compute_node_hierarchy
+
+    hierarchies = [
+        compute_node_hierarchy(
+            f"repo/src/Commerce/Shop.Api/Controllers/Orders{i}Controller.cs",
+            fallback_community=i,
+        )
+        for i in range(1000)
+    ]
+
+    assert {h["l0"] for h in hierarchies} == {"Shop.Api"}
+    assert {h["l1"] for h in hierarchies} == {"Shop.Api/Controllers"}
+    assert len({h["l2"] for h in hierarchies}) == 1000
 
 
 def test_node_hierarchy_uses_dotnet_project_without_community():


### PR DESCRIPTION
## Summary

Follow-up to #88 for the customer huge C# / Angular monorepo graph. The extractor/viewer now produces data, but the first screen could still render as 10k+ L0 graphify communities and run full-leaf ForceAtlas2 before the overview existed, which made large browsers/machines stall.

This PR changes the huge-graph path so the first screen is a semantic overview instead of a raw community dump:

- makes L0/L1 hierarchy path/.NET project regions first (`Shop.Api`, `Shop.Application/Orders`, etc.)
- preserves graphify/Leiden community IDs at the deepest rollup level for drilldown instead of using each community as an L0 node
- adds a regression proving 1,000 communities under one C# project collapse to one L0 region
- skips full-leaf FA2 warmup above 30k graph nodes and opens with the semantic overview immediately
- renames viewer level copy from `communities` to `regions/modules/clusters` so the UI matches the new model

The practical customer impact is that the screenshot case should stop opening as `L0 · 10,517 communities`; it should open as a much smaller set of meaningful regions, with clusters available deeper in the zoom/drill path.

## Validation

- `python -m pytest services\\prism-service\\tests\\unit -q` -> `238 passed, 3 warnings`
- embedded Sigma viewer script extracted from `graph_page.py` -> `node --check` passed
- `python -m py_compile services\\prism-service\\app\\services\\graph_service.py services\\prism-service\\app\\ui\\graph_page.py` passed before splitting the clean PR branch
- `git diff --check` passed before splitting the clean PR branch; only CRLF normalization warnings
