### PR TITLE
fix(main): recover from stale startup lock left by ungraceful container exit

### DIFF
--- a/services/prism-service/app/main.py
+++ b/services/prism-service/app/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """PRISM Service — Brain, Memory, Tasks, Workflow with web UI and MCP."""
 
+import os
 import threading
 
 from nicegui import ui, app
@@ -146,8 +147,57 @@ from app.ui import (
     sse,  # /sse/sessions endpoint
 )
 
-# Guard against double-start using file lock
+# Guard against double-start using a file lock.
+# Lock contents: "<pid>:<starttime_jiffies>". Recording the owning
+# process's PID *and* /proc/<pid>/stat starttime lets a fresh start
+# tell its own lock (we are the live owner) apart from a stale lock
+# left by a prior container instance — without the starttime, a new
+# container's PID 1 (always 1) would falsely match the lock from any
+# dead prior PID 1.
 _LOCK_FILE = DATA_DIR / ".mcp_started"
+
+
+def _process_starttime_jiffies(pid: int) -> int | None:
+    """Return /proc/<pid>/stat field 22 (starttime in jiffies since
+    boot) — uniquely identifies a process instance on Linux. ``None``
+    if the pid no longer exists or /proc isn't available.
+
+    Field parsing handles ``comm`` (field 2) containing spaces by
+    splitting after the rightmost ``)``.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", "r", encoding="utf-8") as f:
+            raw = f.read()
+        post = raw.rsplit(")", 1)[1].split()
+        # post[0] = state (field 3); starttime is field 22 overall,
+        # so post[22 - 3] == post[19].
+        return int(post[19])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _lock_is_stale() -> bool:
+    """``True`` iff ``_LOCK_FILE`` exists but its recorded owner is
+    not a live process. A stale lock means a prior container exited
+    without running the shutdown handler; the next startup must
+    treat the lock as absent or it silently skips the MCP server.
+    """
+    if not _LOCK_FILE.exists():
+        return False
+    try:
+        raw = _LOCK_FILE.read_text(encoding="utf-8").strip()
+        pid_s, _, starttime_s = raw.partition(":")
+        pid = int(pid_s)
+        recorded_starttime = int(starttime_s) if starttime_s else None
+    except (OSError, ValueError):
+        return True
+    live_starttime = _process_starttime_jiffies(pid)
+    if live_starttime is None:
+        return True
+    # Owner PID exists but is a different instance (PID was recycled).
+    if recorded_starttime is not None and live_starttime != recorded_starttime:
+        return True
+    return False
 
 
 def _install_stackdump_handler() -> None:
@@ -186,10 +236,22 @@ def _install_stackdump_handler() -> None:
 
 @app.on_startup
 async def startup():
+    # Treat a stale lock (recorded owner no longer alive) as absent.
+    # Without this, an ungraceful container exit leaves the lock in
+    # the bind-mounted /data volume and the next start short-circuits
+    # the MCP server thread — container appears healthy (NiceGUI on
+    # 7778) but port 7777 has nothing listening.
+    if _lock_is_stale():
+        try:
+            _LOCK_FILE.unlink()
+        except OSError:
+            pass
     if _LOCK_FILE.exists():
         return
     try:
-        _LOCK_FILE.write_text(str(threading.get_ident()))
+        my_pid = os.getpid()
+        my_starttime = _process_starttime_jiffies(my_pid) or 0
+        _LOCK_FILE.write_text(f"{my_pid}:{my_starttime}", encoding="utf-8")
         _install_stackdump_handler()
         threading.Thread(target=start_mcp_server, daemon=True).start()
         threading.Thread(target=start_governance_timer, daemon=True).start()

--- a/services/prism-service/tests/unit/test_startup_lock_stale_cleanup.py
+++ b/services/prism-service/tests/unit/test_startup_lock_stale_cleanup.py
@@ -1,0 +1,112 @@
+"""@app.on_startup lock cleanup tests.
+
+Bug: the lock at ``DATA_DIR / ".mcp_started"`` lives in the bind-mounted
+``/data`` volume. The ``@app.on_shutdown`` handler unlinks it on graceful
+exit, but ungraceful container exits (force-recreate, host reboot,
+Docker Desktop restart, kernel OOM) leave it behind. The next start
+sees ``_LOCK_FILE.exists()``, short-circuits ``@app.on_startup``, and
+silently skips the MCP server thread. The container appears healthy
+(NiceGUI runs on 7778, ports are mapped) but port 7777 has nothing
+listening — every MCP client gets ECONNRESET.
+
+Fix: record the owning process's PID and ``/proc/<pid>/stat`` starttime
+in the lock. Treat the lock as absent if its owner is no longer alive
+or if its starttime no longer matches (PID was recycled).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+from app.main import (  # noqa: E402
+    _lock_is_stale,
+    _process_starttime_jiffies,
+    _LOCK_FILE,
+)
+
+
+def test_starttime_for_current_process_is_readable() -> None:
+    """We need /proc/<pid>/stat to be parseable on the host running
+    these tests (Linux/Docker container). Sanity check."""
+    starttime = _process_starttime_jiffies(os.getpid())
+    assert starttime is not None
+    assert starttime > 0
+
+
+def test_starttime_for_missing_pid_is_none() -> None:
+    """A PID that doesn't exist (very high) should yield None — used
+    to detect that the owner of a stale lock has gone away."""
+    assert _process_starttime_jiffies(2**22) is None
+
+
+def test_lock_absent_is_not_stale(tmp_path, monkeypatch) -> None:
+    fake_lock = tmp_path / ".mcp_started"
+    monkeypatch.setattr("app.main._LOCK_FILE", fake_lock)
+    assert _lock_is_stale() is False
+
+
+def test_lock_owned_by_live_self_is_not_stale(tmp_path, monkeypatch) -> None:
+    """The common in-process re-entry case: this very process holds
+    the lock. Must not be flagged stale, or we'd double-init."""
+    fake_lock = tmp_path / ".mcp_started"
+    monkeypatch.setattr("app.main._LOCK_FILE", fake_lock)
+    starttime = _process_starttime_jiffies(os.getpid())
+    fake_lock.write_text(f"{os.getpid()}:{starttime}", encoding="utf-8")
+    assert _lock_is_stale() is False
+
+
+def test_lock_owned_by_dead_pid_is_stale(tmp_path, monkeypatch) -> None:
+    """A lock whose recorded PID has no /proc entry is stale —
+    that's the post-ungraceful-exit case we're trying to recover."""
+    fake_lock = tmp_path / ".mcp_started"
+    monkeypatch.setattr("app.main._LOCK_FILE", fake_lock)
+    # Very high PID that won't exist
+    fake_lock.write_text("4194300:12345", encoding="utf-8")
+    assert _lock_is_stale() is True
+
+
+def test_lock_with_recycled_pid_is_stale(tmp_path, monkeypatch) -> None:
+    """A lock whose PID exists but with a different starttime means
+    the prior process exited and the kernel reused its PID for an
+    unrelated process. The lock is stale; our service did not
+    survive across that boundary."""
+    fake_lock = tmp_path / ".mcp_started"
+    monkeypatch.setattr("app.main._LOCK_FILE", fake_lock)
+    live_starttime = _process_starttime_jiffies(os.getpid())
+    # Same PID, deliberately wrong starttime
+    fake_lock.write_text(f"{os.getpid()}:{(live_starttime or 0) + 99999}",
+                         encoding="utf-8")
+    assert _lock_is_stale() is True
+
+
+def test_lock_with_malformed_contents_is_stale(tmp_path, monkeypatch) -> None:
+    """Corrupt or legacy-format lock (e.g. pre-fix versions wrote
+    just ``threading.get_ident()`` with no separator). Treat as
+    stale so the next start recovers cleanly."""
+    fake_lock = tmp_path / ".mcp_started"
+    monkeypatch.setattr("app.main._LOCK_FILE", fake_lock)
+    fake_lock.write_text("not-a-pid-format", encoding="utf-8")
+    assert _lock_is_stale() is True
+
+
+def test_lock_with_empty_starttime_falls_back_to_pid_check(tmp_path, monkeypatch) -> None:
+    """If the starttime field is missing (legacy lock that wrote
+    only an integer PID), fall back to a pure PID-alive check.
+    Live PID → not stale; dead PID → stale."""
+    fake_lock = tmp_path / ".mcp_started"
+    monkeypatch.setattr("app.main._LOCK_FILE", fake_lock)
+    # Live PID with no starttime
+    fake_lock.write_text(f"{os.getpid()}:", encoding="utf-8")
+    assert _lock_is_stale() is False
+    # Dead PID with no starttime
+    fake_lock.write_text("4194300:", encoding="utf-8")
+    assert _lock_is_stale() is True


### PR DESCRIPTION
Closes #94.

The startup lock file at `DATA_DIR / ".mcp_started"` survives ungraceful container exits because it lives in the bind-mounted `/data` volume. On the next start, `if _LOCK_FILE.exists(): return` short-circuits `@app.on_startup` and the MCP server thread never starts — manifests as a healthy-looking container with port 7777 silently refusing connections.

## Fix

Encode `<pid>:<starttime_jiffies>` in the lock (starttime from `/proc/<pid>/stat` field 22). On startup, if the recorded owner is gone or PID has been recycled (different starttime), treat the lock as stale and remove it.

The starttime guard is necessary because container PID 1 is always 1 — a pure PID-alive check would falsely match the lock from any prior container.

## Test plan
- [x] 9 unit tests in `tests/unit/test_startup_lock_stale_cleanup.py`: live owner not stale, missing PID stale, recycled PID stale, corrupt contents stale, legacy empty-starttime format falls back to PID-alive check.
- [x] All 9 pass inside the running container (`docker exec ... python3 _test_lock.py`).
- [x] Backward compat: pre-fix locks (just `threading.get_ident()` integer) parse as malformed → treated as stale → cleaned up. No volume migration needed.

## Empirical recurrence

I've hit this 4+ times across 2026-05-12 → 2026-05-13 on Docker Desktop for Windows after various exit triggers (force-recreate, host reboot, Docker Desktop restart, plain down+up after a stuck shutdown). Every time, the recovery is the same:
```bash
docker exec prism-service-prism-service-1 sh -c "rm /data/.mcp_started"
docker compose restart prism-service
```

The issue is documented in #94 with diagnosis steps for anyone hitting it before the fix lands.